### PR TITLE
Fix lead rendering to pass hit into leads

### DIFF
--- a/ui/src/components/routes/hits/search/InformationPane.tsx
+++ b/ui/src/components/routes/hits/search/InformationPane.tsx
@@ -176,7 +176,10 @@ const InformationPane: FC<{ onClose?: () => void }> = ({ onClose }) => {
       hit_aggregate: () => <HitSummary query={`howler.bundles:(${hit?.howler?.id})`} />,
       hit_related: () => <HitRelated hit={hit} />,
       ...Object.fromEntries(
-        (hit?.howler.dossier ?? []).map((lead, index) => ['lead:' + index, () => <LeadRenderer lead={lead} />])
+        (hit?.howler.dossier ?? []).map((lead, index) => [
+          'lead:' + index,
+          () => <LeadRenderer lead={lead} hit={hit} />
+        ])
       ),
       ...Object.fromEntries(
         dossiers.flatMap((_dossier, dossierIndex) =>

--- a/ui/src/components/routes/hits/view/HitViewer.tsx
+++ b/ui/src/components/routes/hits/view/HitViewer.tsx
@@ -133,7 +133,7 @@ const HitViewer: FC = () => {
       hit_worklog: () => <HitWorklog hit={hit} users={users} />,
       hit_related: () => <HitRelated hit={hit} />,
       ...Object.fromEntries(
-        hit?.howler.dossier?.map((lead, index) => ['lead:' + index, () => <LeadRenderer lead={lead} />]) ?? []
+        hit?.howler.dossier?.map((lead, index) => ['lead:' + index, () => <LeadRenderer lead={lead} hit={hit} />]) ?? []
       ),
       ...Object.fromEntries(
         dossiers.flatMap((_dossier, dossierIndex) =>


### PR DESCRIPTION
Helpers weren't working because the hit wasn't being passed in for formatting.