### PR TITLE
feat(ui): Open links in a new tab; Add Clickable Source Alert Link on Hitcard

### DIFF
--- a/ui/src/components/elements/hit/HitBanner.tsx
+++ b/ui/src/components/elements/hit/HitBanner.tsx
@@ -1,8 +1,10 @@
+import { OpenInNew } from '@mui/icons-material';
 import {
   Box,
   Chip,
   Divider,
   Grid,
+  IconButton,
   Stack,
   Tooltip,
   Typography,
@@ -235,9 +237,8 @@ const HitBanner: FC<HitBannerProps> = ({ hit, layout = HitLayout.NORMAL, showAss
           {analyticId ? (
             <Link
               to={`/analytics/${analyticId}`}
-              onAuxClick={e => {
-                e.stopPropagation();
-              }}
+              target="_blank"
+              rel="noopener noreferrer"
               onClick={e => {
                 e.stopPropagation();
               }}
@@ -248,7 +249,14 @@ const HitBanner: FC<HitBannerProps> = ({ hit, layout = HitLayout.NORMAL, showAss
             hit.howler.analytic
           )}
           {hit.howler.detection && ': '}
-          {hit.howler.detection}
+          <Link
+            to={`/hits/${hit.howler.id}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={e => e.stopPropagation()}
+          >
+            {hit.howler.detection}
+          </Link>
         </Typography>
         {hit.howler?.rationale && (
           <Typography
@@ -342,6 +350,19 @@ const HitBanner: FC<HitBannerProps> = ({ hit, layout = HitLayout.NORMAL, showAss
       >
         <HitTimestamp hit={hit} layout={layout} />
         {showAssigned && <Assigned hit={hit} layout={layout} />}
+        {hit.howler.links?.[0]?.href && (
+          <Tooltip title={hit.howler.links[0].title || 'Open in source platform'}>
+            <IconButton
+              size="small"
+              onClick={e => {
+                e.stopPropagation();
+                window.open(hit.howler.links[0].href, '_blank');
+              }}
+            >
+              <OpenInNew />
+            </IconButton>
+          </Tooltip>
+        )}
         <Stack direction="row" spacing={layout !== HitLayout.COMFY ? 0.5 : 1}>
           <EscalationChip hit={hit} layout={layout} />
           {['in-progress', 'on-hold'].includes(hit.howler.status) && (

--- a/ui/src/components/elements/hit/HitBanner.tsx
+++ b/ui/src/components/elements/hit/HitBanner.tsx
@@ -4,7 +4,6 @@ import {
   Chip,
   Divider,
   Grid,
-  IconButton,
   Stack,
   Tooltip,
   Typography,
@@ -248,19 +247,8 @@ const HitBanner: FC<HitBannerProps> = ({ hit, layout = HitLayout.NORMAL, showAss
           ) : (
             hit.howler.analytic
           )}
-          {hit.howler.detection && (
-            <>
-              {': '}
-              <Link
-                to={`/hits/${hit.howler.id}`}
-                target="_blank"
-                rel="noopener noreferrer"
-                onClick={e => e.stopPropagation()}
-              >
-                {hit.howler.detection}
-              </Link>
-            </>
-          )}
+          {hit.howler.detection && ': '}
+          {hit.howler.detection}
         </Typography>
         {hit.howler?.rationale && (
           <Typography
@@ -355,18 +343,15 @@ const HitBanner: FC<HitBannerProps> = ({ hit, layout = HitLayout.NORMAL, showAss
         <HitTimestamp hit={hit} layout={layout} />
         {showAssigned && <Assigned hit={hit} layout={layout} />}
         {hit.howler.links?.[0]?.href && (
-          <Tooltip title={hit.howler.links[0].title || 'Open in source platform'}>
-            <IconButton
-              size="small"
-              aria-label={hit.howler.links[0].title || 'Open in source platform'}
-              onClick={e => {
-                e.stopPropagation();
-                window.open(hit.howler.links[0].href, '_blank', 'noopener,noreferrer');
-              }}
-            >
-              <OpenInNew />
-            </IconButton>
-          </Tooltip>
+          <Chip
+            icon={<OpenInNew />}
+            label={hit.howler.links[0].title || 'Open in source platform'}
+            size={layout !== HitLayout.COMFY ? 'small' : 'medium'}
+            onClick={e => {
+              e.stopPropagation();
+              window.open(hit.howler.links[0].href, '_blank', 'noopener,noreferrer');
+            }}
+          />
         )}
         <Stack direction="row" spacing={layout !== HitLayout.COMFY ? 0.5 : 1}>
           <EscalationChip hit={hit} layout={layout} />

--- a/ui/src/components/elements/hit/HitBanner.tsx
+++ b/ui/src/components/elements/hit/HitBanner.tsx
@@ -8,6 +8,7 @@ import {
   Tooltip,
   Typography,
   avatarClasses,
+  chipClasses,
   iconButtonClasses,
   useTheme,
   type TypographyProps
@@ -208,7 +209,10 @@ const HitBanner: FC<HitBannerProps> = ({ hit, layout = HitLayout.NORMAL, showAss
       display="grid"
       gridTemplateColumns="minmax(0, auto) minmax(0, 1fr) minmax(0, auto)"
       alignItems="stretch"
-      sx={{ width: '100%', ml: 0, overflow: 'hidden' }}
+      sx={{ width: '100%', ml: 0, overflow: 'hidden', textDecoration: 'none', color: 'text.primary' }}
+      component="a"
+      href={`/hits/${hit?.howler.id}`}
+      onClick={e => e.preventDefault()}
     >
       {leftBox}
       <Stack
@@ -345,11 +349,15 @@ const HitBanner: FC<HitBannerProps> = ({ hit, layout = HitLayout.NORMAL, showAss
         {hit.howler.links?.[0]?.href && (
           <Chip
             icon={<OpenInNew />}
-            label={hit.howler.links[0].title || 'Open in source platform'}
+            label={hit.howler.links[0].title || t('hit.header.link')}
             size={layout !== HitLayout.COMFY ? 'small' : 'medium'}
+            component="a"
+            href={hit.howler.links[0].href}
+            target="_blank"
+            rel="noopener noreferrer"
+            sx={{ [`.${chipClasses.label}`]: { cursor: 'pointer !important' } }}
             onClick={e => {
               e.stopPropagation();
-              window.open(hit.howler.links[0].href, '_blank', 'noopener,noreferrer');
             }}
           />
         )}

--- a/ui/src/components/elements/hit/HitBanner.tsx
+++ b/ui/src/components/elements/hit/HitBanner.tsx
@@ -248,15 +248,19 @@ const HitBanner: FC<HitBannerProps> = ({ hit, layout = HitLayout.NORMAL, showAss
           ) : (
             hit.howler.analytic
           )}
-          {hit.howler.detection && ': '}
-          <Link
-            to={`/hits/${hit.howler.id}`}
-            target="_blank"
-            rel="noopener noreferrer"
-            onClick={e => e.stopPropagation()}
-          >
-            {hit.howler.detection}
-          </Link>
+          {hit.howler.detection && (
+            <>
+              {': '}
+              <Link
+                to={`/hits/${hit.howler.id}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={e => e.stopPropagation()}
+              >
+                {hit.howler.detection}
+              </Link>
+            </>
+          )}
         </Typography>
         {hit.howler?.rationale && (
           <Typography
@@ -354,9 +358,10 @@ const HitBanner: FC<HitBannerProps> = ({ hit, layout = HitLayout.NORMAL, showAss
           <Tooltip title={hit.howler.links[0].title || 'Open in source platform'}>
             <IconButton
               size="small"
+              aria-label={hit.howler.links[0].title || 'Open in source platform'}
               onClick={e => {
                 e.stopPropagation();
-                window.open(hit.howler.links[0].href, '_blank');
+                window.open(hit.howler.links[0].href, '_blank', 'noopener,noreferrer');
               }}
             >
               <OpenInNew />

--- a/ui/src/locales/en/translation.json
+++ b/ui/src/locales/en/translation.json
@@ -165,6 +165,7 @@
   "hit.header.bundlesize": "{{hits}} hits",
   "hit.header.escalation": "Escalation Level: ",
   "hit.header.indicators": "Indicators",
+  "hit.header.link": "Open Link",
   "hit.header.rationale": "Rationale",
   "hit.header.scrutiny": "Scrutiny: ",
   "hit.header.status": "Status: ",

--- a/ui/src/locales/fr/translation.json
+++ b/ui/src/locales/fr/translation.json
@@ -167,6 +167,7 @@
   "hit.header.bundlesize": "{{hits}} hits",
   "hit.header.escalation": "Niveau d'escalade: ",
   "hit.header.indicators": "Indicateurs",
+  "hit.header.link": "Ouvrir lien",
   "hit.header.rationale": "Justification",
   "hit.header.scrutiny": "Examen minutieux: ",
   "hit.header.status": "Statut: ",


### PR DESCRIPTION
The changes focus on making links open in new tabs and adding an icon button for accessing external resources.

* Changed the analytic link and detection text to open in a new browser tab, using `target="_blank"` and `rel="noopener noreferrer"` for security and usability.
* Added a chip that opens the link in a new tab without triggering parent click handlers. 