### PR TITLE
fix(ui): fix offset error in table view

### DIFF
--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -1,5 +1,9 @@
 # Howler Releases
 
+## Howler UI `v2.17.3`
+
+- **Append-Results Null Crash Fix** *(bugfix)*: Fixed a crash (`can't access property "offset", q is null`) that occurred when a load-more (append) search response resolved after the component had remounted with a null response state (e.g., after a page refresh); the updater now falls back to replacing the response instead of merging into null.
+
 ## Howler UI `v2.17.2`
 
 - **Table Settings Persistence** *(new feature)*: Added persistence to table settings in grid view so display preferences are retained across sessions.

--- a/ui/package.json
+++ b/ui/package.json
@@ -166,5 +166,5 @@
     "test-ui": "vitest --ui --coverage"
   },
   "type": "module",
-  "version": "2.17.2"
+  "version": "2.17.3"
 }

--- a/ui/src/components/app/providers/HitSearchProvider.test.tsx
+++ b/ui/src/components/app/providers/HitSearchProvider.test.tsx
@@ -324,6 +324,37 @@ describe('HitSearchContext', () => {
       });
     });
 
+    it('should not crash when appendResults is true but response is null', async () => {
+      const mockResponse = {
+        items: [{ howler: { id: 'hit1' } }],
+        offset: 0,
+        rows: 1,
+        total: 10
+      };
+
+      vi.mocked(hpost).mockResolvedValueOnce(mockResponse as any);
+
+      const hook = renderHook(
+        () =>
+          useContextSelector(HitSearchContext, ctx => ({
+            search: ctx.search,
+            response: ctx.response
+          })),
+        { wrapper: Wrapper }
+      );
+
+      // response is null — call search with appendResults=true directly
+      act(() => {
+        hook.result.current.search('test query', true);
+      });
+
+      await waitFor(() => {
+        expect(hook.result.current.response).not.toBeNull();
+        expect(hook.result.current.response?.items).toHaveLength(1);
+        expect(hook.result.current.response?.items[0].howler.id).toBe('hit1');
+      });
+    });
+
     it('should include bundle filter when on bundles route', async () => {
       mockLocation.pathname = '/bundles/test_bundle_id';
       mockParams.mockReturnValue({ id: 'test_bundle_id' });

--- a/ui/src/components/app/providers/HitSearchProvider.tsx
+++ b/ui/src/components/app/providers/HitSearchProvider.tsx
@@ -186,12 +186,16 @@ const HitSearchProvider: FC<PropsWithChildren> = ({ children }) => {
           if (!appendResults) {
             setResponse(_response);
           } else {
-            setResponse(_existingResponse => ({
-              ..._response,
-              offset: _existingResponse.offset,
-              rows: Math.min(_existingResponse.rows + _response.rows, _response.total),
-              items: [..._existingResponse.items, ..._response.items]
-            }));
+            setResponse(_existingResponse =>
+              _existingResponse
+                ? {
+                    ..._response,
+                    offset: _existingResponse.offset,
+                    rows: Math.min(_existingResponse.rows + _response.rows, _response.total),
+                    items: [..._existingResponse.items, ..._response.items]
+                  }
+                : _response
+            );
           }
         } catch (e) {
           setError(e.message);


### PR DESCRIPTION
Resolved an error when searching in the table view.

---

This pull request addresses a critical bug in the Howler UI search functionality that could cause a crash when loading more results if the response state was unexpectedly null. The main fix ensures robust handling of this edge case, and a new test has been added to prevent regressions.

**Bugfixes:**

* Fixed a crash in the search results appending logic in `HitSearchProvider.tsx` by ensuring that if the response state is null, the updater now replaces the response instead of attempting to merge into a null value. This prevents errors like `can't access property "offset", q is null` after a component remount or page refresh.

**Testing Improvements:**

* Added a test to `HitSearchProvider.test.tsx` that verifies no crash occurs when `appendResults` is true but the response is null, ensuring the bug is covered and future regressions are caught.

**Documentation:**

* Documented the bugfix in `docs/RELEASES.md` under Howler UI `v2.17.3`, describing the resolved crash scenario and its context.