### PR TITLE
chore: normalize logging string format style

### DIFF
--- a/api/build_scripts/generate_classes.py
+++ b/api/build_scripts/generate_classes.py
@@ -149,7 +149,7 @@ def generate_structure():  # noqa: C901
         validation_list = validation_req.json()["api_response"]["items"]
 
         if len(validation_list) == 0:
-            log.critical(f"No validation object found for index {index}, aborting")
+            log.critical("No validation object found for index %s, aborting", index)
             sys.exit(1)
 
         validation_obj = next(
@@ -192,7 +192,7 @@ def generate_structure():  # noqa: C901
                 if current.get(current_field, None) is None:
                     # If we haven't initialized this node yet, we'll do so now
                     current[current_field] = dict()
-                    log.debug(f"{indent}{current_field}:")
+                    log.debug("%s%s:", indent, current_field)
 
                 # Descend down the tree we're creating, and the validation object.
                 current = current[current_field]
@@ -260,10 +260,7 @@ def generate_structure():  # noqa: C901
                     assert isinstance(
                         current_value,
                         python_type,
-                    ), (
-                        f"Type {key} does not match: {type(current_value)}, "
-                        f"{python_type} from {index_data[key]['type']}"
-                    )
+                    ), f"Type {key} does not match: {type(current_value)}, {python_type} from {index_data[key]['type']}"
             except KeyError as e:
                 # We have to special case dossier models, since they have up to five defined fields but often only the
                 # first few are actually set. We can safely ignore KeyErrors from them if they aren't set.
@@ -285,7 +282,7 @@ def generate_structure():  # noqa: C901
                 "__ts_field_type": ts_field_type,
                 "__required": key in REQUIRED_FIELDS,
             }
-            log.debug(f"{indent}{current_field}: ts:{ts_field_type}")
+            log.debug("%s%s: ts:%s", indent, current_field, ts_field_type)
 
     return structure
 
@@ -536,7 +533,7 @@ def generate_api_config_types():
             # | }]              |
             def fix_whitespace(match_obj):
                 lines = match_obj.group(2).split("\n")
-                return f'{{{" ".join(line.strip() for line in lines)}}}[]'
+                return f"{{{' '.join(line.strip() for line in lines)}}}[]"
 
             config_type = re.sub(r"\[\s+({([\s\S]+?)},?\s+)+]", fix_whitespace, config_type)
 
@@ -581,10 +578,10 @@ def generate_api_config_types():
             + textwrap.dedent(
                 f"""
                 export interface ApiType {{
-                  indexes: API{to_pascal_case('indexes')};
-                  lookups: API{to_pascal_case('lookups')};
-                  configuration: API{to_pascal_case('configuration')};
-                  c12nDef: API{to_pascal_case('c12nDef')};
+                  indexes: API{to_pascal_case("indexes")};
+                  lookups: API{to_pascal_case("lookups")};
+                  configuration: API{to_pascal_case("configuration")};
+                  c12nDef: API{to_pascal_case("c12nDef")};
                 }}
                 """
             )

--- a/api/build_scripts/generate_classes.py
+++ b/api/build_scripts/generate_classes.py
@@ -143,7 +143,7 @@ def generate_structure():  # noqa: C901
             sys.exit(1)
 
         if validation_req.status_code == 400:
-            log.fatal(f"400 when pulling validation data! Response: {validation_req.json()}")
+            log.fatal("400 when pulling validation data! Response: %s", validation_req.json())
             sys.exit(1)
 
         validation_list = validation_req.json()["api_response"]["items"]

--- a/api/howler/api/v1/auth.py
+++ b/api/howler/api/v1/auth.py
@@ -347,23 +347,23 @@ def login(**_):  # noqa: C901
     # For sanity's sake, we throw exceptions throughout the authentication code and simply catch the exceptions here to
     # return the corresponding HTTP Code to the user
     except (OAuthError, AuthenticationException) as err:
-        logger.warning(f"Authentication failure. (U:{user} - IP:{ip}) [{err}]")
+        logger.warning("Authentication failure. (U:%s - IP:%s) [%s]", user, ip, err)
         return unauthorized(err=str(err))
 
     except AccessDeniedException as err:
-        logger.warning(f"Authorization failure. (U:{user} - IP:{ip}) [{err}]")
+        logger.warning("Authorization failure. (U:%s - IP:%s) [%s]", user, ip, err)
         return forbidden(err=err.message)
 
     except InvalidDataException as err:
         return bad_request(err=err.message or str(err))
 
     except HowlerException:
-        logger.exception(f"Internal Authentication Error. (U:{user} - IP:{ip})")
+        logger.exception("Internal Authentication Error. (U:%s - IP:%s)", user, ip)
         return internal_error(
             err="Unhandled exception occured while Authenticating. Contact your administrator.",
         )
 
-    logger.info(f"Login successful. (U:{logged_in_uname} - IP:{ip})")
+    logger.info("Login successful. (U:%s - IP:%s)", logged_in_uname, ip)
 
     xsrf_token = generate_random_secret()
 

--- a/api/howler/api/v1/clue.py
+++ b/api/howler/api/v1/clue.py
@@ -91,7 +91,7 @@ def proxy_to_clue(path, **kwargs):
                 timeout=5 * 60,
             )
 
-    logger.debug(f"Request to clue completed in {round(time.perf_counter() - start)}ms")
+    logger.debug("Request to clue completed in %s ms", round(time.perf_counter() - start))
 
     if not response.ok:
         return bad_gateway(response.json(), err="Something went wrong when connecting to clue")

--- a/api/howler/api/v1/hit.py
+++ b/api/howler/api/v1/hit.py
@@ -99,7 +99,7 @@ def create_hits(user: User, **kwargs):
     response_body: dict[str, list[Any]] = {"valid": [], "invalid": []}
     odms = []
     ignore_extra_values: bool = bool(request.args.get("ignore_extra_values", False, type=lambda v: v.lower() == "true"))
-    logger.debug(f"ignore_extra_values = {ignore_extra_values}")
+    logger.debug("ignore_extra_values = %s", ignore_extra_values)
     warnings = []
     for hit in hits:
         try:
@@ -108,7 +108,7 @@ def create_hits(user: User, **kwargs):
             odms.append(odm)
             warnings.extend(_warnings)
         except HowlerException as e:
-            logger.warning(f"{type(e).__name__} when saving new hit!")
+            logger.warning("%s when saving new hit!", type(e).__name__)
             logger.warning(e)
             response_body["invalid"].append({"input": hit, "error": str(e)})
 

--- a/api/howler/api/v1/tool.py
+++ b/api/howler/api/v1/tool.py
@@ -67,7 +67,7 @@ def create_one_or_many_hits(tool_name: str, user: User, **kwargs):  # noqa: C901
     field_map = data.pop("map", None)
     hits = data.pop("hits", None)
     ignore_extra_values: bool = bool(request.args.get("ignore_extra_values", False, type=lambda v: v.lower() == "true"))
-    logger.debug(f"ignore_extra_values = {ignore_extra_values}")
+    logger.debug("ignore_extra_values = %s", ignore_extra_values)
     # Check data type
     if not isinstance(field_map, dict):
         return bad_request(err="Invalid: 'map' field is missing or invalid.")
@@ -115,7 +115,7 @@ def create_one_or_many_hits(tool_name: str, user: User, **kwargs):  # noqa: C901
                     try:
                         field_data: Optional[_Field] = hit_fields[target]
                     except KeyError:
-                        logger.debug(f"`{target}` not in hit fields")
+                        logger.debug("`%s` not in hit fields", target)
                         field_data = next(
                             (v for k, v in hit_fields.items() if get_parent_key(k) == target),
                             None,
@@ -153,7 +153,7 @@ def create_one_or_many_hits(tool_name: str, user: User, **kwargs):  # noqa: C901
                 }
             )
         except HowlerException as e:
-            logger.warning(f"{type(e).__name__} when saving {cur_id}!")
+            logger.warning("%s when saving %s!", type(e).__name__, cur_id)
             logger.warning(e)
 
             out.append({"id": None, "error": str(e)})

--- a/api/howler/app.py
+++ b/api/howler/app.py
@@ -206,7 +206,7 @@ if logger.parent:
 
 # Setup APMs
 if config.core.metrics.apm_server.server_url is not None:
-    logger.info(f"Exporting application metrics to: {config.core.metrics.apm_server.server_url}")
+    logger.info("Exporting application metrics to: %s", config.core.metrics.apm_server.server_url)
     ElasticAPM(
         app,
         server_url=config.core.metrics.apm_server.server_url,

--- a/api/howler/common/loader.py
+++ b/api/howler/common/loader.py
@@ -58,9 +58,9 @@ def get_classification(yml_config: Optional[str] = None):  # noqa: C901
                 )
 
         if not yml_config_path.exists():
-            log.warning(f"{yml_config_path} does not exist!")
+            log.warning("%s does not exist!", yml_config_path)
             yml_config_path = Path("/etc") / APP_NAME.replace("-dev", "") / "classification.yml"
-            log.warning(f"Checking at {yml_config_path} instead.")
+            log.warning("Checking at %s instead.", yml_config_path)
     else:
         yml_config_path = Path(yml_config)
 

--- a/api/howler/cronjobs/retention.py
+++ b/api/howler/cronjobs/retention.py
@@ -39,7 +39,7 @@ def setup_job(sched: BaseScheduler):
 
         return
 
-    logger.debug(f"Initializing retention cronjob with cron {config.system.retention.crontab}")
+    logger.debug("Initializing retention cronjob with cron %s", config.system.retention.crontab)
 
     if DEBUG:
         _kwargs: dict[str, Any] = {"next_run_time": datetime.now()}

--- a/api/howler/cronjobs/rules.py
+++ b/api/howler/cronjobs/rules.py
@@ -44,7 +44,7 @@ def create_correlated_bundle(rule: Analytic, query: str, correlated_hits: list[H
     # If a matching bundle exists already, just reused it (likely only ever lucene specific)
     existing_result = datastore().hit.search(f"howler.hash:{hashed}", rows=1)
     if existing_result["total"] > 0:
-        logger.debug(f"Rule hash {hashed} exists - skipping create")
+        logger.debug("Rule hash %s exists - skipping create", hashed)
         return existing_result["items"][0]
 
     child_ids = [match.howler.id for match in correlated_hits]
@@ -200,7 +200,10 @@ def create_executor(rule: Analytic):  # noqa: C901
                 __scheduler_instance.remove_job(f"rule_{rule.analytic_id}")
             # TODO: Allow restarting of rules
             logger.critical(
-                f"Rule {rule.name} ({rule.analytic_id}) has been stopped, due to an exception: {type(e)}",
+                "Rule %s (%s) has been stopped, due to an exception: %s",
+                rule.name,
+                rule.analytic_id,
+                type(e),
                 exc_info=True,
             )
 
@@ -220,12 +223,12 @@ def register_rules(new_rule: Optional[Analytic] = None, test_override: bool = Fa
 
     if new_rule:
         if __scheduler_instance.get_job(f"rule_{new_rule.analytic_id}"):
-            logger.info(f"Updating existing rule: {new_rule.analytic_id} on interval {new_rule.rule_crontab}")
+            logger.info("Updating existing rule: %s on interval %s", new_rule.analytic_id, new_rule.rule_crontab)
 
             # remove the existing job
             __scheduler_instance.remove_job(f"rule_{new_rule.analytic_id}")
         else:
-            logger.info(f"Registering new rule: {new_rule.analytic_id} on interval {new_rule.rule_crontab}")
+            logger.info("Registering new rule: %s on interval %s", new_rule.analytic_id, new_rule.rule_crontab)
         rules = [new_rule]
     else:
         logger.debug("Registering rules")
@@ -237,10 +240,12 @@ def register_rules(new_rule: Optional[Analytic] = None, test_override: bool = Fa
         interval = rule.rule_crontab or f"{random.randint(0, 59)} * * * *"  # noqa: S311
 
         if __scheduler_instance.get_job(job_id):
-            logger.debug(f"Rule {job_id} already running!")
+            logger.debug("Rule %s already running!", job_id)
             return
 
-        logger.debug(f"Initializing rule cronjob with:\tJob ID: {job_id}\tRule Name: {rule.name}\tCrontab: {interval}")
+        logger.debug(
+            "Initializing rule cronjob with:\tJob ID: %s\tRule Name: %s\tCrontab: %s", job_id, rule.name, interval
+        )
 
         if DEBUG or new_rule:
             _kwargs: dict[str, Any] = {"next_run_time": datetime.now()}
@@ -255,7 +260,7 @@ def register_rules(new_rule: Optional[Analytic] = None, test_override: bool = Fa
             **_kwargs,
         )
 
-    logger.info(f"Initialized {total_initialized} rules")
+    logger.info("Initialized %s rules", total_initialized)
 
 
 def setup_job(sched: BaseScheduler):

--- a/api/howler/cronjobs/view_cleanup.py
+++ b/api/howler/cronjobs/view_cleanup.py
@@ -68,7 +68,7 @@ def setup_job(sched: BaseScheduler):
 
         return
 
-    logger.debug(f"Initializing view cleanup cronjob with cron {config.system.view_cleanup.crontab}")
+    logger.debug("Initializing view cleanup cronjob with cron %s", config.system.view_cleanup.crontab)
 
     if DEBUG:
         _kwargs: dict[str, Any] = {"next_run_time": datetime.now()}

--- a/api/howler/datastore/collection.py
+++ b/api/howler/datastore/collection.py
@@ -411,7 +411,8 @@ class ESCollection(Generic[ModelType]):
                     retries += 1
                 elif err_code == 403 or err_code == "403":
                     logger.warning(
-                        f"Elasticsearch cluster is preventing writing operations on index {self.name}, retrying..."
+                        "Elasticsearch cluster is preventing writing operations on index %s, retrying...",
+                        self.name,
                     )
                     time.sleep(min(retries, self.MAX_RETRY_BACKOFF))
                     self.datastore.connection_reset()
@@ -470,7 +471,7 @@ class ESCollection(Generic[ModelType]):
             except elasticsearch.exceptions.TransportError as e:
                 err_code, _, _ = e.args
                 if err_code == 408 or err_code == "408":
-                    logger.warning(f"Waiting for index {index} to get to status {min_status}...")
+                    logger.warning("Waiting for index %s to get to status %s...", index, min_status)
                 else:
                     raise
 
@@ -576,8 +577,9 @@ class ESCollection(Generic[ModelType]):
 
         if cur_shards > target_shards:
             logger.info(
-                f"Current shards ({cur_shards}) is bigger then target shards ({target_shards}), "
-                "we will be shrinking the index."
+                "Current shards (%s) is bigger then target shards (%s), we will be shrinking the index.",
+                cur_shards,
+                target_shards,
             )
             if cur_shards % target_shards != 0:
                 logger.info("The target shards is not a factor of the current shards, aborting...")
@@ -591,8 +593,9 @@ class ESCollection(Generic[ModelType]):
                 method = self.datastore.client.indices.shrink
         elif cur_shards < target_shards:
             logger.info(
-                f"Current shards ({cur_shards}) is smaller then target shards ({target_shards}), "
-                "we will be splitting the index."
+                "Current shards (%s) is smaller then target shards (%s), we will be splitting the index.",
+                cur_shards,
+                target_shards,
             )
             if target_shards % cur_shards != 0:
                 logger.warning("The current shards is not a factor of the target shards, aborting...")
@@ -601,13 +604,14 @@ class ESCollection(Generic[ModelType]):
                 method = self.datastore.client.indices.split
         else:
             logger.info(
-                f"Current shards ({cur_shards}) is equal to the target shards ({target_shards}), "
-                "only house keeping operations will be performed."
+                "Current shards (%s) is equal to the target shards (%s), only house keeping operations will be performed.",
+                cur_shards,
+                target_shards,
             )
 
         if method:
             # Before we do anything, we should make sure the source index is in a good state
-            logger.info(f"Waiting for {self.name.upper()} status to be GREEN.")
+            logger.info("Waiting for %s status to be GREEN.", self.name.upper())
             self._wait_for_status(self.name, min_status="green")
 
             # Block all indexes to be written to
@@ -618,7 +622,7 @@ class ESCollection(Generic[ModelType]):
             if not self.with_retries(self.datastore.client.indices.exists, index=temp_name):
                 # if there are specific settings to be applied to the index, apply them
                 if clone_setup_settings:
-                    logger.info(f"Rellocating index to node {target_node.upper()}.")
+                    logger.info("Rellocating index to node %s.", target_node.upper())
                     self.with_retries(
                         self.datastore.client.indices.put_settings,
                         index=self.index_name,
@@ -630,7 +634,7 @@ class ESCollection(Generic[ModelType]):
                         time.sleep(1)
 
                 # Make a clone of the current index
-                logger.info(f"Cloning {self.index_name.upper()} into {temp_name.upper()}.")
+                logger.info("Cloning %s into %s.", self.index_name.upper(), temp_name.upper())
                 self._safe_index_copy(
                     self.datastore.client.indices.clone,
                     self.index_name,
@@ -640,14 +644,16 @@ class ESCollection(Generic[ModelType]):
                 )
 
             # Make 100% sure temporary index is ready
-            logger.info(f"Waiting for {temp_name.upper()} status to be GREEN.")
+            logger.info("Waiting for %s status to be GREEN.", temp_name.upper())
             self._wait_for_status(temp_name, "green")
 
             # Make sure temporary index is the alias if not already
             if self._get_current_alias(self.name) != temp_name:
                 logger.info(
-                    f"Make {temp_name.upper()} the current alias for {self.name.upper()} "
-                    f"and delete {self.index_name.upper()}."
+                    "Make %s the current alias for %s and delete %s.",
+                    temp_name.upper(),
+                    self.name.upper(),
+                    self.index_name.upper(),
                 )
                 # Make the hot index the temporary index while deleting the original index
                 alias_actions = [
@@ -658,17 +664,19 @@ class ESCollection(Generic[ModelType]):
 
             # Make sure the original index is deleted
             if self.with_retries(self.datastore.client.indices.exists, index=self.index_name):
-                logger.info(f"Delete extra {self.index_name.upper()} index.")
+                logger.info("Delete extra %s index.", self.index_name.upper())
                 self.with_retries(self.datastore.client.indices.delete, index=self.index_name)
 
             # Shrink/split the temporary index into the original index
-            logger.info(f"Perform shard fix operation from {temp_name.upper()} to {self.index_name.upper()}.")
+            logger.info("Perform shard fix operation from %s to %s.", temp_name.upper(), self.index_name.upper())
             self._safe_index_copy(method, temp_name, self.index_name, settings=settings)
 
             # Make the original index the new alias
             logger.info(
-                f"Make {self.index_name.upper()} the current alias for {self.name.upper()} "
-                f"and delete {temp_name.upper()}."
+                "Make %s the current alias for %s and delete %s.",
+                self.index_name.upper(),
+                self.name.upper(),
+                temp_name.upper(),
             )
             alias_actions = [
                 {"add": {"index": self.index_name, "alias": self.name}},
@@ -681,7 +689,7 @@ class ESCollection(Generic[ModelType]):
         self.with_retries(self.datastore.client.indices.put_settings, settings=write_unblock_settings)
 
         # Restore normal routing and replicas
-        logger.debug(f"Restore original routing table for {self.name.upper()}.")
+        logger.debug("Restore original routing table for %s.", self.name.upper())
         self.with_retries(
             self.datastore.client.indices.put_settings,
             index=self.name,
@@ -849,7 +857,7 @@ class ESCollection(Generic[ModelType]):
                     key_list.remove(row["_id"])
                     add_to_output(row["_source"], row["_id"])
                 except ValueError:
-                    logger.exception(f"MGet returned multiple documents for id: {row['_id']}")
+                    logger.exception("MGet returned multiple documents for id: %s", row["_id"])
 
         if key_list and error_on_missing:
             raise MultiKeyError(key_list, out)
@@ -2359,7 +2367,7 @@ class ESCollection(Generic[ModelType]):
         """
         # Create HOT index
         if not self.with_retries(self.datastore.client.indices.exists, index=self.name):
-            logger.debug(f"Index {self.name.upper()} does not exists. Creating it now...")
+            logger.debug("Index %s does not exists. Creating it now...", self.name.upper())
             try:
                 self.with_retries(
                     self.datastore.client.indices.create,
@@ -2370,7 +2378,7 @@ class ESCollection(Generic[ModelType]):
             except elasticsearch.exceptions.RequestError as e:
                 if "resource_already_exists_exception" not in str(e):
                     raise
-                logger.warning(f"Tried to create an index template that already exists: {self.name.upper()}")
+                logger.warning("Tried to create an index template that already exists: %s", self.name.upper())
 
             self.with_retries(
                 self.datastore.client.indices.put_alias,

--- a/api/howler/datastore/collection.py
+++ b/api/howler/datastore/collection.py
@@ -604,7 +604,8 @@ class ESCollection(Generic[ModelType]):
                 method = self.datastore.client.indices.split
         else:
             logger.info(
-                "Current shards (%s) is equal to the target shards (%s), only house keeping operations will be performed.",
+                "Current shards (%s) is equal to the target shards (%s), only house keeping operations will be "
+                "performed.",
                 cur_shards,
                 target_shards,
             )

--- a/api/howler/datastore/collection.py
+++ b/api/howler/datastore/collection.py
@@ -398,7 +398,7 @@ class ESCollection(Generic[ModelType]):
             except elasticsearch.exceptions.TransportError as e:
                 err_code, msg, cause = e.args
                 if err_code == 503 or err_code == "503":
-                    logger.warning(f"Looks like index {self.name} is not ready yet, retrying...")
+                    logger.warning("Looks like index %s is not ready yet, retrying...", self.name)
                     time.sleep(min(retries, self.MAX_RETRY_BACKOFF))
                     self.datastore.connection_reset()
                     retries += 1

--- a/api/howler/datastore/collection.py
+++ b/api/howler/datastore/collection.py
@@ -604,7 +604,7 @@ class ESCollection(Generic[ModelType]):
                 method = self.datastore.client.indices.split
         else:
             logger.info(
-                "Current shards (%s) is equal to the target shards (%s), only house keeping operations will be "
+                "Current shards (%s) is equal to the target shards (%s), only housekeeping operations will be "
                 "performed.",
                 cur_shards,
                 target_shards,
@@ -623,7 +623,7 @@ class ESCollection(Generic[ModelType]):
             if not self.with_retries(self.datastore.client.indices.exists, index=temp_name):
                 # if there are specific settings to be applied to the index, apply them
                 if clone_setup_settings:
-                    logger.info("Rellocating index to node %s.", target_node.upper())
+                    logger.info("Relocating index to node %s.", target_node.upper())
                     self.with_retries(
                         self.datastore.client.indices.put_settings,
                         index=self.index_name,
@@ -2368,7 +2368,7 @@ class ESCollection(Generic[ModelType]):
         """
         # Create HOT index
         if not self.with_retries(self.datastore.client.indices.exists, index=self.name):
-            logger.debug("Index %s does not exists. Creating it now...", self.name.upper())
+            logger.debug("Index %s does not exist. Creating it now...", self.name.upper())
             try:
                 self.with_retries(
                     self.datastore.client.indices.create,

--- a/api/howler/datastore/migrations/fix_process.py
+++ b/api/howler/datastore/migrations/fix_process.py
@@ -15,12 +15,12 @@ def migrate():
         logger.info("Preconditions met, continuing.")
 
         db_size = collection.search("howler.id:*", track_total_hits=True, rows=0)["total"]
-        logger.info(f"Database size pre-migration: {db_size}")
+        logger.info("Database size pre-migration: %s", db_size)
     else:
         logger.info("Preconditions not met, stopping")
         return
 
-    logger.info(f"We will delete {result['total']} hits. Continue?")
+    logger.info("We will delete %s hits. Continue?", result["total"])
     prompt_result = input("y/[n]")
 
     if prompt_result.lower() != "y":
@@ -32,7 +32,7 @@ def migrate():
     collection.commit()
 
     db_size_after = collection.search("howler.id:*", track_total_hits=True, rows=0)["total"]
-    logger.info(f"Database size post-migration: {db_size_after}")
+    logger.info("Database size post-migration: %s", db_size_after)
 
     logger.info("Migration complete")
 

--- a/api/howler/helper/discover.py
+++ b/api/howler/helper/discover.py
@@ -47,11 +47,11 @@ def get_apps_list(discovery_url: Optional[str]) -> list[dict[str, str]]:
                             )
 
                     except Exception:
-                        logger.exception(f"Failed to parse get app: {str(app)}")
+                        logger.exception("Failed to parse get app: %s", str(app))
             else:
-                logger.warning(f"Invalid response from server for apps discovery: {discovery_url}")
+                logger.warning("Invalid response from server for apps discovery: %s", discovery_url)
         except Exception:
-            logger.exception(f"Failed to get apps from discover URL: {discovery_url}")
+            logger.exception("Failed to get apps from discover URL: %s", discovery_url)
 
         DISCO_CACHE[discovery_url] = sorted(apps, key=lambda k: k["name"])
         return sorted(apps, key=lambda k: k["name"])

--- a/api/howler/odm/helper.py
+++ b/api/howler/odm/helper.py
@@ -361,7 +361,7 @@ def create_users_with_username(ds: HowlerDatastore, usernames: list[str]):
         ds.user.save(username, user_data)
 
         if "pytest" not in sys.modules:
-            logger.info(f"{username}:{username}")
+            logger.info("%s:%s", username, username)
 
     ds.user.commit()
     ds.user_avatar.commit()

--- a/api/howler/odm/random_data.py
+++ b/api/howler/odm/random_data.py
@@ -137,7 +137,7 @@ def create_users(ds):
     ds.view.save(admin_view.view_id, admin_view)
 
     if "pytest" not in sys.modules:
-        logger.info(f"\t{user_data.uname}:{admin_pass}")
+        logger.info("\t%s:%s", user_data.uname, admin_pass)
 
     user_hash = get_password_hash(user_pass)
 
@@ -184,7 +184,7 @@ def create_users(ds):
     ds.view.save(user_view.view_id, user_view)
 
     if "pytest" not in sys.modules:
-        logger.info(f"\t{user_data.uname}:{user_pass}")
+        logger.info("\t%s:%s", user_data.uname, user_pass)
 
     huey_hash = get_password_hash(huey_pass)
 
@@ -231,7 +231,7 @@ def create_users(ds):
     ds.view.save(huey_view.view_id, huey_view)
 
     if "pytest" not in sys.modules:
-        logger.info(f"\t{huey_data.uname}:{huey_pass}")
+        logger.info("\t%s:%s", huey_data.uname, huey_pass)
 
     shawnh_view = View(
         {
@@ -261,7 +261,7 @@ def create_users(ds):
     ds.view.save(shawnh_view.view_id, shawnh_view)
 
     if "pytest" not in sys.modules:
-        logger.info(f"\t{shawn_data.uname}:{shawnh_pass}")
+        logger.info("\t%s:%s", shawn_data.uname, shawnh_pass)
 
     goose_view = View(
         {
@@ -291,7 +291,7 @@ def create_users(ds):
     ds.view.save(goose_view.view_id, goose_view)
 
     if "pytest" not in sys.modules:
-        logger.info(f"\t{goose_data.uname}:{goose_pass}")
+        logger.info("\t%s:%s", goose_data.uname, goose_pass)
 
     ds.user.commit()
     ds.user_avatar.commit()
@@ -892,7 +892,7 @@ if __name__ == "__main__":
 
     for index, operations in INDEXES.items():
         if index in args:
-            logger.info(f"Creating {index}...")
+            logger.info("Creating %s...", index)
 
             # Create functions
             for create_fn in operations[1]:

--- a/api/howler/remote/datatypes/__init__.py
+++ b/api/howler/remote/datatypes/__init__.py
@@ -60,7 +60,7 @@ def retry_call(func, *args, **kw):
 
             return ret_val
         except (redis.ConnectionError, ConnectionResetError) as ce:
-            log.warning(f"No connection to Redis, reconnecting... [{ce}]")
+            log.warning("No connection to Redis, reconnecting... [%s]", ce)
             time.sleep(2**exponent)
             exponent = exponent + 1 if exponent < maximum else exponent
 

--- a/api/howler/security/__init__.py
+++ b/api/howler/security/__init__.py
@@ -186,7 +186,7 @@ class api_login(object):  # noqa: D101, N801
 
                 ip = request.headers.get("X-Forwarded-For", request.remote_addr)
                 if "pytest" not in sys.modules:
-                    logger.info(f"Logged in as {user['uname']} from {ip} for path {request.path}")
+                    logger.info("Logged in as %s from %s for path %s", user["uname"], ip, request.path)
 
                 # If auditing is enabled, write this successful access to the audit logs
                 if self.audit:
@@ -231,13 +231,13 @@ class api_login(object):  # noqa: D101, N801
                 quota = user.get("api_quota", 25)
                 if not QUOTA_TRACKER.begin(user["uname"], quota):
                     if config.ui.enforce_quota:
-                        logger.warning(f"{user['uname']} was prevented from using the api due to exceeded quota.")
+                        logger.warning("%s was prevented from using the api due to exceeded quota.", user["uname"])
                         FAILED_ATTEMPTS.labels("429").inc()
                         return too_many_requests(err=f"You've exceeded your maximum quota of {quota}")
                     else:
-                        logger.debug(f"Quota of {quota} exceeded for user {user['uname']}.")
+                        logger.debug("Quota of %s exceeded for user %s.", quota, user["uname"])
             else:
-                logger.debug(f"Quota not enforced for {user['uname']}")
+                logger.debug("Quota not enforced for %s", user["uname"])
 
             # Save user data in kwargs for future reference in the wrapped method
             kwargs["user"] = user

--- a/api/howler/security/socket.py
+++ b/api/howler/security/socket.py
@@ -51,7 +51,7 @@ def websocket_auth(required_type: Optional[list[str]] = None, required_priv: Opt
                     raise AuthenticationException()  # noqa: TRY301
 
                 if not set(required_priv) & set(privs):
-                    logger.warning(f"{ws_id}: Authentication header is invalid")
+                    logger.warning("%s: Authentication header is invalid", ws_id)
                     ws.close(
                         1008,
                         ws_response(
@@ -63,7 +63,7 @@ def websocket_auth(required_type: Optional[list[str]] = None, required_priv: Opt
                     )
                     return forbidden()
 
-                logger.info(f"{ws_id} authenticated as {user['uname']}")
+                logger.info("%s authenticated as %s", ws_id, user["uname"])
                 ws.send(
                     ws_response(
                         "info",
@@ -77,13 +77,13 @@ def websocket_auth(required_type: Optional[list[str]] = None, required_priv: Opt
 
                 f(ws, *args, ws_id=ws_id, username=user["uname"], privs=privs, **kwargs)
             except ConnectionClosed:
-                logger.info(f"{ws_id}: Client closed connection")
+                logger.info("%s: Client closed connection", ws_id)
             except (
                 AuthenticationException,
                 ValueError,
                 InvalidTokenError,
             ):
-                logger.warning(f"{ws_id}: Authentication header is invalid")
+                logger.warning("%s: Authentication header is invalid", ws_id)
                 if ws:
                     ws.close(
                         1008,

--- a/api/howler/services/event_service.py
+++ b/api/howler/services/event_service.py
@@ -54,7 +54,7 @@ def emit(event: str, data: Any):
         if event not in handlers:
             return
 
-        logger.debug(f"event:{event} - emitting data")
+        logger.debug("event:%s - emitting data", event)
 
         for handler in handlers[event]:
             handler(data)
@@ -72,7 +72,7 @@ def on(event: str, handler: Callable):
 
     handlers[event].append(handler)
 
-    logger.debug(f"event:{event} - added listener")
+    logger.debug("event:%s - added listener", event)
 
 
 def off(event: str, handler: Callable):
@@ -90,4 +90,4 @@ def off(event: str, handler: Callable):
 
     handlers[event] = [h for h in handlers[event] if h != handler]
 
-    logger.debug(f"event:{event} - removed listener")
+    logger.debug("event:%s - removed listener", event)


### PR DESCRIPTION
## Summary

Converts f-string interpolation in `logger` calls to the preferred `%s`-style (lazy/printf-style) string formatting across the backend API codebase.

## Motivation

Using f-strings in logger calls (e.g. `logger.warning(f"Value is {x}")`) eagerly formats the string even when the log message will never be emitted (e.g. because the log level is filtered out). The Python logging module supports lazy interpolation natively — passing arguments as positional parameters (e.g. `logger.warning("Value is %s", x)`) defers string formatting until the record is actually going to be handled. This is both more performant and the style recommended by the Python logging docs and most linters (e.g. `ruff` rule `G004`).

## Changes

- **`api/howler/datastore/collection.py`** — Converted all f-string logger calls to `%s`-style across retry logic, shard management, and index wait helpers.
- **`api/howler/api/v1/`** (`auth.py`, `clue.py`, `hit.py`, `tool.py`) — Same conversion for API endpoint logging.
- **`api/howler/cronjobs/`** (`retention.py`, `rules.py`, `view_cleanup.py`) — Converted cron job logger calls; `rules.py` also had minor structural clean-up.
- **`api/howler/services/event_service.py`** — Converted event service logger calls.
- **`api/howler/security/`** (`__init__.py`, `socket.py`) — Converted security module logger calls.
- **`api/howler/common/loader.py`**, **`api/howler/helper/discover.py`**, **`api/howler/odm/helper.py`**, **`api/howler/odm/random_data.py`**, **`api/howler/remote/datatypes/__init__.py`** — Converted logger calls in utility/ODM/remote modules.
- **`api/howler/datastore/migrations/fix_process.py`** — Converted logger calls in migration script.
- **`api/howler/app.py`** — Converted logger call in application setup.
- **`api/build_scripts/generate_classes.py`** — Converted logger calls and minor clean-up.

## Type of Change

- [x] Chore / refactor (no functional change, no new features, no bug fixes)

## Testing

No behavioural changes — all existing tests continue to apply. Formatting verified with `ruff`.
