### PR TITLE
feat: ODM inheritance and plugin support

### DIFF
--- a/api/howler/odm/base.py
+++ b/api/howler/odm/base.py
@@ -1212,7 +1212,7 @@ class Model:
         include_autogen_note=True,
         defaults=None,
         url_prefix="/howler/odm/class/",
-    ) -> dict | str:
+    ) -> str:
         markdown_content = (
             (
                 '??? success "Auto-Generated Documentation"\n    '

--- a/api/howler/odm/base.py
+++ b/api/howler/odm/base.py
@@ -1081,10 +1081,10 @@ class Model:
         Args:
             skip_mappings (bool): Skip over mappings where the real subfield names are unknown.
         """
-        if skip_mappings and "_odm_field_cache_skip" in cls.__dict__:
+        if not no_cache and skip_mappings and "_odm_field_cache_skip" in cls.__dict__:
             return cls._odm_field_cache_skip
 
-        if not skip_mappings and "_odm_field_cache" in cls.__dict__:
+        if not no_cache and not skip_mappings and "_odm_field_cache" in cls.__dict__:
             return cls._odm_field_cache
 
         out = dict()
@@ -1524,12 +1524,23 @@ def model(index=None, store=None, description=None, id_field=None):
 
     def _finish_model(cls):
         cls._Model__description = description
-        cls._Model__id_field = id_field
+        fields = cls.fields()
 
-        if cls._Model__id_field is None:
+        if id_field is None:
             cls._Model__id_field = f"{cls.__name__.lower()}_id"
+        else:
+            if not isinstance(id_field, str):
+                raise HowlerTypeError(f"id_field must be a str, got {type(id_field).__name__}")
 
-        for name, field_data in cls.fields().items():
+            if not FIELD_SANITIZER.match(id_field) or id_field in BANNED_FIELDS:
+                raise HowlerValueError(f"Illegal id_field name: {id_field}")
+
+            if id_field not in fields:
+                raise HowlerValueError(f"id_field must reference a declared field: {id_field}")
+
+            cls._Model__id_field = id_field
+
+        for name, field_data in fields.items():
             if not FIELD_SANITIZER.match(name) or name in BANNED_FIELDS:
                 raise HowlerValueError(f"Illegal variable name: {name}")
 

--- a/api/howler/odm/base.py
+++ b/api/howler/odm/base.py
@@ -19,7 +19,7 @@ from datetime import datetime
 from enum import Enum as PyEnum
 from enum import EnumMeta
 from typing import Any as _Any
-from typing import Dict, Union
+from typing import Callable
 from venv import logger
 
 import arrow
@@ -29,6 +29,8 @@ from dateutil.tz import tzutc
 from howler.common import loader
 from howler.common.exceptions import HowlerKeyError, HowlerNotImplementedError, HowlerTypeError, HowlerValueError
 from howler.common.net import is_valid_domain, is_valid_ip
+from howler.odm.howler_enum import HowlerEnum
+from howler.utils.compat import StrEnum as PyStrEnum
 from howler.utils.dict_utils import flatten, recursive_update
 from howler.utils.isotime import now_as_iso
 from howler.utils.uid import get_random_id
@@ -549,15 +551,23 @@ class Processor(ValidatedKeyword):
 
 
 class Enum(Keyword):
-    """A field storing a short string that has predefined list of possible values"""
+    """A field storing a short string that has predefined list of possible values.
 
-    def __init__(self, values: PyEnum | list[typing.Any] | set[typing.Any], *args, **kwargs):
+    Accepts values from lists/sets, Enum classes, and StrEnum (PyStrEnum) members.
+    """
+
+    def __init__(
+        self,
+        values: type[HowlerEnum] | type[PyEnum] | type[PyStrEnum] | list[typing.Any] | set[typing.Any],
+        *args,
+        **kwargs,
+    ):
         super().__init__(*args, **kwargs)
         if isinstance(values, set):
             self.values = values
         elif isinstance(values, (list, tuple)):
             self.values = set(values)
-        elif isinstance(values, (PyEnum, EnumMeta)):
+        elif isinstance(values, (PyEnum, PyStrEnum, EnumMeta)):
             self.values = set([e.value for e in values])  # type: ignore
         else:
             raise HowlerTypeError(f"Type unsupported for Enum odm: {type(values)}")
@@ -1063,7 +1073,7 @@ class Optional(_Field):
 
 class Model:
     @classmethod
-    def fields(cls, skip_mappings=False) -> dict[str, _Field]:
+    def fields(cls, skip_mappings=False, no_cache=False) -> dict[str, _Field]:
         """Describe the elements of the model.
 
         For compound fields return the field object.
@@ -1071,33 +1081,42 @@ class Model:
         Args:
             skip_mappings (bool): Skip over mappings where the real subfield names are unknown.
         """
-        if skip_mappings and hasattr(cls, "_odm_field_cache_skip"):
+        if skip_mappings and "_odm_field_cache_skip" in cls.__dict__:
             return cls._odm_field_cache_skip
 
-        if not skip_mappings and hasattr(cls, "_odm_field_cache"):
+        if not skip_mappings and "_odm_field_cache" in cls.__dict__:
             return cls._odm_field_cache
 
         out = dict()
+        # Iterate through inherited classes. If any of them are odm.Model (e.g., they expose fields())
+        # then include their fields as well. This allows for class inheritance.
+        for base in cls.__bases__:
+            _fields: Callable[..., dict[str, _Field]] | None = getattr(base, "fields", None)
+            if _fields and callable(_fields):
+                out.update(_fields(skip_mappings=skip_mappings, no_cache=True))
+
         for name, field_data in cls.__dict__.items():
             if isinstance(field_data, _Field):
                 if skip_mappings and isinstance(field_data, Mapping):
                     continue
                 out[name.rstrip("_")] = field_data
 
-        if skip_mappings:
-            cls._odm_field_cache_skip = out
-        else:
-            cls._odm_field_cache = out
+        if not no_cache:
+            if skip_mappings:
+                cls._odm_field_cache_skip = out
+            else:
+                cls._odm_field_cache = out
+
         return out
 
     @classmethod
     def add_namespace(cls, namespace: str, field: _Field, index=None, store=None, description=None):
         recursive_set_name(field, namespace)
 
-        if hasattr(cls, "_odm_field_cache_skip"):
+        if "_odm_field_cache_skip" in cls.__dict__:
             cls._odm_field_cache_skip[namespace.rstrip("_")] = field
 
-        if hasattr(cls, "_odm_field_cache"):
+        if "_odm_field_cache" in cls.__dict__:
             cls._odm_field_cache[namespace.rstrip("_")] = field
 
         setattr(cls, namespace, field)
@@ -1112,10 +1131,10 @@ class Model:
 
     @classmethod
     def remove_namespace(cls, namespace: str):
-        if hasattr(cls, "_odm_field_cache_skip"):
+        if "_odm_field_cache_skip" in cls.__dict__:
             del cls._odm_field_cache_skip[namespace.rstrip("_")]
 
-        if hasattr(cls, "_odm_field_cache"):
+        if "_odm_field_cache" in cls.__dict__:
             del cls._odm_field_cache[namespace.rstrip("_")]
 
         delattr(cls, namespace)
@@ -1147,8 +1166,11 @@ class Model:
             else:
                 out[name] = sub_field
 
-        if isinstance(field, Compound) and show_compound:
-            out[name] = field
+        if show_compound:
+            if isinstance(field, Compound):
+                out[name] = field
+            elif isinstance(field, List) and isinstance(field.child_type, Compound):
+                out[name] = field.child_type
 
         return out
 
@@ -1163,6 +1185,11 @@ class Model:
             skip_mappings (bool): Skip over mappings where the real subfield names are unknown.
         """
         out = dict()
+        for base in cls.__bases__:
+            _flat_fields: Callable[..., dict[str, _Field]] | None = getattr(base, "flat_fields", None)
+            if _flat_fields and callable(_flat_fields):
+                out.update(_flat_fields(show_compound=show_compound, skip_mappings=skip_mappings))
+
         for name, field in cls.__dict__.items():
             if isinstance(field, _Field):
                 if skip_mappings and isinstance(field, Mapping):
@@ -1185,7 +1212,7 @@ class Model:
         include_autogen_note=True,
         defaults=None,
         url_prefix="/howler/odm/class/",
-    ) -> Union[str, Dict]:
+    ) -> dict | str:
         markdown_content = (
             (
                 '??? success "Auto-Generated Documentation"\n    '
@@ -1476,11 +1503,32 @@ def recursive_set_name(field, name, to_parent=False):
         recursive_set_name(field.child_type, name, to_parent=True)
 
 
-def model(index=None, store=None, description=None):
-    """Decorator to create model objects."""
+def model(index=None, store=None, description=None, id_field=None):
+    """Decorator that finalizes a Model subclass for use with the datastore.
+    Assigns metadata to the class (description, id field), validates that all
+    declared field names are legal, recursively sets each field's name, and
+    applies default index/store settings to every field.
+    If ``id_field`` is not provided, it defaults to ``<classname_lower>_id``.
+    Args:
+        index: Default index setting applied to all fields on the model.
+        store: Default store setting applied to all fields on the model.
+        description: Human-readable description of the model.
+        id_field: Name of the field used as the primary key. Defaults to
+            ``<classname_lower>_id`` when not specified.
+    Returns:
+        A class decorator that configures and returns the decorated Model subclass.
+    Raises:
+        HowlerValueError: If any field name fails the ``FIELD_SANITIZER`` regex
+            or appears in ``BANNED_FIELDS``.
+    """
 
     def _finish_model(cls):
         cls._Model__description = description
+        cls._Model__id_field = id_field
+
+        if cls._Model__id_field is None:
+            cls._Model__id_field = f"{cls.__name__.lower()}_id"
+
         for name, field_data in cls.fields().items():
             if not FIELD_SANITIZER.match(name) or name in BANNED_FIELDS:
                 raise HowlerValueError(f"Illegal variable name: {name}")

--- a/api/howler/utils/compat.py
+++ b/api/howler/utils/compat.py
@@ -1,0 +1,21 @@
+"""Compatibility shims for symbols added in Python 3.11.
+
+Import from this module instead of using `if sys.version_info` guards inline.
+"""
+
+import sys
+
+if sys.version_info >= (3, 11):
+    from enum import StrEnum
+    from typing import NotRequired, TypedDict
+else:
+    from enum import Enum as _Enum
+
+    class StrEnum(str, _Enum):  # type: ignore[no-redef]
+        """str + Enum backport for Python < 3.11."""
+
+    # typing_extensions.TypedDict supports Generic[T] mixing on Python < 3.11;
+    # the stdlib version does not gain that until 3.11.
+    from typing_extensions import NotRequired, TypedDict  # noqa: F401
+
+__all__ = ["NotRequired", "StrEnum", "TypedDict"]

--- a/api/howler/utils/compat.py
+++ b/api/howler/utils/compat.py
@@ -19,6 +19,7 @@ else:
 
         def __format__(self, format_spec: str) -> str:
             return str.__format__(self, format_spec)
+
     # typing_extensions.TypedDict supports Generic[T] mixing on Python < 3.11;
     # the stdlib version does not gain that until 3.11.
     from typing_extensions import NotRequired, TypedDict  # noqa: F401

--- a/api/howler/utils/compat.py
+++ b/api/howler/utils/compat.py
@@ -14,6 +14,11 @@ else:
     class StrEnum(str, _Enum):  # type: ignore[no-redef]
         """str + Enum backport for Python < 3.11."""
 
+        def __str__(self) -> str:
+            return str.__str__(self)
+
+        def __format__(self, format_spec: str) -> str:
+            return str.__format__(self, format_spec)
     # typing_extensions.TypedDict supports Generic[T] mixing on Python < 3.11;
     # the stdlib version does not gain that until 3.11.
     from typing_extensions import NotRequired, TypedDict  # noqa: F401

--- a/api/test/unit/test_odm.py
+++ b/api/test/unit/test_odm.py
@@ -4,7 +4,7 @@ import os
 import pytest
 
 from howler.common.classification import InvalidClassification
-from howler.common.exceptions import HowlerException
+from howler.common.exceptions import HowlerException, HowlerTypeError
 from howler.odm import (
     UUID,
     Classification,
@@ -948,10 +948,11 @@ def test_model_id_field_default():
 
 
 def test_model_id_field_explicit():
-    """An explicit id_field value should be stored verbatim."""
+    """An explicit id_field value should be stored verbatim when it references a declared field."""
 
     @model(id_field="custom_id")
     class MyRecord(Model):
+        custom_id = Keyword()
         name = Keyword()
 
     assert MyRecord._Model__id_field == "custom_id"
@@ -972,13 +973,14 @@ def test_model_id_field_stored_on_class():
 
     @model(id_field="doc_id")
     class Document(Model):
+        doc_id = Keyword()
         body = Keyword()
 
     # Accessible on the class directly
     assert Document._Model__id_field == "doc_id"
 
     # Also consistent across instances (class attribute, not instance attribute)
-    instance = Document({"body": "hello"})
+    instance = Document({"doc_id": "abc", "body": "hello"})
     assert type(instance)._Model__id_field == "doc_id"
 
 
@@ -987,10 +989,12 @@ def test_model_id_field_independent_per_class():
 
     @model(id_field="alpha_key")
     class Alpha(Model):
+        alpha_key = Keyword()
         x = Keyword()
 
     @model(id_field="beta_key")
     class Beta(Model):
+        beta_key = Keyword()
         y = Keyword()
 
     @model()
@@ -1000,3 +1004,115 @@ def test_model_id_field_independent_per_class():
     assert Alpha._Model__id_field == "alpha_key"
     assert Beta._Model__id_field == "beta_key"
     assert Gamma._Model__id_field == "gamma_id"
+
+
+def test_model_id_field_not_a_string_raises():
+    """Passing a non-string id_field should raise HowlerTypeError."""
+
+    with pytest.raises(HowlerTypeError):
+
+        @model(id_field=123)
+        class BadType(Model):
+            value = Keyword()
+
+
+def test_model_id_field_illegal_name_raises():
+    """An id_field whose name fails FIELD_SANITIZER or is in BANNED_FIELDS should raise HowlerValueError."""
+
+    # Uppercase letters are not allowed by FIELD_SANITIZER (^[a-z][a-z0-9_-]*$)
+    with pytest.raises(ValueError):
+
+        @model(id_field="BadField")
+        class IllegalName(Model):
+            value = Keyword()
+
+    # _id is in BANNED_FIELDS
+    with pytest.raises(ValueError):
+
+        @model(id_field="_id")
+        class BannedName(Model):
+            value = Keyword()
+
+
+def test_model_id_field_not_in_fields_raises():
+    """An id_field that does not reference a declared field should raise HowlerValueError."""
+
+    with pytest.raises(ValueError):
+
+        @model(id_field="missing_field")
+        class MissingField(Model):
+            value = Keyword()
+
+    """Base model fields should be included in subclass fields()."""
+
+    @model(index=True, store=True, description="Base model")
+    class Base(Model):
+        base_field = Keyword()
+
+    @model(index=True, store=True, description="Child model")
+    class Child(Base):
+        child_field = Keyword()
+
+    fields = Child.fields()
+    assert "base_field" in fields, "base_field from Base should appear in Child.fields()"
+    assert "child_field" in fields, "child_field should appear in Child.fields()"
+
+
+def test_model_inheritance_subclass_overrides_base_field():
+    """A subclass that redeclares a field from the base should use the subclass version."""
+
+    @model(index=True, store=True, description="Base model")
+    class OverrideBase(Model):
+        shared_field = Keyword(default="base_default")
+
+    @model(index=True, store=True, description="Override child model")
+    class OverrideChild(OverrideBase):
+        shared_field = Keyword(default="child_default")
+
+    fields = OverrideChild.fields()
+    assert "shared_field" in fields
+    assert fields["shared_field"].default == "child_default", (
+        "Child's override of shared_field should shadow the base's version"
+    )
+
+
+def test_model_inheritance_cache_isolation():
+    """Subclass field cache must not bleed into or reuse the parent's cache."""
+
+    @model(index=True, store=True, description="Parent")
+    class ParentModel(Model):
+        parent_only = Keyword()
+
+    @model(index=True, store=True, description="Sub")
+    class SubModel(ParentModel):
+        sub_only = Keyword()
+
+    parent_fields = ParentModel.fields()
+    sub_fields = SubModel.fields()
+
+    # Parent cache should NOT contain the child-only field
+    assert "sub_only" not in parent_fields, "Parent cache should not include subclass fields"
+    # Child cache should contain both
+    assert "parent_only" in sub_fields
+    assert "sub_only" in sub_fields
+    # The two caches must be different objects
+    assert parent_fields is not sub_fields, "Parent and child field caches must be independent objects"
+
+
+def test_model_inheritance_no_cache_skips_cache():
+    """fields(no_cache=True) should bypass and not populate the field cache."""
+
+    @model(index=True, store=True, description="NoCacheTest")
+    class NoCacheModel(Model):
+        val = Keyword()
+
+    # Populate cache normally
+    _ = NoCacheModel.fields()
+    assert "_odm_field_cache" in NoCacheModel.__dict__
+
+    # Call with no_cache=True — result should be equivalent but cache unchanged
+    result = NoCacheModel.fields(no_cache=True)
+    assert "val" in result
+    # Cache object should not have been replaced by the no_cache call
+    cached = NoCacheModel.fields()
+    assert cached is not result, "no_cache=True result should be a fresh dict, not the stored cache"

--- a/api/test/unit/test_odm.py
+++ b/api/test/unit/test_odm.py
@@ -835,3 +835,168 @@ def test_domain():
 
     with pytest.raises(HowlerException):
         Test({"domain": "foo", "strict_domain": "foo"})
+
+
+def test_flat_fields_show_compound_list_of_compound():
+    """flat_fields(show_compound=True) should include the compound child type for List[Compound] fields."""
+
+    @model()
+    class Inner(Model):
+        name = Keyword()
+        value = Integer()
+
+    @model()
+    class Outer(Model):
+        items = List(Compound(Inner))
+        label = Keyword()
+
+    flat = Outer.flat_fields(show_compound=True)
+
+    # The list field key should appear and map to the Inner compound child type
+    assert "items" in flat
+    items_field = flat["items"]
+    assert isinstance(items_field, Compound)
+    assert items_field.child_type is Inner
+
+    # Scalar field should still be present
+    assert "label" in flat
+
+    # Sub-fields of Inner should also be present
+    assert "items.name" in flat
+    assert "items.value" in flat
+
+
+def test_flat_fields_show_compound_false_excludes_list_compound_key():
+    """flat_fields(show_compound=False) should NOT add the top-level key for List[Compound] fields."""
+
+    @model()
+    class Inner(Model):
+        name = Keyword()
+
+    @model()
+    class Outer(Model):
+        items = List(Compound(Inner))
+
+    flat_without = Outer.flat_fields(show_compound=False)
+    flat_with = Outer.flat_fields(show_compound=True)
+
+    # With show_compound=False the 'items' key should not appear (only sub-fields)
+    assert "items" not in flat_without
+    assert "items.name" in flat_without
+
+    # With show_compound=True it should appear
+    assert "items" in flat_with
+
+
+def test_flat_fields_show_compound_list_compound_type_is_child():
+    """The value stored under the list key must be the Compound child type (not the List wrapper)."""
+
+    @model()
+    class Tag(Model):
+        key = Keyword()
+        count = Integer()
+
+    @model()
+    class Doc(Model):
+        tags = List(Compound(Tag))
+
+    flat = Doc.flat_fields(show_compound=True)
+
+    assert "tags" in flat
+    # Should be the Compound child type (Tag), not a List or Compound wrapper
+    tags_field = flat["tags"]
+    assert isinstance(tags_field, Compound)
+    assert tags_field.child_type is Tag
+
+
+def test_flat_fields_show_compound_nested_list_compound():
+    """Multiple List[Compound] fields are all included correctly."""
+
+    @model()
+    class Alpha(Model):
+        x = Keyword()
+
+    @model()
+    class Beta(Model):
+        y = Integer()
+
+    @model()
+    class Container(Model):
+        alphas = List(Compound(Alpha))
+        betas = List(Compound(Beta))
+
+    flat = Container.flat_fields(show_compound=True)
+
+    assert "alphas" in flat
+    alphas_field = flat["alphas"]
+    assert isinstance(alphas_field, Compound)
+    assert alphas_field.child_type is Alpha
+    assert "betas" in flat
+    betas_field = flat["betas"]
+    assert isinstance(betas_field, Compound)
+    assert betas_field.child_type is Beta
+
+
+def test_model_id_field_default():
+    """When id_field is not specified, it should default to '<classname_lower>_id'."""
+
+    @model()
+    class MyDocument(Model):
+        title = Keyword()
+
+    assert MyDocument._Model__id_field == "mydocument_id"
+
+
+def test_model_id_field_explicit():
+    """An explicit id_field value should be stored verbatim."""
+
+    @model(id_field="custom_id")
+    class MyRecord(Model):
+        name = Keyword()
+
+    assert MyRecord._Model__id_field == "custom_id"
+
+
+def test_model_id_field_none_uses_default():
+    """Passing id_field=None explicitly should also produce the default '<classname_lower>_id'."""
+
+    @model(id_field=None)
+    class SomeModel(Model):
+        value = Integer()
+
+    assert SomeModel._Model__id_field == "somemodel_id"
+
+
+def test_model_id_field_stored_on_class():
+    """The id_field should be accessible via cls._Model__id_field (not instance-level)."""
+
+    @model(id_field="doc_id")
+    class Document(Model):
+        body = Keyword()
+
+    # Accessible on the class directly
+    assert Document._Model__id_field == "doc_id"
+
+    # Also consistent across instances (class attribute, not instance attribute)
+    instance = Document({"body": "hello"})
+    assert type(instance)._Model__id_field == "doc_id"
+
+
+def test_model_id_field_independent_per_class():
+    """Each model class should store its own id_field independently."""
+
+    @model(id_field="alpha_key")
+    class Alpha(Model):
+        x = Keyword()
+
+    @model(id_field="beta_key")
+    class Beta(Model):
+        y = Keyword()
+
+    @model()
+    class Gamma(Model):
+        z = Keyword()
+
+    assert Alpha._Model__id_field == "alpha_key"
+    assert Beta._Model__id_field == "beta_key"
+    assert Gamma._Model__id_field == "gamma_id"


### PR DESCRIPTION
## ODM Improvements: Inheritance Support, `id_field`, and Python 3.11 Compatibility Shims

### Summary

This PR extends the Howler ODM (`api/howler/odm/base.py`) with several improvements that unlock better plugin authoring patterns and clean up some existing rough edges. A small compatibility shim module is also added to support Python < 3.11 environments.

99% of this PR is Matts code, I have just commandeered it to solve an issue with ODM model inheritance from a plugin.  

The "Cache correctness fix" is the code I added to assist in inherited models in a plugin.

The `id_field` support was left in for preparation for use with DatastoreMixin class that will be introduced in Cases.

---

### Changes

#### `api/howler/odm/base.py`

- **Model inheritance support** — `fields()` and `flat_fields()` now walk `cls.__bases__` and merge fields from parent `Model` subclasses. This allows ODM models to be composed via standard Python class inheritance, which is particularly useful for plugin authors who want to extend a base model without duplicating field declarations.
- **Cache correctness fix** — Field cache lookups now use `cls.__dict__` instead of `hasattr()`, preventing a subclass from incorrectly reading a parent's cached result and then caching it as its own. The `no_cache` parameter on `fields()` now also guards the **read** path (not just the write path), so `fields(no_cache=True)` consistently returns a freshly-built dict even when a cache already exists.
- **`id_field` support on `@model`** — The `@model` decorator now accepts an optional `id_field` argument with full validation: raises `HowlerTypeError` if the value is not a `str`; raises `HowlerValueError` if the name fails `FIELD_SANITIZER`, appears in `BANNED_FIELDS`, or does not reference a field declared on the model. Each model class stores `_Model__id_field`, which defaults to `<classname_lower>_id` when not specified.
- **`Enum` field accepts `StrEnum`** — `Enum.__init__` now accepts `StrEnum` (and `HowlerEnum`) in addition to plain `PyEnum` / `EnumMeta`, so enum fields can be backed by string-enum classes directly.
- **`flat_fields(show_compound=True)` includes `List[Compound]`** — When `show_compound=True`, a `List(Compound(T))` field now emits its top-level key mapped to the inner `Compound` child type, consistent with how bare `Compound` fields are handled.
- **Minor cleanup** — Replaced legacy `Union[str, Dict]` annotation with the modern `dict | str` form; removed unused `Dict`/`Union` imports.
#### `api/howler/utils/compat.py` *(new)*
Centralises Python 3.11 compatibility shims (`StrEnum`, `NotRequired`, `TypedDict`) so the rest of the codebase can import them unconditionally without scattered `sys.version_info` guards.
#### `api/test/unit/test_odm.py`
- Tests for `flat_fields(show_compound=True/False)` behaviour with `List[Compound]` fields.
- Tests for `@model(id_field=...)` — default derivation, explicit value, `None` fallback, class-vs-instance scope, and per-class independence.
- **New `id_field` validation tests** — `test_model_id_field_not_a_string_raises`, `test_model_id_field_illegal_name_raises`, and `test_model_id_field_not_in_fields_raises` cover the three new error paths added to `_finish_model`.
- **Updated `id_field` tests** — four existing tests that passed an `id_field` not present in the model's declared fields were corrected to include the referenced field, bringing them in line with the new validation.
- **New inheritance tests** — `test_model_inheritance_fields_included`, `test_model_inheritance_subclass_overrides_base_field`, `test_model_inheritance_cache_isolation`, and `test_model_inheritance_no_cache_skips_cache` provide focused regression coverage for the inheritance traversal and cache isolation behaviour.
---
### Motivation
Plugin authors frequently want to define a base ODM model in a shared library and extend it in a plugin. The previous implementation silently dropped inherited fields or returned incorrect cached results for subclasses. The inheritance fix, combined with the `id_field` decorator argument, makes this pattern fully supported and predictable.