### PR TITLE
Add basic auth alternative for connecting to datastore

### DIFF
--- a/api/howler/datastore/store.py
+++ b/api/howler/datastore/store.py
@@ -66,7 +66,7 @@ class ESStore(object):
                     os.environ[f"{host.name.upper()}_HOST_APIKEY_ID"],
                     os.environ[f"{host.name.upper()}_HOST_APIKEY_SECRET"],
                 )
-            elif os.getenv(f"{host.name.upper()}_HOST_USERNAME", None) is not None:
+            elif os.getenv(f"{host.name.upper()}_HOST_USERNAME") is not None:
                 self._username = os.environ[f"{host.name.upper()}_HOST_USERNAME"]
                 self._password = os.environ[f"{host.name.upper()}_HOST_PASSWORD"]
 


### PR DESCRIPTION
This PR adds the possibility to use basic authentication through environment variables for the elasticsearch datastore connection.