### PR TITLE
feat(api): add cronjob to remove analytics with no matching hits

### DIFF
--- a/api/howler/cronjobs/retention.py
+++ b/api/howler/cronjobs/retention.py
@@ -40,7 +40,23 @@ def _remove_analytics_without_hits(ds: HowlerDatastore):
     matched_analytics = _find_analytics_with_hits(ds)
 
     if matched_analytics is not None:
-        ds.analytic.delete_by_search_object({"bool": {"must_not": [{"terms": {"name": matched_analytics}}]}})
+        ds.analytic.delete_by_search_object(
+            {
+                "bool": {
+                    "filter": [
+                        {
+                            "bool": {
+                                "must_not": [
+                                    {"exists": {"field": "rule"}},
+                                    {"exists": {"field": "rule_type"}},
+                                ]
+                            }
+                        }
+                    ],
+                    "must_not": [{"terms": {"name": matched_analytics}}],
+                }
+            }
+        )
         ds.analytic.commit()
     else:
         logger.warning("No matched analytics aggregation result. Skipping cleanup.")

--- a/api/howler/cronjobs/retention.py
+++ b/api/howler/cronjobs/retention.py
@@ -50,7 +50,7 @@ def _find_analytics_with_hits(ds: HowlerDatastore) -> list[str]:
     if total_analytics:
         matched_analytics = ds.hit.search(
             "howler.id:*",
-            aggs=[
+            aggregations=[
                 (
                     "matched_analytics",
                     {

--- a/api/howler/cronjobs/retention.py
+++ b/api/howler/cronjobs/retention.py
@@ -64,7 +64,7 @@ def _find_analytics_with_hits(ds: HowlerDatastore) -> list[str]:
         )
 
         matched_analytic_names = [
-            bucket["key"] for bucket in matched_analytics["agg_result"]["matched_analytics"]["buckets"]
+            bucket["key"] for bucket in matched_analytics["aggregations"]["matched_analytics"]["buckets"]
         ]
 
     else:

--- a/api/howler/cronjobs/retention.py
+++ b/api/howler/cronjobs/retention.py
@@ -39,11 +39,14 @@ def _remove_analytics_without_hits(ds: HowlerDatastore):
 
     matched_analytics = _find_analytics_with_hits(ds)
 
-    ds.analytic.delete_by_search_object({"bool": {"must_not": [{"terms": {"name": matched_analytics}}]}})
-    ds.analytic.commit()
+    if matched_analytics is not None:
+        ds.analytic.delete_by_search_object({"bool": {"must_not": [{"terms": {"name": matched_analytics}}]}})
+        ds.analytic.commit()
+    else:
+        logger.warning("No matched analytics aggregation result. Skipping cleanup.")
 
 
-def _find_analytics_with_hits(ds: HowlerDatastore) -> list[str]:
+def _find_analytics_with_hits(ds: HowlerDatastore) -> list[str] | None:
 
     total_analytics = ds.analytic.count("id:*", filters=None)["count"]
 
@@ -61,11 +64,15 @@ def _find_analytics_with_hits(ds: HowlerDatastore) -> list[str]:
                     },
                 )
             ],
+            rows=0,
         )
 
-        matched_analytic_names = [
-            bucket["key"] for bucket in matched_analytics["aggregations"]["matched_analytics"]["buckets"]
-        ]
+        if "matched_analytics" in matched_analytics["aggregations"]:
+            matched_analytic_names = [
+                bucket["key"] for bucket in matched_analytics["aggregations"]["matched_analytics"]["buckets"]
+            ]
+        else:
+            return None
 
     else:
         matched_analytic_names = []

--- a/api/howler/cronjobs/retention.py
+++ b/api/howler/cronjobs/retention.py
@@ -8,6 +8,7 @@ from pytz import timezone
 
 from howler.common.logging import get_logger
 from howler.config import DEBUG, config
+from howler.datastore.howler_store import HowlerDatastore
 
 logger = get_logger(__file__)
 
@@ -29,6 +30,42 @@ def execute():
     ds.hit.commit()
 
     logger.debug("Deletion complete")
+
+    logger.debug("Cleaning analytics with no matching hits")
+    _remove_analytics_without_hits(ds)
+
+
+def _remove_analytics_without_hits(ds: HowlerDatastore):
+
+    matched_analytics = _find_analytics_with_hits(ds)
+
+    ds.analytic.delete_by_search_object({"bool": {"must_not": [{"terms": {"name": matched_analytics}}]}})
+    ds.analytic.commit()
+
+
+def _find_analytics_with_hits(ds: HowlerDatastore) -> list[str]:
+
+    total_analytics = ds.analytic.count("id:*", filters=None)["count"]
+    matched_analytics = ds.hit.search(
+        "howler.id:*",
+        aggs=[
+            (
+                "matched_analytics",
+                {
+                    "terms": {
+                        "field": "howler.analytic",
+                        "size": total_analytics,
+                    }
+                },
+            )
+        ],
+    )
+
+    matched_analytic_names = [
+        bucket["key"] for bucket in matched_analytics["agg_result"]["matched_analytics"]["buckets"]
+    ]
+
+    return matched_analytic_names
 
 
 def setup_job(sched: BaseScheduler):

--- a/api/howler/cronjobs/retention.py
+++ b/api/howler/cronjobs/retention.py
@@ -46,24 +46,29 @@ def _remove_analytics_without_hits(ds: HowlerDatastore):
 def _find_analytics_with_hits(ds: HowlerDatastore) -> list[str]:
 
     total_analytics = ds.analytic.count("id:*", filters=None)["count"]
-    matched_analytics = ds.hit.search(
-        "howler.id:*",
-        aggs=[
-            (
-                "matched_analytics",
-                {
-                    "terms": {
-                        "field": "howler.analytic",
-                        "size": total_analytics,
-                    }
-                },
-            )
-        ],
-    )
 
-    matched_analytic_names = [
-        bucket["key"] for bucket in matched_analytics["agg_result"]["matched_analytics"]["buckets"]
-    ]
+    if total_analytics:
+        matched_analytics = ds.hit.search(
+            "howler.id:*",
+            aggs=[
+                (
+                    "matched_analytics",
+                    {
+                        "terms": {
+                            "field": "howler.analytic",
+                            "size": total_analytics,
+                        }
+                    },
+                )
+            ],
+        )
+
+        matched_analytic_names = [
+            bucket["key"] for bucket in matched_analytics["agg_result"]["matched_analytics"]["buckets"]
+        ]
+
+    else:
+        matched_analytic_names = []
 
     return matched_analytic_names
 

--- a/api/howler/cronjobs/retention.py
+++ b/api/howler/cronjobs/retention.py
@@ -59,7 +59,10 @@ def _remove_analytics_without_hits(ds: HowlerDatastore):
         )
         ds.analytic.commit()
     else:
-        logger.warning("No matched analytics aggregation result. Skipping cleanup.")
+        logger.warning(
+            "Aggregation search for matched analytics did not run or returned no results. "
+            "There is likely an issue with the query. Skipping cleanup."
+        )
 
 
 def _find_analytics_with_hits(ds: HowlerDatastore) -> list[str] | None:

--- a/api/howler/datastore/collection.py
+++ b/api/howler/datastore/collection.py
@@ -1121,7 +1121,7 @@ class ESCollection(Generic[ModelType]):
         except elasticsearch.NotFoundError:
             return False
 
-    def delete_by_query(self, query, workers=20, sort=None, max_docs=None):
+    def delete_by_query(self, query: str, workers=20, sort=None, max_docs=None):
         """This function should delete the underlying documents referenced by the query.
         It should return true if the documents were in fact properly deleted.
 
@@ -1129,7 +1129,18 @@ class ESCollection(Generic[ModelType]):
         :param workers: Number of workers used for deletion if basic currency delete is used
         :return: True is delete successful
         """
-        query = {"bool": {"must": {"query_string": {"query": query}}}}
+        query_obj = {"bool": {"must": {"query_string": {"query": query}}}}
+        success = self.delete_by_search_object(query=query_obj, workers=workers, sort=sort, max_docs=max_docs)
+        return success
+
+    def delete_by_search_object(self, query: dict, workers=20, sort=None, max_docs=None):
+        """Delete the underlying documents matching the query object.
+        Returns true if the documents were in fact properly deleted.
+
+        :param query: Query object following elasticsearch request structure
+        :param workers: Number of workers used for deletion if basic currency delete is used
+        :return: True is delete successful
+        """
         info = self._delete_async(self.name, query=query, sort=sort_str(parse_sort(sort)), max_docs=max_docs)
         return info.get("deleted", 0) != 0
 

--- a/api/howler/datastore/collection.py
+++ b/api/howler/datastore/collection.py
@@ -1562,7 +1562,6 @@ class ESCollection(Generic[ModelType]):
         self,
         query: str | None,
         as_obj: Literal[True] = True,
-        aggregations: None = None,
         offset: int = 0,
         rows: int | None = None,
         sort: typing.Any = None,
@@ -1574,6 +1573,8 @@ class ESCollection(Generic[ModelType]):
         use_archive: bool = False,
         track_total_hits: bool = False,
         script_fields: list[str] = [],
+        *,
+        aggregations: None = None,
     ) -> SearchResult[ModelType]: ...
 
     @overload
@@ -1581,7 +1582,6 @@ class ESCollection(Generic[ModelType]):
         self,
         query: str | None,
         as_obj: Literal[False],
-        aggregations: None = None,
         offset: int = 0,
         rows: int | None = None,
         sort: typing.Any = None,
@@ -1593,15 +1593,15 @@ class ESCollection(Generic[ModelType]):
         use_archive: bool = False,
         track_total_hits: bool = False,
         script_fields: list[str] = [],
+        *,
+        aggregations: None = None,
     ) -> SearchResult[dict[str, typing.Any]]: ...
 
     @overload
     def search(
         self,
         query: str | None,
-        *,
         as_obj: Literal[True] = True,
-        aggregations: list[tuple[str, dict]],
         offset: int = 0,
         rows: int | None = None,
         sort: typing.Any = None,
@@ -1613,15 +1613,15 @@ class ESCollection(Generic[ModelType]):
         use_archive: bool = False,
         track_total_hits: bool = False,
         script_fields: list[str] = [],
+        *,
+        aggregations: list[tuple[str, dict]],
     ) -> AggSearchResult[ModelType]: ...
 
     @overload
     def search(
         self,
         query: str | None,
-        *,
         as_obj: Literal[False],
-        aggregations: list[tuple[str, dict]],
         offset: int = 0,
         rows: int | None = None,
         sort: typing.Any = None,
@@ -1633,13 +1633,14 @@ class ESCollection(Generic[ModelType]):
         use_archive: bool = False,
         track_total_hits: bool = False,
         script_fields: list[str] = [],
+        *,
+        aggregations: list[tuple[str, dict]],
     ) -> AggSearchResult[dict[str, typing.Any]]: ...
 
     def search(
         self,
         query,
         as_obj=True,
-        aggregations=None,
         offset=0,
         rows=None,
         sort=None,
@@ -1651,6 +1652,8 @@ class ESCollection(Generic[ModelType]):
         use_archive=False,
         track_total_hits=None,
         script_fields=[],
+        *,
+        aggregations=None,
     ):
         """This function should perform a search through the datastore and return a
         search result object that consist on the following::

--- a/api/howler/datastore/collection.py
+++ b/api/howler/datastore/collection.py
@@ -1519,7 +1519,21 @@ class ESCollection(Generic[ModelType]):
         # Add any arbitrary aggregations
         if parsed_values["aggregations"]:
             query_body.setdefault("aggregations", {})
+            cluster_settings = self.datastore.client.cluster.get_settings(include_defaults=True, flat_settings=True)
+            flattened_settings = {
+                **cluster_settings["defaults"],
+                **cluster_settings["transient"],
+                **cluster_settings["persistent"],
+            }
+            max_buckets = int(flattened_settings["search.max_buckets"])
             for agg_name, agg_args in parsed_values["aggregations"]:
+                if any("size" in agg_def and agg_def["size"] > max_buckets for agg_def in agg_args.values()):
+                    # verify the size of the agg query doesn't exceed the max
+                    warnings.warn(
+                        f"Aggregation {agg_name} has a size argument higher than the maximum allowed "
+                        f"buckets of the cluster ({max_buckets}). Skipping aggregation."
+                    )
+                    continue
                 query_body["aggregations"][f"{self.CUSTOM_AGG_PREFIX}{agg_name}"] = agg_args
 
         try:
@@ -1761,7 +1775,7 @@ class ESCollection(Generic[ModelType]):
                 "items": search_ret_data["items"],
                 "aggregations": {
                     k[len(self.CUSTOM_AGG_PREFIX) :]: v
-                    for k, v in result["aggregations"].items()
+                    for k, v in result.get("aggregations", {}).items()
                     if k.startswith(self.CUSTOM_AGG_PREFIX)
                 },
             }

--- a/api/howler/datastore/collection.py
+++ b/api/howler/datastore/collection.py
@@ -1121,7 +1121,7 @@ class ESCollection(Generic[ModelType]):
         except elasticsearch.NotFoundError:
             return False
 
-    def delete_by_query(self, query: str, workers=20, sort=None, max_docs=None):
+    def delete_by_query(self, query: str, sort=None, max_docs=None):
         """This function should delete the underlying documents referenced by the query.
         It should return true if the documents were in fact properly deleted.
 
@@ -1130,10 +1130,10 @@ class ESCollection(Generic[ModelType]):
         :return: True is delete successful
         """
         query_obj = {"bool": {"must": {"query_string": {"query": query}}}}
-        success = self.delete_by_search_object(query=query_obj, workers=workers, sort=sort, max_docs=max_docs)
+        success = self.delete_by_search_object(query=query_obj, sort=sort, max_docs=max_docs)
         return success
 
-    def delete_by_search_object(self, query: dict, workers=20, sort=None, max_docs=None):
+    def delete_by_search_object(self, query: dict, sort=None, max_docs=None):
         """Delete the underlying documents matching the query object.
         Returns true if the documents were in fact properly deleted.
 

--- a/api/howler/datastore/collection.py
+++ b/api/howler/datastore/collection.py
@@ -1670,7 +1670,7 @@ class ESCollection(Generic[ModelType]):
         If aggregations are provided the search result will include an additional field::
 
             {
-                "agg_result": {         # Dictionary where the keys are the keys of the `aggregations` parameter
+                "aggregations": {       # Dictionary where the keys are the keys of the `aggregations` parameter
                     "agg_name": {...}   #   and the values are the results of the aggregations
                 }
             }
@@ -1756,7 +1756,7 @@ class ESCollection(Generic[ModelType]):
                 "rows": search_ret_data["rows"],
                 "total": search_ret_data["total"],
                 "items": search_ret_data["items"],
-                "agg_result": {
+                "aggregations": {
                     k[len(self.CUSTOM_AGG_PREFIX) :]: v
                     for k, v in result["aggregations"].items()
                     if k.startswith(self.CUSTOM_AGG_PREFIX)

--- a/api/howler/datastore/collection.py
+++ b/api/howler/datastore/collection.py
@@ -38,7 +38,7 @@ from howler.datastore.support.schemas import (
     default_index,
     default_mapping,
 )
-from howler.datastore.types import SearchResult
+from howler.datastore.types import AggSearchResult, SearchResult
 from howler.odm.base import (
     BANNED_FIELDS,
     IP,
@@ -211,9 +211,11 @@ class ESCollection(Generic[ModelType]):
         "sort": DEFAULT_SORT,
         "df": None,
         "script_fields": [],
+        "aggs": None,
     }
     IGNORE_ENSURE_COLLECTION: bool = False
     ENSURE_COLLECTION_WARNED: bool = False
+    CUSTOM_AGG_PREFIX: str = "_custom_agg__"
 
     def __init__(self, datastore: ESStore, name, model_class=None, validate=True, max_attempts=10):
         self.replicas = int(
@@ -1503,6 +1505,12 @@ class ESCollection(Generic[ModelType]):
                 },
             }
 
+        # Add any arbitrary aggregations
+        if parsed_values["aggs"]:
+            query_body.setdefault("aggregations", {})
+            for agg_name, agg_args in parsed_values["aggs"]:
+                query_body["aggregations"][f"{self.CUSTOM_AGG_PREFIX}{agg_name}"] = agg_args
+
         try:
             if deep_paging_id is not None and not deep_paging_id == "*":
                 # Get the next page
@@ -1543,6 +1551,7 @@ class ESCollection(Generic[ModelType]):
         self,
         query: str | None,
         as_obj: Literal[True] = True,
+        aggs: None = None,
         offset: int = 0,
         rows: int | None = None,
         sort: typing.Any = None,
@@ -1561,6 +1570,7 @@ class ESCollection(Generic[ModelType]):
         self,
         query: str | None,
         as_obj: Literal[False],
+        aggs: None = None,
         offset: int = 0,
         rows: int | None = None,
         sort: typing.Any = None,
@@ -1574,10 +1584,51 @@ class ESCollection(Generic[ModelType]):
         script_fields: list[str] = [],
     ) -> SearchResult[dict[str, typing.Any]]: ...
 
+    @overload
+    def search(
+        self,
+        query: str | None,
+        *,
+        as_obj: Literal[True] = True,
+        aggs: list[tuple[str, dict]],
+        offset: int = 0,
+        rows: int | None = None,
+        sort: typing.Any = None,
+        fl: str | None = None,
+        timeout: int | None = None,
+        filters: list[str] | str | None = None,
+        access_control: typing.Any = None,
+        deep_paging_id: str | None = None,
+        use_archive: bool = False,
+        track_total_hits: bool = False,
+        script_fields: list[str] = [],
+    ) -> AggSearchResult[ModelType]: ...
+
+    @overload
+    def search(
+        self,
+        query: str | None,
+        *,
+        as_obj: Literal[False],
+        aggs: list[tuple[str, dict]],
+        offset: int = 0,
+        rows: int | None = None,
+        sort: typing.Any = None,
+        fl: str | None = None,
+        timeout: int | None = None,
+        filters: list[str] | str | None = None,
+        access_control: typing.Any = None,
+        deep_paging_id: str | None = None,
+        use_archive: bool = False,
+        track_total_hits: bool = False,
+        script_fields: list[str] = [],
+    ) -> AggSearchResult[dict[str, typing.Any]]: ...
+
     def search(
         self,
         query,
         as_obj=True,
+        aggs=None,
         offset=0,
         rows=None,
         sort=None,
@@ -1605,6 +1656,14 @@ class ESCollection(Generic[ModelType]):
                     }, ...]
             }
 
+        If aggregations are provided the search result will include an additional field::
+
+            {
+                "agg_result": {         # Dictionary where the keys are the keys of the `aggs` parameter
+                    "agg_name": {...}   #   and the values are the results of the aggregations
+                }
+            }
+
         :param script_fields: List of name/script tuple of fields to be evaluated at runtime
         :param track_total_hits: Return to total matching document count
         :param use_archive: Query also the archive
@@ -1618,6 +1677,8 @@ class ESCollection(Generic[ModelType]):
         :param timeout: maximum time of execution
         :param filters: additional queries to run on the original query to reduce the scope
         :param access_control: access control parameters to limiti the scope of the query
+        :param aggs: optional list of arbitrary aggregations to run alongside the query
+            structured the same way as the es rest query aggs field
         :return: a search result object
         """
         if offset is None:
@@ -1660,6 +1721,9 @@ class ESCollection(Generic[ModelType]):
         if script_fields:
             args.append(("script_fields", script_fields))
 
+        if aggs:
+            args.append(("aggs", aggs))
+
         result = self._search(
             args,
             deep_paging_id=deep_paging_id,
@@ -1699,6 +1763,18 @@ class ESCollection(Generic[ModelType]):
 
         if new_deep_paging_id is not None:
             ret_data["next_deep_paging_id"] = new_deep_paging_id
+
+        if aggs:
+            agg_ret_data: AggSearchResult = {
+                **SearchResult(ret_data),
+                "agg_result": {
+                    k[len(self.CUSTOM_AGG_PREFIX) :]: v
+                    for k, v in result["aggregations"].items()
+                    if k.startswith(self.CUSTOM_AGG_PREFIX)
+                },
+            }
+
+            return agg_ret_data
 
         return ret_data
 

--- a/api/howler/datastore/collection.py
+++ b/api/howler/datastore/collection.py
@@ -211,7 +211,7 @@ class ESCollection(Generic[ModelType]):
         "sort": DEFAULT_SORT,
         "df": None,
         "script_fields": [],
-        "aggs": None,
+        "aggregations": None,
     }
     IGNORE_ENSURE_COLLECTION: bool = False
     ENSURE_COLLECTION_WARNED: bool = False
@@ -1517,9 +1517,9 @@ class ESCollection(Generic[ModelType]):
             }
 
         # Add any arbitrary aggregations
-        if parsed_values["aggs"]:
+        if parsed_values["aggregations"]:
             query_body.setdefault("aggregations", {})
-            for agg_name, agg_args in parsed_values["aggs"]:
+            for agg_name, agg_args in parsed_values["aggregations"]:
                 query_body["aggregations"][f"{self.CUSTOM_AGG_PREFIX}{agg_name}"] = agg_args
 
         try:
@@ -1562,7 +1562,7 @@ class ESCollection(Generic[ModelType]):
         self,
         query: str | None,
         as_obj: Literal[True] = True,
-        aggs: None = None,
+        aggregations: None = None,
         offset: int = 0,
         rows: int | None = None,
         sort: typing.Any = None,
@@ -1581,7 +1581,7 @@ class ESCollection(Generic[ModelType]):
         self,
         query: str | None,
         as_obj: Literal[False],
-        aggs: None = None,
+        aggregations: None = None,
         offset: int = 0,
         rows: int | None = None,
         sort: typing.Any = None,
@@ -1601,7 +1601,7 @@ class ESCollection(Generic[ModelType]):
         query: str | None,
         *,
         as_obj: Literal[True] = True,
-        aggs: list[tuple[str, dict]],
+        aggregations: list[tuple[str, dict]],
         offset: int = 0,
         rows: int | None = None,
         sort: typing.Any = None,
@@ -1621,7 +1621,7 @@ class ESCollection(Generic[ModelType]):
         query: str | None,
         *,
         as_obj: Literal[False],
-        aggs: list[tuple[str, dict]],
+        aggregations: list[tuple[str, dict]],
         offset: int = 0,
         rows: int | None = None,
         sort: typing.Any = None,
@@ -1639,7 +1639,7 @@ class ESCollection(Generic[ModelType]):
         self,
         query,
         as_obj=True,
-        aggs=None,
+        aggregations=None,
         offset=0,
         rows=None,
         sort=None,
@@ -1670,7 +1670,7 @@ class ESCollection(Generic[ModelType]):
         If aggregations are provided the search result will include an additional field::
 
             {
-                "agg_result": {         # Dictionary where the keys are the keys of the `aggs` parameter
+                "agg_result": {         # Dictionary where the keys are the keys of the `aggregations` parameter
                     "agg_name": {...}   #   and the values are the results of the aggregations
                 }
             }
@@ -1688,7 +1688,7 @@ class ESCollection(Generic[ModelType]):
         :param timeout: maximum time of execution
         :param filters: additional queries to run on the original query to reduce the scope
         :param access_control: access control parameters to limiti the scope of the query
-        :param aggs: optional list of arbitrary aggregations to run alongside the query
+        :param aggregations: optional list of arbitrary aggregations to run alongside the query
             structured the same way as the es rest query aggs field
         :return: a search result object
         """
@@ -1732,8 +1732,8 @@ class ESCollection(Generic[ModelType]):
         if script_fields:
             args.append(("script_fields", script_fields))
 
-        if aggs:
-            args.append(("aggs", aggs))
+        if aggregations:
+            args.append(("aggregations", aggregations))
 
         result = self._search(
             args,
@@ -1750,7 +1750,7 @@ class ESCollection(Generic[ModelType]):
             "items": [self._format_output(doc, field_list, as_obj=as_obj) for doc in result["hits"]["hits"]],
         }
 
-        if aggs:
+        if aggregations:
             agg_ret_data: AggSearchResult = {
                 "offset": search_ret_data["offset"],
                 "rows": search_ret_data["rows"],

--- a/api/howler/datastore/collection.py
+++ b/api/howler/datastore/collection.py
@@ -1742,12 +1742,30 @@ class ESCollection(Generic[ModelType]):
             track_total_hits=track_total_hits,
         )
 
-        ret_data: SearchResult = {
+        ret_data: SearchResult | AggSearchResult
+        search_ret_data: SearchResult = {
             "offset": int(offset),
             "rows": int(rows),
             "total": int(result["hits"]["total"]["value"]),
             "items": [self._format_output(doc, field_list, as_obj=as_obj) for doc in result["hits"]["hits"]],
         }
+
+        if aggs:
+            agg_ret_data: AggSearchResult = {
+                "offset": search_ret_data["offset"],
+                "rows": search_ret_data["rows"],
+                "total": search_ret_data["total"],
+                "items": search_ret_data["items"],
+                "agg_result": {
+                    k[len(self.CUSTOM_AGG_PREFIX) :]: v
+                    for k, v in result["aggregations"].items()
+                    if k.startswith(self.CUSTOM_AGG_PREFIX)
+                },
+            }
+            ret_data = agg_ret_data
+
+        else:
+            ret_data = search_ret_data
 
         new_deep_paging_id = result.get("_scroll_id", None)
 
@@ -1774,18 +1792,6 @@ class ESCollection(Generic[ModelType]):
 
         if new_deep_paging_id is not None:
             ret_data["next_deep_paging_id"] = new_deep_paging_id
-
-        if aggs:
-            agg_ret_data: AggSearchResult = {
-                **SearchResult(ret_data),
-                "agg_result": {
-                    k[len(self.CUSTOM_AGG_PREFIX) :]: v
-                    for k, v in result["aggregations"].items()
-                    if k.startswith(self.CUSTOM_AGG_PREFIX)
-                },
-            }
-
-            return agg_ret_data
 
         return ret_data
 

--- a/api/howler/datastore/collection.py
+++ b/api/howler/datastore/collection.py
@@ -1760,7 +1760,7 @@ class ESCollection(Generic[ModelType]):
         )
 
         ret_data: SearchResult | AggSearchResult
-        search_ret_data: SearchResult = {
+        ret_data = {
             "offset": int(offset),
             "rows": int(rows),
             "total": int(result["hits"]["total"]["value"]),
@@ -1768,21 +1768,14 @@ class ESCollection(Generic[ModelType]):
         }
 
         if aggregations:
-            agg_ret_data: AggSearchResult = {
-                "offset": search_ret_data["offset"],
-                "rows": search_ret_data["rows"],
-                "total": search_ret_data["total"],
-                "items": search_ret_data["items"],
+            ret_data = {
+                **ret_data,
                 "aggregations": {
                     k[len(self.CUSTOM_AGG_PREFIX) :]: v
                     for k, v in result.get("aggregations", {}).items()
                     if k.startswith(self.CUSTOM_AGG_PREFIX)
                 },
             }
-            ret_data = agg_ret_data
-
-        else:
-            ret_data = search_ret_data
 
         new_deep_paging_id = result.get("_scroll_id", None)
 

--- a/api/howler/datastore/types.py
+++ b/api/howler/datastore/types.py
@@ -16,3 +16,7 @@ class SearchResult(TypedDict, Generic[SearchResultType]):
     total: int
     items: list[SearchResultType]
     next_deep_paging_id: NotRequired[str | None]
+
+
+class AggSearchResult(SearchResult[SearchResultType]):
+    agg_result: dict[str, dict]

--- a/api/howler/datastore/types.py
+++ b/api/howler/datastore/types.py
@@ -19,4 +19,4 @@ class SearchResult(TypedDict, Generic[SearchResultType]):
 
 
 class AggSearchResult(SearchResult[SearchResultType]):
-    agg_result: dict[str, dict]
+    aggregations: dict[str, dict]

--- a/api/test/conftest.py
+++ b/api/test/conftest.py
@@ -82,19 +82,6 @@ def datastore_connection(config, auth_fail_queue):
         random_data.wipe_users(ds)
 
 
-@pytest.fixture(scope="session")
-def datastore_connection_with_hits(datastore_connection):
-    try:
-        random_data.wipe_hits(datastore_connection)
-        random_data.wipe_analytics(datastore_connection)
-        random_data.create_hits(datastore_connection)
-        random_data.create_analytics(datastore_connection)
-        yield datastore_connection
-    finally:
-        random_data.wipe_hits(datastore_connection)
-        random_data.wipe_analytics(datastore_connection)
-
-
 # Under different test setups, the host may have a different address
 POSSIBLE_HOSTS = [
     "https://localhost:443",

--- a/api/test/conftest.py
+++ b/api/test/conftest.py
@@ -82,6 +82,19 @@ def datastore_connection(config, auth_fail_queue):
         random_data.wipe_users(ds)
 
 
+@pytest.fixture(scope="session")
+def datastore_connection_with_hits(datastore_connection):
+    try:
+        random_data.wipe_hits(datastore_connection)
+        random_data.wipe_analytics(datastore_connection)
+        random_data.create_hits(datastore_connection)
+        random_data.create_analytics(datastore_connection)
+        yield datastore_connection
+    finally:
+        random_data.wipe_hits(datastore_connection)
+        random_data.wipe_analytics(datastore_connection)
+
+
 # Under different test setups, the host may have a different address
 POSSIBLE_HOSTS = [
     "https://localhost:443",

--- a/api/test/integration/cronjobs/test_retention.py
+++ b/api/test/integration/cronjobs/test_retention.py
@@ -100,3 +100,18 @@ def test_no_hits_remove_analytics_without_hits(datastore_connection_no_hits):
 
     analytic_names = get_analytic_names(datastore_connection_no_hits)
     assert analytic_names == []
+
+
+def test_too_many_analytics_does_not_run_cleanup(monkeypatch, datastore_connection):
+    """Test that if the analytics aggregation fails, the cleanup does not run and no analytics are deleted"""
+
+    # simulate large number of analytics
+    monkeypatch.setattr(datastore_connection.analytic, "count", lambda *args, **kwargs: {"count": 65537})
+
+    before_delete = get_analytic_names(datastore_connection)
+
+    with pytest.warns(UserWarning, match="size argument higher than the maximum allowed"):
+        _remove_analytics_without_hits(datastore_connection)
+
+    after_delete = get_analytic_names(datastore_connection)
+    assert lists_equivalent(after_delete, before_delete)

--- a/api/test/integration/cronjobs/test_retention.py
+++ b/api/test/integration/cronjobs/test_retention.py
@@ -2,12 +2,44 @@ import pytest
 
 from howler.cronjobs.retention import _find_analytics_with_hits, _remove_analytics_without_hits
 from howler.datastore.howler_store import HowlerDatastore
+from howler.odm import random_data
 from howler.odm.helper import EXAMPLE_ANALYTICS
 
 
 @pytest.fixture(scope="function")
 def expected_analytics():
     return [*EXAMPLE_ANALYTICS, "SecretAnalytic"]
+
+
+@pytest.fixture(scope="function")
+def datastore_connection_with_hits(datastore_connection):
+    try:
+        random_data.wipe_hits(datastore_connection)
+        random_data.wipe_analytics(datastore_connection)
+        random_data.create_hits(datastore_connection, hit_count=50)
+        random_data.create_analytics(datastore_connection)
+        yield datastore_connection
+    finally:
+        random_data.wipe_hits(datastore_connection)
+        random_data.wipe_analytics(datastore_connection)
+
+
+@pytest.fixture(scope="function")
+def datastore_connection_no_hits(datastore_connection_with_hits):
+    random_data.wipe_hits(datastore_connection_with_hits)
+    yield datastore_connection_with_hits
+
+
+@pytest.fixture(scope="function")
+def datastore_connection_no_extra_analytics(datastore_connection):
+    try:
+        random_data.wipe_hits(datastore_connection)
+        random_data.wipe_analytics(datastore_connection)
+        random_data.create_hits(datastore_connection, hit_count=50)
+        yield datastore_connection
+    finally:
+        random_data.wipe_hits(datastore_connection)
+        random_data.wipe_analytics(datastore_connection)
 
 
 def lists_equivalent(l1: list[str], l2: list[str]):
@@ -38,3 +70,33 @@ def test_remove_analytics_without_hits(datastore_connection_with_hits: HowlerDat
 
     analytic_names = get_analytic_names(datastore_connection_with_hits)
     assert lists_equivalent(analytic_names, expected_analytics)
+
+
+def test_no_hits_find_analytics_with_hits(datastore_connection_no_hits):
+    """Test that if there are no analytics the search returns an empty list"""
+
+    matched_analytics = _find_analytics_with_hits(datastore_connection_no_hits)
+
+    assert matched_analytics == []
+
+
+def test_only_valid_remove_analytics_without_hits(datastore_connection_no_extra_analytics):
+    """Test that no analytics removed if all analytics are valid"""
+
+    before_delete = get_analytic_names(datastore_connection_no_extra_analytics)
+
+    _remove_analytics_without_hits(datastore_connection_no_extra_analytics)
+
+    after_delete = get_analytic_names(datastore_connection_no_extra_analytics)
+    assert lists_equivalent(after_delete, before_delete)
+
+
+def test_no_hits_remove_analytics_without_hits(datastore_connection_no_hits):
+    """Test that empty hits index clears all analytics"""
+    before_delete = get_analytic_names(datastore_connection_no_hits)
+    assert len(before_delete) != 0
+
+    _remove_analytics_without_hits(datastore_connection_no_hits)
+
+    analytic_names = get_analytic_names(datastore_connection_no_hits)
+    assert analytic_names == []

--- a/api/test/integration/cronjobs/test_retention.py
+++ b/api/test/integration/cronjobs/test_retention.py
@@ -1,0 +1,40 @@
+import pytest
+
+from howler.cronjobs.retention import _find_analytics_with_hits, _remove_analytics_without_hits
+from howler.datastore.howler_store import HowlerDatastore
+from howler.odm.helper import EXAMPLE_ANALYTICS
+
+
+@pytest.fixture(scope="function")
+def expected_analytics():
+    return [*EXAMPLE_ANALYTICS, "SecretAnalytic"]
+
+
+def lists_equivalent(l1: list[str], l2: list[str]):
+    return sorted(s.lower() for s in l1) == sorted(s.lower() for s in l2)
+
+
+def get_analytic_names(ds: HowlerDatastore):
+    search_result = ds.analytic.search("id:*")
+    analytic_names = [item["name"] for item in search_result["items"]]
+    return analytic_names
+
+
+def test_find_analytics_with_hits(datastore_connection_with_hits, expected_analytics):
+    """Test that the search returns all the analytic names with matching hits"""
+
+    matched_analytics = _find_analytics_with_hits(datastore_connection_with_hits)
+
+    assert lists_equivalent(matched_analytics, expected_analytics)
+
+
+def test_remove_analytics_without_hits(datastore_connection_with_hits: HowlerDatastore, expected_analytics):
+    """Test that only and all analytics with hits remain after running removal"""
+
+    analytic_names = get_analytic_names(datastore_connection_with_hits)
+    assert len(analytic_names) > len(expected_analytics)
+
+    _remove_analytics_without_hits(datastore_connection_with_hits)
+
+    analytic_names = get_analytic_names(datastore_connection_with_hits)
+    assert lists_equivalent(analytic_names, expected_analytics)

--- a/api/test/integration/cronjobs/test_retention.py
+++ b/api/test/integration/cronjobs/test_retention.py
@@ -4,6 +4,8 @@ from howler.cronjobs.retention import _find_analytics_with_hits, _remove_analyti
 from howler.datastore.howler_store import HowlerDatastore
 from howler.odm import random_data
 from howler.odm.helper import EXAMPLE_ANALYTICS
+from howler.odm.models.analytic import Analytic
+from howler.odm.randomizer import random_model_obj
 
 
 @pytest.fixture(scope="function")
@@ -12,22 +14,50 @@ def expected_analytics():
 
 
 @pytest.fixture(scope="function")
-def datastore_connection_with_hits(datastore_connection):
+def orphan_analytic_names():
+    return [f"OrphanAnalytic{i}" for i in range(10)]
+
+
+@pytest.fixture(scope="function")
+def rule_analytic_name():
+    return "RuleAnalytic"
+
+
+@pytest.fixture(scope="function")
+def rule_analytic(rule_analytic_name):
+    a: Analytic = random_model_obj(Analytic)
+    a.rule = "some rule"
+    a.rule_type = "lucene"
+    a.detections = ["Rule"]
+    a.name = rule_analytic_name
+    return a
+
+
+@pytest.fixture(scope="function")
+def orphan_analytics(orphan_analytic_names):
+    analytics = []
+    for name in orphan_analytic_names:
+        a: Analytic = random_model_obj(Analytic)
+        a.rule = None
+        a.rule_type = None
+        a.name = name
+        analytics.append(a)
+    return analytics
+
+
+@pytest.fixture(scope="function")
+def datastore_connection_with_hits(datastore_connection, orphan_analytics):
     try:
         random_data.wipe_hits(datastore_connection)
         random_data.wipe_analytics(datastore_connection)
         random_data.create_hits(datastore_connection, hit_count=50)
-        random_data.create_analytics(datastore_connection)
+        for analytic in orphan_analytics:
+            datastore_connection.analytic.save(analytic.analytic_id, analytic)
+        datastore_connection.analytic.commit()
         yield datastore_connection
     finally:
         random_data.wipe_hits(datastore_connection)
         random_data.wipe_analytics(datastore_connection)
-
-
-@pytest.fixture(scope="function")
-def datastore_connection_no_hits(datastore_connection_with_hits):
-    random_data.wipe_hits(datastore_connection_with_hits)
-    yield datastore_connection_with_hits
 
 
 @pytest.fixture(scope="function")
@@ -40,6 +70,23 @@ def datastore_connection_no_extra_analytics(datastore_connection):
     finally:
         random_data.wipe_hits(datastore_connection)
         random_data.wipe_analytics(datastore_connection)
+
+
+@pytest.fixture(scope="function")
+def datastore_connection_with_rule_analytics(datastore_connection_with_hits, rule_analytic):
+    try:
+        datastore_connection_with_hits.analytic.save(rule_analytic.analytic_id, rule_analytic)
+        datastore_connection_with_hits.analytic.commit()
+        yield datastore_connection_with_hits
+    finally:
+        datastore_connection_with_hits.analytic.delete(rule_analytic.analytic_id)
+        datastore_connection_with_hits.analytic.commit()
+
+
+@pytest.fixture(scope="function")
+def datastore_connection_no_hits(datastore_connection_with_rule_analytics):
+    random_data.wipe_hits(datastore_connection_with_rule_analytics)
+    yield datastore_connection_with_rule_analytics
 
 
 def lists_equivalent(l1: list[str], l2: list[str]):
@@ -64,12 +111,30 @@ def test_remove_analytics_without_hits(datastore_connection_with_hits: HowlerDat
     """Test that only and all analytics with hits remain after running removal"""
 
     analytic_names = get_analytic_names(datastore_connection_with_hits)
-    assert len(analytic_names) > len(expected_analytics)
+    assert len(analytic_names) > len(expected_analytics), "Test setup failure: not enough analytics without hits"
 
     _remove_analytics_without_hits(datastore_connection_with_hits)
 
     analytic_names = get_analytic_names(datastore_connection_with_hits)
     assert lists_equivalent(analytic_names, expected_analytics)
+
+
+def test_remove_analytics_without_hits_does_not_remove_rule_analytics(
+    datastore_connection_with_rule_analytics, expected_analytics, rule_analytic_name
+):
+    """Test that analytics with rules are not removed even if they have no hits"""
+
+    expected_analytics_with_rule = expected_analytics + [rule_analytic_name]
+
+    analytic_names = get_analytic_names(datastore_connection_with_rule_analytics)
+    assert len(analytic_names) > len(expected_analytics_with_rule), (
+        "Test setup failure: not enough analytics without hits"
+    )
+
+    _remove_analytics_without_hits(datastore_connection_with_rule_analytics)
+
+    analytic_names = get_analytic_names(datastore_connection_with_rule_analytics)
+    assert lists_equivalent(analytic_names, expected_analytics_with_rule)
 
 
 def test_no_hits_find_analytics_with_hits(datastore_connection_no_hits):
@@ -91,15 +156,15 @@ def test_only_valid_remove_analytics_without_hits(datastore_connection_no_extra_
     assert lists_equivalent(after_delete, before_delete)
 
 
-def test_no_hits_remove_analytics_without_hits(datastore_connection_no_hits):
-    """Test that empty hits index clears all analytics"""
+def test_no_hits_remove_analytics_without_hits(datastore_connection_no_hits, rule_analytic_name):
+    """Test that empty hits index clears all analytics except rule analytics"""
     before_delete = get_analytic_names(datastore_connection_no_hits)
-    assert len(before_delete) != 0
+    assert len(before_delete) != 0, "Test setup failure: there should be analytics to delete"
 
     _remove_analytics_without_hits(datastore_connection_no_hits)
 
     analytic_names = get_analytic_names(datastore_connection_no_hits)
-    assert analytic_names == []
+    assert analytic_names == [rule_analytic_name]
 
 
 def test_too_many_analytics_does_not_run_cleanup(monkeypatch, datastore_connection):

--- a/api/test/integration/cronjobs/test_retention.py
+++ b/api/test/integration/cronjobs/test_retention.py
@@ -73,7 +73,7 @@ def test_remove_analytics_without_hits(datastore_connection_with_hits: HowlerDat
 
 
 def test_no_hits_find_analytics_with_hits(datastore_connection_no_hits):
-    """Test that if there are no analytics the search returns an empty list"""
+    """Test that if there are no hits the search returns an empty list"""
 
     matched_analytics = _find_analytics_with_hits(datastore_connection_no_hits)
 

--- a/api/test/integration/test_datastore.py
+++ b/api/test/integration/test_datastore.py
@@ -556,7 +556,7 @@ def _test_agg_search(c: ESCollection):
         ("cardinality_agg_name", cardinality_agg),
     ]
 
-    result = c.search("id:*", aggs=aggs)
+    result = c.search("id:*", aggregations=aggs)
 
     assert "agg_result" in result
     assert result["agg_result"].keys() == {"terms_agg_name", "cardinality_agg_name"}
@@ -587,7 +587,7 @@ TEST_FUNCTIONS = [
     (_test_histogram, "histogram"),
     (_test_facet, "facet"),
     (_test_stats, "stats"),
-    (_test_agg_search, "agg"),
+    (_test_agg_search, "aggregations"),
 ]
 
 

--- a/api/test/integration/test_datastore.py
+++ b/api/test/integration/test_datastore.py
@@ -568,6 +568,26 @@ def _test_agg_search(c: ESCollection):
     assert result["aggregations"]["cardinality_agg_name"].keys() == {"value"}
 
 
+def _test_oversized_agg_search(c: ESCollection):
+    """
+    Test that submitting an aggregation that exceeds the configured size limit emits a warning.
+
+    This test attempts to run a terms aggregation with a size larger than the allowed maximum,
+    and verifies that the appropriate warning is given and the aggregation is ignored.
+    """
+    terms_agg: dict = {"terms": {"field": "lvl_i", "size": 65537}}
+    aggs: list = [("oversized_terms_agg", terms_agg)]
+
+    with pytest.warns(
+        UserWarning,
+        match="Aggregation oversized_terms_agg has a size argument "
+        "higher than the maximum allowed buckets of the cluster",
+    ):
+        result = c.search("id:*", aggregations=aggs)
+
+    assert "aggregations" not in result or "oversized_terms_agg" not in result["aggregations"]
+
+
 TEST_FUNCTIONS = [
     (_test_exists, "exists"),
     (_test_get, "get"),
@@ -588,6 +608,7 @@ TEST_FUNCTIONS = [
     (_test_facet, "facet"),
     (_test_stats, "stats"),
     (_test_agg_search, "aggregations"),
+    (_test_oversized_agg_search, "oversized_aggregations"),
 ]
 
 

--- a/api/test/integration/test_datastore.py
+++ b/api/test/integration/test_datastore.py
@@ -542,6 +542,32 @@ def _test_stats(c: ESCollection):
         assert v > 0
 
 
+def _test_agg_search(c: ESCollection):
+    """
+    Test submitting arbitrary aggregations with search.
+
+    Apply a bucket agg (terms) and a metrics agg (cardinality)
+    and verify the structure of the result.
+    """
+    terms_agg: dict = {"terms": {"field": "lvl_i"}}
+    cardinality_agg: dict = {"cardinality": {"field": "lvl_i"}}
+    aggs: list = [
+        ("terms_agg_name", terms_agg),
+        ("cardinality_agg_name", cardinality_agg),
+    ]
+
+    result = c.search("id:*", aggs=aggs)
+
+    assert "agg_result" in result
+    assert result["agg_result"].keys() == {"terms_agg_name", "cardinality_agg_name"}
+    assert result["agg_result"]["terms_agg_name"].keys() == {
+        "doc_count_error_upper_bound",
+        "sum_other_doc_count",
+        "buckets",
+    }
+    assert result["agg_result"]["cardinality_agg_name"].keys() == {"value"}
+
+
 TEST_FUNCTIONS = [
     (_test_exists, "exists"),
     (_test_get, "get"),
@@ -561,6 +587,7 @@ TEST_FUNCTIONS = [
     (_test_histogram, "histogram"),
     (_test_facet, "facet"),
     (_test_stats, "stats"),
+    (_test_agg_search, "agg"),
 ]
 
 

--- a/api/test/integration/test_datastore.py
+++ b/api/test/integration/test_datastore.py
@@ -558,14 +558,14 @@ def _test_agg_search(c: ESCollection):
 
     result = c.search("id:*", aggregations=aggs)
 
-    assert "agg_result" in result
-    assert result["agg_result"].keys() == {"terms_agg_name", "cardinality_agg_name"}
-    assert result["agg_result"]["terms_agg_name"].keys() == {
+    assert "aggregations" in result
+    assert result["aggregations"].keys() == {"terms_agg_name", "cardinality_agg_name"}
+    assert result["aggregations"]["terms_agg_name"].keys() == {
         "doc_count_error_upper_bound",
         "sum_other_doc_count",
         "buckets",
     }
-    assert result["agg_result"]["cardinality_agg_name"].keys() == {"value"}
+    assert result["aggregations"]["cardinality_agg_name"].keys() == {"value"}
 
 
 TEST_FUNCTIONS = [


### PR DESCRIPTION
Remove analytics from the datastore once all hits generated by the analytic have been removed due to a retention job.

**Changes**:

ESCollection:
- Add a parameter to the search function to allow passing a list of aggregation search objects. Example usage in [_test_agg_search](https://github.com/CybercentreCanada/howler/compare/develop...cronjob_remove_analytics_without_hits#diff-f1d4831736b0f7b6bb02598a9b79d922ebe258edde983d1ca2a9b6fb56770856R545). Very little support is provided for creating the search object but the usage is more flexible.
- Add a deletion function to delete all documents that match a search object (similar to delete_by_query but allowing any valid es query object instead of using a query string).

Retention cronjob:
- After deleting hits in the retention cronjob, delete any analytics whose names do not appear in any hit's howler.analytic field.