### PR TITLE
Removed metadata from hit details pane

### DIFF
--- a/ui/src/components/elements/hit/HitDetails.tsx
+++ b/ui/src/components/elements/hit/HitDetails.tsx
@@ -294,7 +294,10 @@ const HitDetails: FC<{ hit: Hit }> = ({ hit }) => {
       groupBy(
         Object.entries(flatten(hit ?? {}, { safe: true })).filter(
           ([key, value]) =>
-            key.includes('.') && ['howler', 'labels'].every(prefix => !key.startsWith(prefix)) && !isEmpty(value)
+            !key.startsWith('__') &&
+            key.includes('.') &&
+            ['howler', 'labels'].every(prefix => !key.startsWith(prefix)) &&
+            !isEmpty(value)
         ),
         ([key]) => key.split('.')[0]
       ),


### PR DESCRIPTION
This pull request introduces a small but important change to the filtering logic in the `HitDetails` component. The update ensures that any keys starting with double underscores (`__`) are excluded from the grouped entries, preventing internal or system fields from being displayed.

* Filtering logic update: Modified the filter in `HitDetails.tsx` to exclude keys starting with `__` from grouped entries, improving data cleanliness and preventing internal fields from being shown.