### PR TITLE
Finish borealis->clue refactor

### DIFF
--- a/api/howler/api/__init__.py
+++ b/api/howler/api/__init__.py
@@ -32,7 +32,7 @@ def _make_api_response(
 ) -> Response:
     quota_user = flsk_session.pop("quota_user", None)
     quota_set = flsk_session.pop("quota_set", False)
-    if quota_user and quota_set and not request.path.startswith("/api/v1/borealis"):
+    if quota_user and quota_set and not request.path.startswith("/api/v1/clue"):
         QUOTA_TRACKER.end(quota_user)
 
     if type(err) is Exception:  # pragma: no cover

--- a/api/howler/api/v1/clue.py
+++ b/api/howler/api/v1/clue.py
@@ -14,9 +14,9 @@ from howler.config import cache, config
 from howler.plugins import get_plugins
 from howler.security import api_login
 
-SUB_API = "borealis"
-borealis_api = make_subapi_blueprint(SUB_API, api_version=1)
-borealis_api._doc = "Proxy enrichment requests to borealis"
+SUB_API = "clue"
+clue_api = make_subapi_blueprint(SUB_API, api_version=1)
+clue_api._doc = "Proxy enrichment requests to clue"
 
 logger = get_logger(__file__)
 
@@ -28,27 +28,27 @@ def skip_cache(*args):
 
 @cache.memoize(15 * 60, unless=skip_cache)
 def get_token(access_token: str) -> str:
-    """Get a borealis token based on the current howler token"""
-    get_borealis_token: Optional[Callable[[str], str]] = None
+    """Get a clue token based on the current howler token"""
+    get_clue_token: Optional[Callable[[str], str]] = None
 
     for plugin in get_plugins():
-        if get_borealis_token := plugin.modules.token_functions.get("borealis", None):
+        if get_clue_token := plugin.modules.token_functions.get("clue", None):
             break
 
-    if get_borealis_token:
-        borealis_access_token = get_borealis_token(access_token)
+    if get_clue_token:
+        clue_access_token = get_clue_token(access_token)
     else:
-        logger.info("No custom borealis token logic provided, continuing with howler credentials")
-        borealis_access_token = access_token
+        logger.info("No custom clue token logic provided, continuing with howler credentials")
+        clue_access_token = access_token
 
-    return borealis_access_token
+    return clue_access_token
 
 
 @generate_swagger_docs()
-@borealis_api.route("/<path:path>", methods=["GET", "POST"])
+@clue_api.route("/<path:path>", methods=["GET", "POST"])
 @api_login(required_priv=["R"], required_method=["oauth"])
-def proxy_to_borealis(path, **kwargs):
-    """Proxy enrichment requests to Borealis
+def proxy_to_clue(path, **kwargs):
+    """Proxy enrichment requests to Clue
 
     Variables:
     None
@@ -60,11 +60,9 @@ def proxy_to_borealis(path, **kwargs):
     Any
 
     Result Example:
-    Borealis Responses
+    Clue Responses
     """
-    logger.info(
-        "Proxying borealis request to path %s/%s?%s", config.core.borealis.url, path, request.query_string.decode()
-    )
+    logger.info("Proxying clue request to path %s/%s?%s", config.core.clue.url, path, request.query_string.decode())
 
     auth_data: Optional[str] = request.headers.get("Authorization", None, type=str)
 
@@ -73,29 +71,29 @@ def proxy_to_borealis(path, **kwargs):
 
     auth_token = auth_data.split(" ")[1]
 
-    borealis_token = get_token(auth_token)
+    clue_token = get_token(auth_token)
 
     start = time.perf_counter()
-    with elasticapm.capture_span("borealis", span_type="http"):
+    with elasticapm.capture_span("clue", span_type="http"):
         if request.method.lower() == "get":
             response = requests.get(
-                f"{config.core.borealis.url}/{path}",
-                headers={"Authorization": f"Bearer {borealis_token}", "Accept": "application/json"},
+                f"{config.core.clue.url}/{path}",
+                headers={"Authorization": f"Bearer {clue_token}", "Accept": "application/json"},
                 params=request.args.to_dict(),
                 timeout=5 * 60,
             )
         else:
             response = requests.post(
-                f"{config.core.borealis.url}/{path}",
+                f"{config.core.clue.url}/{path}",
                 json=request.json,
-                headers={"Authorization": f"Bearer {borealis_token}", "Accept": "application/json"},
+                headers={"Authorization": f"Bearer {clue_token}", "Accept": "application/json"},
                 params=request.args.to_dict(),
                 timeout=5 * 60,
             )
 
-    logger.debug(f"Request to borealis completed in {round(time.perf_counter() - start)}ms")
+    logger.debug(f"Request to clue completed in {round(time.perf_counter() - start)}ms")
 
     if not response.ok:
-        return bad_gateway(response.json(), err="Something went wrong when connecting to borealis")
+        return bad_gateway(response.json(), err="Something went wrong when connecting to clue")
 
     return ok(response.json()["api_response"])

--- a/api/howler/app.py
+++ b/api/howler/app.py
@@ -138,11 +138,11 @@ if HWL_USE_REST_API or DEBUG:
         logger.debug("Enabled Notebook Integration")
         app.register_blueprint(notebook_api)
 
-    if config.core.borealis.enabled:
-        from howler.api.v1.borealis import borealis_api
+    if config.core.clue.enabled:
+        from howler.api.v1.clue import clue_api
 
-        logger.debug("Enabled Borealis Integration")
-        app.register_blueprint(borealis_api)
+        logger.debug("Enabled Clue Integration")
+        app.register_blueprint(clue_api)
 
     logger.info("Checking plugins for additional routes")
     for plugin in get_plugins():

--- a/api/howler/odm/helper.py
+++ b/api/howler/odm/helper.py
@@ -259,13 +259,13 @@ def generate_useful_hit(lookups: dict[str, dict[str, Any]], users: list[User], p
         ),
     ]
 
-    if config.core.borealis.enabled:
+    if config.core.clue.enabled:
         hit.howler.dossier.append(
             Lead(
                 {
                     "icon": "material-symbols:image",
-                    "label": {"en": "Borealis", "fr": "Borealis"},
-                    "format": "borealis",
+                    "label": {"en": "Clue", "fr": "Clue"},
+                    "format": "clue",
                     "content": "test-plugin.image",
                     "metadata": {"type": "ip", "value": "127.0.01", "classification": "TLP:CLEAR"},
                 }
@@ -276,8 +276,8 @@ def generate_useful_hit(lookups: dict[str, dict[str, Any]], users: list[User], p
             Lead(
                 {
                     "icon": "material-symbols:code-rounded",
-                    "label": {"en": "Borealis", "fr": "Borealis"},
-                    "format": "borealis",
+                    "label": {"en": "Clue", "fr": "Clue"},
+                    "format": "clue",
                     "content": "test-plugin.json",
                     "metadata": {"type": "ip", "value": "127.0.01", "classification": "TLP:CLEAR"},
                 }

--- a/api/howler/odm/models/config.py
+++ b/api/howler/odm/models/config.py
@@ -409,24 +409,24 @@ class UI(BaseModel):
     )
 
 
-class Borealis(BaseModel):
-    """Borealis enrichment service integration configuration.
+class Clue(BaseModel):
+    """Clue enrichment service integration configuration.
 
-    Defines settings for integrating with Borealis, an external enrichment
+    Defines settings for integrating with Clue, an external enrichment
     service that can provide additional context and status information for
     hits displayed in the Howler UI.
     """
 
-    enabled: bool = Field(default=False, description="Should borealis integration be enabled?")
+    enabled: bool = Field(default=False, description="Should clue integration be enabled?")
 
     url: str = Field(
         default="http://enrichment-rest.enrichment.svc.cluster.local:5000",
-        description="What url should Howler connect to to interact with Borealis?",
+        description="What url should Howler connect to to interact with Clue?",
     )
 
     status_checks: list[str] = Field(
         default=[],
-        description="A list of borealis fetchers that return status results given a Howler ID to show in the UI.",
+        description="A list of clue fetchers that return status results given a Howler ID to show in the UI.",
     )
 
 
@@ -451,7 +451,7 @@ class Core(BaseModel):
     """Core application configuration for Howler.
 
     Aggregates all core service configurations including Redis, metrics,
-    and external integrations like Borealis and nbgallery notebooks.
+    and external integrations like Clue and nbgallery notebooks.
     Also manages the loading of external plugins.
     """
 
@@ -463,8 +463,8 @@ class Core(BaseModel):
     redis: Redis = Redis()
     "Configuration for Redis instances"
 
-    borealis: Borealis = Borealis()
-    "Configuration for Borealis Integration"
+    clue: Clue = Clue()
+    "Configuration for Clue Integration"
 
     notebook: Notebook = Notebook()
     "Configuration for Notebook Integration"
@@ -529,7 +529,7 @@ class Config(BaseSettings):
     logging: Logging = Logging()
     system: System = System()
     ui: UI = UI()
-    mapping: dict[str, str] = Field(description="Mapping of alert keys to borealis type", default={})
+    mapping: dict[str, str] = Field(description="Mapping of alert keys to clue types", default={})
 
     model_config = SettingsConfigDict(
         yaml_file=config_locations,

--- a/api/howler/odm/models/lead.py
+++ b/api/howler/odm/models/lead.py
@@ -2,16 +2,7 @@
 from typing import Optional
 
 from howler import odm
-from howler.odm.howler_enum import HowlerEnum
 from howler.odm.models.localized_label import LocalizedLabel
-
-
-class Formats(str, HowlerEnum):
-    BOREALIS = "borealis"
-    MARKDOWN = "markdown"
-
-    def __str__(self) -> str:
-        return self.value
 
 
 @odm.model(
@@ -24,7 +15,7 @@ class Lead(odm.Model):
         description="An optional icon to use in the tab display for this dossier.", optional=True
     )
     label: LocalizedLabel = odm.Compound(LocalizedLabel, description="Labels for the lead in the UI.")
-    format: str = odm.Enum(values=Formats, description="The format of the lead. ")
+    format: str = odm.Keyword(description="The format of the lead.")
     content: str = odm.Text(
         description="The data for the content. Could be a link, raw markdown text, or other valid lead format.",
     )

--- a/api/howler/odm/models/pivot.py
+++ b/api/howler/odm/models/pivot.py
@@ -31,7 +31,7 @@ class Pivot(odm.Model):
         description="An optional icon to use in the tab display for this dossier.", optional=True
     )
     label: LocalizedLabel = odm.Compound(LocalizedLabel, description="Labels for the pivot in the UI.")
-    value: str = odm.Keyword(description="The link/borealis id to pivot on.")
+    value: str = odm.Keyword(description="The link/plugin information to pivot on.")
     format: str = odm.Keyword(description="The format of the pivot.")
     mappings: list[Mapping] = odm.List(
         odm.Compound(Mapping),

--- a/api/howler/security/__init__.py
+++ b/api/howler/security/__init__.py
@@ -220,8 +220,8 @@ class api_login(object):  # noqa: D101, N801
                     user_id=user.get("uname", None),
                 )
 
-            if request.path.startswith("/api/v1/borealis"):
-                logger.debug("Bypassing quota limits for borealis enrichment")
+            if request.path.startswith("/api/v1/clue"):
+                logger.debug("Bypassing quota limits for clue enrichment")
             elif self.enforce_quota:
                 # Check current user quota
                 flsk_session["quota_user"] = user["uname"]

--- a/api/howler/services/config_service.py
+++ b/api/howler/services/config_service.py
@@ -117,11 +117,11 @@ def get_configuration(user: User, **kwargs):
             },
             "mapping": config.mapping,
             "features": {
-                "borealis": config.core.borealis.enabled,
+                "clue": config.core.clue.enabled,
                 "notebook": config.core.notebook.enabled,
                 **plugin_features,
             },
-            "borealis": {"status_checks": config.core.borealis.status_checks},
+            "clue": {"status_checks": config.core.clue.status_checks},
         },
         "c12nDef": classification_definition,
         "indexes": list_all_fields("admin" in user["type"] if user is not None else False),

--- a/api/test/integration/plugins/test_config_validation.py
+++ b/api/test/integration/plugins/test_config_validation.py
@@ -39,11 +39,11 @@ def test_validation(caplog):
     result = CustomTestConfig.initialize_plugin_configuration(  # type: ignore[operator]
         {
             "name": "test",
-            "modules": {"token_functions": {"borealis": True, "other": "custom.module.example", "false": False}},
+            "modules": {"token_functions": {"clue": True, "other": "custom.module.example", "false": False}},
         }
     )
 
-    assert result["modules"]["token_functions"]["borealis"] == "test.token.borealis:get_token"
+    assert result["modules"]["token_functions"]["clue"] == "test.token.clue:get_token"
     assert result["modules"]["token_functions"]["other"] == "custom.module.example"
     assert "false" not in result["modules"]["token_functions"]
 

--- a/api/test/integration/plugins/test_plugin_auth.py
+++ b/api/test/integration/plugins/test_plugin_auth.py
@@ -30,20 +30,20 @@ def mock_plugin():
 
 def test_auth_hooks(caplog):
     with app.test_request_context():
-        from howler.api.v1.borealis import get_token
+        from howler.api.v1.clue import get_token
 
         with caplog.at_level(logging.INFO):
             assert get_token("bad_token") == "bad_token"
 
-        assert "No custom borealis token logic provided, continuing with howler credentials" in caplog.text
+        assert "No custom clue token logic provided, continuing with howler credentials" in caplog.text
 
         caplog.clear()
 
         from howler.plugins import PLUGINS
 
-        cast(BasePluginConfig, PLUGINS["test-plugin"]).modules.token_functions["borealis"] = mock_get_token
+        cast(BasePluginConfig, PLUGINS["test-plugin"]).modules.token_functions["clue"] = mock_get_token
 
         with caplog.at_level(logging.INFO):
             assert get_token("bad_token") == "access_token"
 
-        assert "No custom borealis token logic provided, continuing with howler credentials" not in caplog.text
+        assert "No custom clue token logic provided, continuing with howler credentials" not in caplog.text

--- a/docs/api/codebase.md
+++ b/docs/api/codebase.md
@@ -46,7 +46,7 @@ This document outlines the overall structure of the Howler API codebase. The fir
     - **`action.py`** - Action management and execution
     - **`analytic.py`** - Analytics management and configuration
     - **`auth.py`** - Authentication and authorization endpoints
-    - **`borealis.py`** - Borealis integration endpoints
+    - **`clue.py`** - Clue integration endpoints
     - **`configs.py`** - Configuration management
     - **`dossier.py`** - Dossier (case) management
     - **`help.py`** - Help and documentation endpoints

--- a/docs/api/plugins.md
+++ b/docs/api/plugins.md
@@ -387,9 +387,9 @@ class YourPluginConfig(BasePluginConfig):
     )
 
     scopes: ScopeConfig = ScopeConfig(
-        borealis="default",
-        notebook="default",
-        spellbook="default"
+        scope1="default",
+        scope2="default",
+        scope3="default"
     )
 
     model_config = SettingsConfigDict(
@@ -419,7 +419,7 @@ You can override any configuration value using environment variables:
 export YOUR_PLUGIN_NAME_URLS__SPELLBOOK="http://different-server:8080/api"
 
 # Override a scope
-export YOUR_PLUGIN_NAME_SCOPES__BOREALIS="custom-scope-id"
+export YOUR_PLUGIN_NAME_SCOPES__CLUE="custom-scope-id"
 ```
 
 Note the double underscore (`__`) used to separate nested configuration levels.

--- a/documentation/docs/installation/configuration.md
+++ b/documentation/docs/installation/configuration.md
@@ -17,13 +17,12 @@ For example: HWL_DATASTORE__TYPE=elasticsearch
 | Field | Type | Description | Required | Default |
 | :--- | :--- | :--- | :--- | :--- |
 | `auth` | [`Auth`](#auth) | Authentication configuration for Howler.      Configures all authentication methods supported by Howler, including     internal username/password authentication and OAuth providers. Also     controls API key settings and restrictions.      | :material-checkbox-marked-outline: Yes | See [Auth](#auth) for details. |
-| `core` | [`Core`](#core) | Core application configuration for Howler.      Aggregates all core service configurations including Redis, metrics,     and external integrations like Borealis and nbgallery notebooks.     Also manages the loading of external plugins.      | :material-checkbox-marked-outline: Yes | See [Core](#core) for details. |
+| `core` | [`Core`](#core) | Core application configuration for Howler.      Aggregates all core service configurations including Redis, metrics,     and external integrations like Clue and nbgallery notebooks.     Also manages the loading of external plugins.      | :material-checkbox-marked-outline: Yes | See [Core](#core) for details. |
 | `datastore` | [`Datastore`](#datastore) | Datastore configuration for Howler.      Defines the backend datastore used by Howler for storing hits and metadata.     Currently supports Elasticsearch as the datastore type.      | :material-checkbox-marked-outline: Yes | See [Datastore](#datastore) for details. |
 | `logging` | [`Logging`](#logging) | Logging configuration for Howler.      Defines how and where Howler logs should be output, including console,     file, and syslog destinations. Also controls log level, format, and     metric export intervals.      | :material-checkbox-marked-outline: Yes | See [Logging](#logging) for details. |
 | `system` | [`System`](#system) | System-level configuration for Howler.      Defines global system settings including deployment type (production,     staging, or development) and configuration for automated maintenance     jobs like data retention and view cleanup.      | :material-checkbox-marked-outline: Yes | See [System](#system) for details. |
 | `ui` | [`UI`](#ui) | User interface and web server configuration.      Defines settings for the Howler web UI including Flask configuration,     session validation, API auditing, static file locations, and WebSocket     integration for real-time updates.      | :material-checkbox-marked-outline: Yes | See [UI](#ui) for details. |
-| `mapping` | `dict[str, str]` | Mapping of alert keys to borealis type | :material-checkbox-marked-outline: Yes | `{}`
-
+| `mapping` | `dict[str, str]` | Mapping of alert keys to clue type | :material-checkbox-marked-outline: Yes | `{}`
 
 # Auth
 
@@ -42,7 +41,6 @@ controls API key settings and restrictions.
 | `internal` | [`Internal`](#internal) | Internal authentication configuration.      Defines settings for Howler's built-in username/password authentication,     including password requirements and brute-force protection via login     failure tracking.      | :material-checkbox-marked-outline: Yes | See [Internal](#internal) for details. |
 | `oauth` | [`OAuth`](#oauth) | OAuth authentication configuration.      Top-level OAuth settings including enabling/disabling OAuth authentication,     Gravatar integration, and a dictionary of configured OAuth providers.     Also controls API key lifetime restrictions for OAuth-authenticated users.      | :material-checkbox-marked-outline: Yes | See [OAuth](#oauth) for details. |
 
-
 # Internal
 
 Internal authentication configuration.
@@ -57,7 +55,6 @@ failure tracking.
 | `failure_ttl` | `int` | How long to wait after `max_failures` before re-attempting login? | :material-checkbox-marked-outline: Yes | `60`
 | `max_failures` | `int` | Maximum number of fails allowed before timeout | :material-checkbox-marked-outline: Yes | `5`
 | `password_requirements` | [`PasswordRequirement`](#passwordrequirement) | Password complexity requirements for internal authentication.      Defines the rules for password creation and validation, including     character type requirements and minimum length.      | :material-checkbox-marked-outline: Yes | See [PasswordRequirement](#passwordrequirement) for details. |
-
 
 # PasswordRequirement
 
@@ -74,7 +71,6 @@ character type requirements and minimum length.
 | `upper` | `bool` | Password must contain uppercase letters | :material-checkbox-marked-outline: Yes | `False`
 | `min_length` | `int` | Minimum password length | :material-checkbox-marked-outline: Yes | `12`
 
-
 # OAuth
 
 OAuth authentication configuration.
@@ -89,7 +85,6 @@ Also controls API key lifetime restrictions for OAuth-authenticated users.
 | `gravatar_enabled` | `bool` | Enable gravatar? | :material-checkbox-marked-outline: Yes | `True`
 | `providers` | `dict[str, OAuthProvider]` | OAuth provider configuration | :material-checkbox-marked-outline: Yes | `{}`
 | `strict_apikeys` | `bool` | Only allow apikeys that last as long as the access token used to log in | :material-checkbox-marked-outline: Yes | `False`
-
 
 # OAuthProvider
 
@@ -129,7 +124,6 @@ OAuth endpoints required for the authentication flow.
 | `jwks_uri` | `str` | URL used to verify if a returned JWKS token is valid | :material-checkbox-marked-outline: Yes | `PydanticUndefined`
 | `user_get` | `str` | Path from the base_url to fetch the user info | :material-minus-box-outline: Optional | `None`
 
-
 # OAuthAutoProperty
 
 Automatic property assignment based on OAuth attributes.
@@ -145,13 +139,12 @@ OAuth provider data.
 | `type` | `Literal[access, classification, role]` | Type of property assignment on pattern match | :material-checkbox-marked-outline: Yes | `PydanticUndefined`
 | `value` | `str` | Assigned property value | :material-checkbox-marked-outline: Yes | `PydanticUndefined`
 
-
 # Core
 
 Core application configuration for Howler.
 
 Aggregates all core service configurations including Redis, metrics,
-and external integrations like Borealis and nbgallery notebooks.
+and external integrations like Clue and nbgallery notebooks.
 Also manages the loading of external plugins.
 
 | Field | Type | Description | Required | Default |
@@ -159,9 +152,8 @@ Also manages the loading of external plugins.
 | `plugins` | `set[str]` | A list of external plugins to load | :material-checkbox-marked-outline: Yes | `set()`
 | `metrics` | [`Metrics`](#metrics) | Metrics collection configuration.      Configures how Howler collects and exports application metrics,     including integration with external APM servers.      | :material-checkbox-marked-outline: Yes | See [Metrics](#metrics) for details. |
 | `redis` | [`Redis`](#redis) | Redis configuration for Howler.      Defines connections to both persistent and non-persistent Redis instances.     The non-persistent instance is used for volatile data like caches, while     the persistent instance is used for data that needs to survive restarts.      | :material-checkbox-marked-outline: Yes | See [Redis](#redis) for details. |
-| `borealis` | [`Borealis`](#borealis) | Borealis enrichment service integration configuration.      Defines settings for integrating with Borealis, an external enrichment     service that can provide additional context and status information for     hits displayed in the Howler UI.      | :material-checkbox-marked-outline: Yes | See [Borealis](#borealis) for details. |
+| `clue` | [`Clue`](#clue) | Clue enrichment service integration configuration.      Defines settings for integrating with Clue, an external enrichment     service that can provide additional context and status information for     hits displayed in the Howler UI.      | :material-checkbox-marked-outline: Yes | See [Clue](#clue) for details. |
 | `notebook` | [`Notebook`](#notebook) | Jupyter notebook integration configuration.      Defines settings for integrating with nbgallery, a collaborative     Jupyter notebook platform, allowing users to access and share     notebooks related to their Howler analysis work.      | :material-checkbox-marked-outline: Yes | See [Notebook](#notebook) for details. |
-
 
 # Metrics
 
@@ -174,7 +166,6 @@ including integration with external APM servers.
 | :--- | :--- | :--- | :--- | :--- |
 | `apm_server` | [`APMServer`](#apmserver) | Application Performance Monitoring (APM) server configuration.      Defines the connection details for an external APM server used to     collect and analyze application performance metrics.      | :material-checkbox-marked-outline: Yes | See [APMServer](#apmserver) for details. |
 
-
 # APMServer
 
 Application Performance Monitoring (APM) server configuration.
@@ -186,7 +177,6 @@ collect and analyze application performance metrics.
 | :--- | :--- | :--- | :--- | :--- |
 | `server_url` | `str` | URL to API server | :material-minus-box-outline: Optional | `None`
 | `token` | `str` | Authentication token for server | :material-minus-box-outline: Optional | `None`
-
 
 # Redis
 
@@ -201,6 +191,17 @@ the persistent instance is used for data that needs to survive restarts.
 | `nonpersistent` | [`RedisServer`](#redisserver) | Configuration for a single Redis server instance.      Defines the connection parameters for a Redis server, including     the hostname and port number.      | :material-checkbox-marked-outline: Yes | See [RedisServer](#redisserver) for details. |
 | `persistent` | [`RedisServer`](#redisserver) | Configuration for a single Redis server instance.      Defines the connection parameters for a Redis server, including     the hostname and port number.      | :material-checkbox-marked-outline: Yes | See [RedisServer](#redisserver) for details. |
 
+# RedisServer
+
+Configuration for a single Redis server instance.
+
+Defines the connection parameters for a Redis server, including
+the hostname and port number.
+
+| Field | Type | Description | Required | Default |
+| :--- | :--- | :--- | :--- | :--- |
+| `host` | `str` | Hostname of Redis instance | :material-checkbox-marked-outline: Yes | `PydanticUndefined`
+| `port` | `int` | Port of Redis instance | :material-checkbox-marked-outline: Yes | `PydanticUndefined`
 
 # RedisServer
 
@@ -214,34 +215,19 @@ the hostname and port number.
 | `host` | `str` | Hostname of Redis instance | :material-checkbox-marked-outline: Yes | `PydanticUndefined`
 | `port` | `int` | Port of Redis instance | :material-checkbox-marked-outline: Yes | `PydanticUndefined`
 
+# Clue
 
-# RedisServer
+Clue enrichment service integration configuration.
 
-Configuration for a single Redis server instance.
-
-Defines the connection parameters for a Redis server, including
-the hostname and port number.
-
-| Field | Type | Description | Required | Default |
-| :--- | :--- | :--- | :--- | :--- |
-| `host` | `str` | Hostname of Redis instance | :material-checkbox-marked-outline: Yes | `PydanticUndefined`
-| `port` | `int` | Port of Redis instance | :material-checkbox-marked-outline: Yes | `PydanticUndefined`
-
-
-# Borealis
-
-Borealis enrichment service integration configuration.
-
-Defines settings for integrating with Borealis, an external enrichment
+Defines settings for integrating with Clue, an external enrichment
 service that can provide additional context and status information for
 hits displayed in the Howler UI.
 
 | Field | Type | Description | Required | Default |
 | :--- | :--- | :--- | :--- | :--- |
-| `enabled` | `bool` | Should borealis integration be enabled? | :material-checkbox-marked-outline: Yes | `False`
-| `url` | `str` | What url should Howler connect to to interact with Borealis? | :material-checkbox-marked-outline: Yes | `http://enrichment-rest.enrichment.svc.cluster.local:5000`
-| `status_checks` | `list[str]` | A list of borealis fetchers that return status results given a Howler ID to show in the UI. | :material-checkbox-marked-outline: Yes | `[]`
-
+| `enabled` | `bool` | Should clue integration be enabled? | :material-checkbox-marked-outline: Yes | `False`
+| `url` | `str` | What url should Howler connect to to interact with Clue? | :material-checkbox-marked-outline: Yes | `http://enrichment-rest.enrichment.svc.cluster.local:5000`
+| `status_checks` | `list[str]` | A list of clue fetchers that return status results given a Howler ID to show in the UI. | :material-checkbox-marked-outline: Yes | `[]`
 
 # Notebook
 
@@ -257,7 +243,6 @@ notebooks related to their Howler analysis work.
 | `scope` | `str` | The scope expected by nbgallery for JWTs | :material-minus-box-outline: Optional | `None`
 | `url` | `str` | The url to connect to nbgallery at | :material-checkbox-marked-outline: Yes | `http://nbgallery.nbgallery.svc.cluster.local:3000`
 
-
 # Datastore
 
 Datastore configuration for Howler.
@@ -269,7 +254,6 @@ Currently supports Elasticsearch as the datastore type.
 | :--- | :--- | :--- | :--- | :--- |
 | `hosts` | `list[Host]` | List of hosts used for the datastore | :material-checkbox-marked-outline: Yes | `[http://elastic:devpass@localhost:9200]`
 | `type` | `Literal[elasticsearch]` | Type of application used for the datastore | :material-checkbox-marked-outline: Yes | `elasticsearch`
-
 
 # Host
 
@@ -289,7 +273,6 @@ Environment variables can override username and password using the pattern
 | `apikey_secret` | `str` | Secret data of the API Key to use when connecting | :material-minus-box-outline: Optional | `None`
 | `scheme` | `str` | Scheme to use when connecting | :material-minus-box-outline: Optional | `http`
 | `host` | `str` | URL to connect to | :material-checkbox-marked-outline: Yes | `PydanticUndefined`
-
 
 # Logging
 
@@ -311,7 +294,6 @@ metric export intervals.
 | `export_interval` | `int` | How often, in seconds, should counters log their values? | :material-checkbox-marked-outline: Yes | `5`
 | `log_as_json` | `bool` | Log in JSON format? | :material-checkbox-marked-outline: Yes | `True`
 
-
 # System
 
 System-level configuration for Howler.
@@ -325,7 +307,6 @@ jobs like data retention and view cleanup.
 | `type` | `Literal[production, staging, development]` | Type of system | :material-checkbox-marked-outline: Yes | `development`
 | `retention` | [`Retention`](#retention) | Hit retention policy configuration.      Defines the automatic data retention policy for hits, including     the maximum age of hits before they are purged and the schedule     for running the retention cleanup job.      | :material-checkbox-marked-outline: Yes | See [Retention](#retention) for details. |
 | `view_cleanup` | [`ViewCleanup`](#viewcleanup) | View cleanup job configuration.      Defines the schedule and behavior for cleaning up stale dashboard views     that reference non-existent backend data.      | :material-checkbox-marked-outline: Yes | See [ViewCleanup](#viewcleanup) for details. |
-
 
 # Retention
 
@@ -342,7 +323,6 @@ for running the retention cleanup job.
 | `limit_amount` | `int` | The number of limit_units to use when computing the retention limit | :material-checkbox-marked-outline: Yes | `350`
 | `crontab` | `str` | The crontab that denotes how often to run the retention job | :material-checkbox-marked-outline: Yes | `0 0 * * *`
 
-
 # ViewCleanup
 
 View cleanup job configuration.
@@ -354,7 +334,6 @@ that reference non-existent backend data.
 | :--- | :--- | :--- | :--- | :--- |
 | `enabled` | `bool` | Whether to enable the view cleanup. If enabled, views pinned to the dashboard that no longer exist in the backend will be cleared. | :material-checkbox-marked-outline: Yes | `True`
 | `crontab` | `str` | The crontab that denotes how often to run the view_cleanup job | :material-checkbox-marked-outline: Yes | `0 0 * * *`
-
 
 # UI
 
@@ -375,4 +354,3 @@ integration for real-time updates.
 | `validate_session_ip` | `bool` | Validate if the session IP matches the IP the session was created from | :material-checkbox-marked-outline: Yes | `True`
 | `validate_session_useragent` | `bool` | Validate if the session useragent matches the useragent the session was created with | :material-checkbox-marked-outline: Yes | `True`
 | `websocket_url` | `str` | The url to hit when emitting websocket events on the cluster | :material-minus-box-outline: Optional | `None`
-

--- a/documentation/docs/installation/default_configuration.md
+++ b/documentation/docs/installation/default_configuration.md
@@ -61,7 +61,7 @@ auth:
         user_get: null
     strict_apikeys: true
 core:
-  borealis:
+  clue:
     enabled: false
     status_checks: []
     url: http://enrichment-rest.enrichment.svc.cluster.local:5000

--- a/documentation/docs/odm/class/lead.md
+++ b/documentation/docs/odm/class/lead.md
@@ -9,8 +9,6 @@
 | :--- | :--- | :--- | :--- | :--- |
 | icon | Text | An optional icon to use in the tab display for this dossier. | :material-minus-box-outline: Optional | `None` |
 | label | [LocalizedLabel](/howler/odm/class/localizedlabel) | Labels for the lead in the UI. | :material-checkbox-marked-outline: Yes | `None` |
-| format | Enum | The format of the lead. <br>Values:<br>`"borealis", "markdown"` | :material-checkbox-marked-outline: Yes | `None` |
+| format | Text | The format of the lead. | :material-checkbox-marked-outline: Yes | `None` |
 | content | Text | The data for the content. Could be a link, raw markdown text, or other valid lead format. | :material-checkbox-marked-outline: Yes | `None` |
 | metadata | Json | Metadata associated with this dossier. Use varies based on format. | :material-minus-box-outline: Optional | `None` |
-
-

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -16,18 +16,18 @@ export default defineConfig(({ mode }) => {
       ws: true,
       configure: (proxy, _options) => {
         proxy.on('error', (err, _req, _res) => {
-          if (_req.url?.includes('borealis') || _req.url?.includes('clue')) {
+          if (_req.url?.includes('clue')) {
             console.error('[clue]', err);
           } else {
             console.error('[howler]', err);
           }
         });
 
-        proxy.on('proxyRes', (proxyRes, req, _res) => {
-          if (req.url?.includes('borealis') || req.url?.includes('clue')) {
-            console.log('[clue]', proxyRes.statusCode, req.url);
+        proxy.on('proxyRes', (proxyRes, _req, _res) => {
+          if (_req.url?.includes('clue')) {
+            console.log('[clue]', proxyRes.statusCode, _req.url);
           } else {
-            console.log('[howler]', proxyRes.statusCode, req.url);
+            console.log('[howler]', proxyRes.statusCode, _req.url);
           }
         });
       }


### PR DESCRIPTION
This pull request migrates the enrichment service integration in Howler from "Borealis" to "Clue". All references, configuration, endpoints, and documentation have been updated to use "Clue" instead of "Borealis". The changes ensure a consistent transition across the codebase, including API routes, configuration models, plugin logic, and test cases.

**API and Service Integration Updates**
* The API endpoint and blueprint for enrichment have been renamed from `borealis` to `clue`, including all related functions, routes, and logging statements in `api/howler/api/v1/clue.py` [[1]](diffhunk://#diff-90d27263fdab527b4cec1d7236e0c20995eb2e2ac87129bcc131ed59f3d47937L17-R19) [[2]](diffhunk://#diff-90d27263fdab527b4cec1d7236e0c20995eb2e2ac87129bcc131ed59f3d47937L31-R51) [[3]](diffhunk://#diff-90d27263fdab527b4cec1d7236e0c20995eb2e2ac87129bcc131ed59f3d47937L63-R65) [[4]](diffhunk://#diff-90d27263fdab527b4cec1d7236e0c20995eb2e2ac87129bcc131ed59f3d47937L76-R97).
* The quota bypass logic and API response handling now reference `/api/v1/clue` instead of `/api/v1/borealis` [[1]](diffhunk://#diff-29224092183669973cc861b2e495febd739bfd25d2aec3617992d4c91d7a2a43L35-R35) [[2]](diffhunk://#diff-4a1beda22c5a00779290a68a8e8eb520108449cd6da4e6c408dd48a6541359d9L223-R224).

**Configuration Model Changes**
* The configuration model for the enrichment service has been renamed from `Borealis` to `Clue`, with all associated fields, descriptions, and references updated [[1]](diffhunk://#diff-52ee7c226148cc8d84fc36b1a9b9dec6db434703478e48aca8a8fd2ce04b392fL412-R429) [[2]](diffhunk://#diff-52ee7c226148cc8d84fc36b1a9b9dec6db434703478e48aca8a8fd2ce04b392fL454-R454) [[3]](diffhunk://#diff-52ee7c226148cc8d84fc36b1a9b9dec6db434703478e48aca8a8fd2ce04b392fL466-R467) [[4]](diffhunk://#diff-52ee7c226148cc8d84fc36b1a9b9dec6db434703478e48aca8a8fd2ce04b392fL532-R532).
* The application initialization and feature flags now use `clue` for enabling/disabling the enrichment integration [[1]](diffhunk://#diff-11e088d985af994b4229bd4581c1c05d5cdd77572305e6c1ea3690cbb43d5ad9L141-R145) [[2]](diffhunk://#diff-b65dbfe68c0be3d711fce6fe3c9cb54789fbafb6fdda2187312d52bd49768af7L120-R124).

**Data Model and Helper Updates**
* All references to "borealis" in the lead and pivot data models and helper functions have been changed to "clue" [[1]](diffhunk://#diff-c6bbcfb48d3f3b7b2fa4308b15d004e31455ff15c6d0e3c32e2245ccd6bcd460L262-R268) [[2]](diffhunk://#diff-c6bbcfb48d3f3b7b2fa4308b15d004e31455ff15c6d0e3c32e2245ccd6bcd460L279-R280) [[3]](diffhunk://#diff-1e8479bc2db91bf59a66b210eef6558a1f38dc58812555a1c05ccea73d269694L5-L16) [[4]](diffhunk://#diff-1e8479bc2db91bf59a66b210eef6558a1f38dc58812555a1c05ccea73d269694L27-R18) [[5]](diffhunk://#diff-b08f3b7bbb328d7353ca2532588c25219aa46fe0fa12be058a04e130d130f401L34-R34).

**Plugin and Test Adjustments**
* Plugin configuration, token functions, and related tests have been updated to use "clue" instead of "borealis" [[1]](diffhunk://#diff-abbbd928cc2c01f92fb8bacdde40eca6d6684af0458faeb7893393c99d88e808L42-R46) [[2]](diffhunk://#diff-c6b7838f21e3b024a223c9c25f7a228d542141ff6edfc5ee47627bcb9e82e4a6L390-R392) [[3]](diffhunk://#diff-c6b7838f21e3b024a223c9c25f7a228d542141ff6edfc5ee47627bcb9e82e4a6L422-R422) [[4]](diffhunk://#diff-becfd87a7f4497955f6e5f01cde726650027ec9a581e97a5893b3fd71d4466fbL33-R49).

**Documentation Updates**
* All documentation references, configuration instructions, and codebase structure descriptions now use "clue" in place of "borealis" [[1]](diffhunk://#diff-3ad3ff5a39c67e19ddc0c54f12378af8cf619dbfa2cefbe82aebc1769db69133L49-R49) [[2]](diffhunk://#diff-f5973768d4af66a94e84b1c4885df7002845cf092861a4626a0d0876725c2d5fL20-R25).

These changes ensure the enrichment service integration is fully transitioned to "Clue" throughout the project.