### PR TITLE
Potential fix for code scanning alert no. 7: Failure to use secure cookies

### DIFF
--- a/api/howler/error.py
+++ b/api/howler/error.py
@@ -40,7 +40,7 @@ def handle_401(e):
         "allow_userpass_login": config.auth.internal.enabled,
     }
     res = unauthorized(data, err=msg)
-    res.set_cookie("XSRF-TOKEN", "", max_age=0)
+    res.set_cookie("XSRF-TOKEN", "", max_age=0, secure=True, httponly=True, samesite='Strict')
     return res
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/CybercentreCanada/howler/security/code-scanning/7](https://github.com/CybercentreCanada/howler/security/code-scanning/7)

To fix the issue, we need to update the `set_cookie` call on line 43 to include the `secure`, `httponly`, and `samesite` attributes. Specifically:
- Set `secure=True` to ensure the cookie is only transmitted over HTTPS.
- Set `httponly=True` to prevent JavaScript from accessing the cookie.
- Set `samesite='Strict'` to restrict the cookie from being sent with cross-origin requests.

This ensures the cookie is securely handled, even during deletion.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
