### PR TITLE
Potential fix for code scanning alert no. 12: Bad HTML filtering regexp

### DIFF
--- a/ui/src/components/routes/overviews/markdownExtendedTokenProvider.ts
+++ b/ui/src/components/routes/overviews/markdownExtendedTokenProvider.ts
@@ -220,7 +220,7 @@ export const language = <languages.IMonarchLanguage>{
 
     comment: [
       [/[^<\-]+/, 'comment.content'],
-      [/-->/, 'comment', '@pop'],
+      [/--(?:!?)>/, 'comment', '@pop'],
       [/<!--/, 'comment.content.invalid'],
       [/[<\-]/, 'comment.content']
     ],


### PR DESCRIPTION
Potential fix for [https://github.com/CybercentreCanada/howler/security/code-scanning/12](https://github.com/CybercentreCanada/howler/security/code-scanning/12)

To fix the issue, the regular expression for matching HTML comment end tags should be updated to account for variations like `--!>`. This can be achieved by modifying the regex to match both `-->` and `--!>`. Specifically, the regex `/-->/` should be replaced with `/--(?:!?)>/`, which matches `-->` and `--!>`.

The change should be made in the `comment` state of the tokenizer, specifically on line 223 where the `-->` regex is used. This ensures that the tokenizer correctly identifies all valid HTML comment end tags.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
