### PR TITLE
Bugfix: Eagerly fetch all analytics for dashboard

### DIFF
--- a/ui/src/components/routes/home/AddNewCard.tsx
+++ b/ui/src/components/routes/home/AddNewCard.tsx
@@ -61,7 +61,7 @@ const AddNewCard: FC<{ dashboard: HowlerUser['dashboard']; addCard: (newCard) =>
 
   const fetchAllAnalytics = async () => {
     setAnalyticsLoading(true);
-    const batchSize = 25;
+    const batchSize = 150;
     let offset = 0;
     let allAnalytics: Analytic[] = [];
     let total = 0;


### PR DESCRIPTION
Since you're already filtering analytics for search on the client-side, I figured an eager approach was alright. LMK if you'd prefer lazy.