### PR TITLE
fix(ui): custom date selection overriding premade time periods

### DIFF
--- a/ui/src/components/app/providers/ParameterProvider.tsx
+++ b/ui/src/components/app/providers/ParameterProvider.tsx
@@ -147,8 +147,8 @@ const ParameterProvider: FC<PropsWithChildren> = ({ children }) => {
         }
 
         if (key === 'span' && typeof value === 'string' && !value.endsWith('custom')) {
-          pendingChanges.current.startDate = undefined;
-          pendingChanges.current.endDate = undefined;
+          pendingChanges.current.startDate = null;
+          pendingChanges.current.endDate = null;
         }
 
         WRITE_THROTTLER.debounce(() => {
@@ -157,8 +157,8 @@ const ParameterProvider: FC<PropsWithChildren> = ({ children }) => {
             ...pendingChanges.current,
             ...(key === 'span' && typeof value === 'string' && !value.endsWith('custom')
               ? {
-                  startDate: undefined,
-                  endDate: undefined
+                  startDate: null,
+                  endDate: null
                 }
               : {})
           }));
@@ -363,7 +363,7 @@ const ParameterProvider: FC<PropsWithChildren> = ({ children }) => {
     const changes: Partial<SearchValues> = {};
 
     PARAM_MAPPINGS.forEach(([urlKey, stateKey]) => {
-      const urlValue = params.has(urlKey) ? params.get(urlKey) : (DEFAULT_VALUES[stateKey] ?? undefined);
+      const urlValue = params.has(urlKey) ? params.get(urlKey) : (DEFAULT_VALUES[stateKey] ?? null);
 
       if (urlValue !== values[stateKey]) {
         (changes as any)[stateKey] = urlValue;

--- a/ui/src/components/app/providers/ParameterProvider.tsx
+++ b/ui/src/components/app/providers/ParameterProvider.tsx
@@ -68,6 +68,7 @@ const PARAM_MAPPINGS: [string, keyof SearchValues][] = [
   ['start_date', 'startDate'],
   ['end_date', 'endDate']
 ];
+
 const WRITE_THROTTLER = new Throttler(100);
 
 /**
@@ -120,9 +121,14 @@ const ParameterProvider: FC<PropsWithChildren> = ({ children }) => {
     offset: parseOffset(params.get('offset')),
     trackTotalHits: (params.get('track_total_hits') ?? 'false') !== 'false'
   });
+  const syncSource = useRef<'state' | 'url' | null>(null);
+  const prevSpanRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    prevSpanRef.current = values.span;
+  }, [values.span]);
 
   // TODO: SELECTING A BUNDLE STILL CAUSES A FREAKOUT
-
   const set: <K extends Exclude<keyof SearchValues, 'filters'>>(key: K) => (value: SearchValues[K]) => void =
     useCallback(
       key => value => {
@@ -148,17 +154,33 @@ const ParameterProvider: FC<PropsWithChildren> = ({ children }) => {
           (pendingChanges.current as any)[key] = value ?? DEFAULT_VALUES[key] ?? null;
         }
 
-        if (key === 'span' && typeof value === 'string' && !value.endsWith('custom')) {
-          pendingChanges.current.startDate = null;
-          pendingChanges.current.endDate = null;
+        if (key === 'span' && typeof value === 'string') {
+          const prevSpan = prevSpanRef.current;
+          const isNowCustom = value === 'date.range.custom';
+          const wasCustom = prevSpan === 'date.range.custom';
+
+          // Clear custom dates
+          if (wasCustom && !isNowCustom) {
+            _setValues(current => ({
+              ...current,
+              span: value,
+              startDate: null as any,
+              endDate: null as any
+            }));
+
+            pendingChanges.current.startDate = null;
+            pendingChanges.current.endDate = null;
+
+            prevSpanRef.current = value;
+            // state updated leave
+            return;
+          }
+
+          prevSpanRef.current = value;
         }
 
         WRITE_THROTTLER.debounce(() => {
-          _setValues(current => ({
-            ...current,
-            ...pendingChanges.current
-          }));
-
+          _setValues(_current => ({ ..._current, ...pendingChanges.current }));
           pendingChanges.current = {};
         });
       },
@@ -289,28 +311,6 @@ const ParameterProvider: FC<PropsWithChildren> = ({ children }) => {
         }
       }
     });
-    const spanValue = values.span;
-    const isCustomSpan = spanValue === 'date.range.custom';
-
-    const urlSpan = params.get('span');
-
-    if (spanValue !== urlSpan) {
-      (changes as any).span = spanValue;
-    }
-
-    // Only emit dates if custom
-    if (isCustomSpan) {
-      if (values.startDate) {
-        (changes as any).start_date = values.startDate;
-      }
-
-      if (values.endDate) {
-        (changes as any).end_date = values.endDate;
-      }
-    } else {
-      (changes as any).start_date = null;
-      (changes as any).end_date = null;
-    }
 
     // Handle filters: compare arrays with isEqual
     const urlFilters = params.getAll('filter');
@@ -352,6 +352,27 @@ const ParameterProvider: FC<PropsWithChildren> = ({ children }) => {
     });
   }, [values, params, location.pathname]);
 
+  useEffect(() => {
+    const changes = getUrlFromState();
+    if (isEmpty(changes)) return;
+
+    syncSource.current = 'state';
+
+    setParams(_params => {
+      const newParams = new URLSearchParams(_params);
+
+      Object.entries(changes).forEach(([key, value]) => {
+        if (value === null || value === undefined) {
+          newParams.delete(key);
+        } else {
+          newParams.set(key, String(value));
+        }
+      });
+
+      return newParams;
+    });
+  }, [getUrlFromState, setParams, values]);
+
   /**
    * Get state changes needed to sync URL parameters to internal state.
    */
@@ -359,34 +380,12 @@ const ParameterProvider: FC<PropsWithChildren> = ({ children }) => {
     const changes: Partial<SearchValues> = {};
 
     PARAM_MAPPINGS.forEach(([urlKey, stateKey]) => {
-      const urlValue = params.has(urlKey) ? params.get(urlKey) : (DEFAULT_VALUES[stateKey] ?? null);
+      const urlValue = params.has(urlKey) ? params.get(urlKey) : (DEFAULT_VALUES[stateKey] ?? undefined);
 
       if (urlValue !== values[stateKey]) {
         (changes as any)[stateKey] = urlValue;
       }
     });
-    const isCustomSpan = params.get('span') === 'date.range.custom';
-
-    if (isCustomSpan) {
-      const start = params.get('start_date');
-      const end = params.get('end_date');
-
-      if (start !== values.startDate) {
-        changes.startDate = start;
-      }
-
-      if (end !== values.endDate) {
-        changes.endDate = end;
-      }
-    } else {
-      if (values.startDate !== null) {
-        changes.startDate = null;
-      }
-
-      if (values.endDate !== null) {
-        changes.endDate = null;
-      }
-    }
 
     // Handle filters: compare arrays with isEqual
     const urlFilters = uniq(params.getAll('filter'));
@@ -419,13 +418,14 @@ const ParameterProvider: FC<PropsWithChildren> = ({ children }) => {
   /**
    * Effect to synchronize the context's state with the address bar
    */
+  const lastUpdateSource = useRef<'url' | 'state' | null>(null);
   useEffect(() => {
     const changes = getUrlFromState();
 
     if (isEmpty(changes)) {
       return;
     }
-
+    lastUpdateSource.current = 'state';
     setParams(
       _params => {
         // Build fresh URLSearchParams from existing params
@@ -455,18 +455,24 @@ const ParameterProvider: FC<PropsWithChildren> = ({ children }) => {
     );
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [values]);
-
+  const syncLock = useRef(false);
   useEffect(() => {
+    if (syncLock.current) return; // IMPORTANT GUARD
+
     const changes = getStateFromUrl();
 
     if (isEmpty(changes)) {
       return;
     }
+    syncLock.current = true;
 
     _setValues(_current => ({
       ..._current,
       ...changes
     }));
+    requestAnimationFrame(() => {
+      lastUpdateSource.current = null;
+    });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [location.search, location.pathname, routeParams.id]);
 

--- a/ui/src/components/app/providers/ParameterProvider.tsx
+++ b/ui/src/components/app/providers/ParameterProvider.tsx
@@ -121,7 +121,6 @@ const ParameterProvider: FC<PropsWithChildren> = ({ children }) => {
     offset: parseOffset(params.get('offset')),
     trackTotalHits: (params.get('track_total_hits') ?? 'false') !== 'false'
   });
-  const syncSource = useRef<'state' | 'url' | null>(null);
   const prevSpanRef = useRef<string | null>(null);
 
   useEffect(() => {
@@ -355,8 +354,6 @@ const ParameterProvider: FC<PropsWithChildren> = ({ children }) => {
   useEffect(() => {
     const changes = getUrlFromState();
     if (isEmpty(changes)) return;
-
-    syncSource.current = 'state';
 
     setParams(_params => {
       const newParams = new URLSearchParams(_params);

--- a/ui/src/components/app/providers/ParameterProvider.tsx
+++ b/ui/src/components/app/providers/ParameterProvider.tsx
@@ -64,7 +64,9 @@ const DEFAULT_VALUES: Partial<SearchValues> = {
 const PARAM_MAPPINGS: [string, keyof SearchValues][] = [
   ['query', 'query'],
   ['sort', 'sort'],
-  ['span', 'span']
+  ['span', 'span'],
+  ['start_date', 'startDate'],
+  ['end_date', 'endDate']
 ];
 const WRITE_THROTTLER = new Throttler(100);
 
@@ -154,13 +156,7 @@ const ParameterProvider: FC<PropsWithChildren> = ({ children }) => {
         WRITE_THROTTLER.debounce(() => {
           _setValues(current => ({
             ...current,
-            ...pendingChanges.current,
-            ...(key === 'span' && typeof value === 'string' && !value.endsWith('custom')
-              ? {
-                  startDate: null,
-                  endDate: null
-                }
-              : {})
+            ...pendingChanges.current
           }));
 
           pendingChanges.current = {};
@@ -375,12 +371,20 @@ const ParameterProvider: FC<PropsWithChildren> = ({ children }) => {
       const start = params.get('start_date');
       const end = params.get('end_date');
 
-      if (start && start !== values.startDate) {
-        (changes as any).startDate = start;
+      if (start !== values.startDate) {
+        changes.startDate = start;
       }
 
-      if (end && end !== values.endDate) {
-        (changes as any).endDate = end;
+      if (end !== values.endDate) {
+        changes.endDate = end;
+      }
+    } else {
+      if (values.startDate !== null) {
+        changes.startDate = null;
+      }
+
+      if (values.endDate !== null) {
+        changes.endDate = null;
       }
     }
 

--- a/ui/src/components/app/providers/ParameterProvider.tsx
+++ b/ui/src/components/app/providers/ParameterProvider.tsx
@@ -64,11 +64,8 @@ const DEFAULT_VALUES: Partial<SearchValues> = {
 const PARAM_MAPPINGS: [string, keyof SearchValues][] = [
   ['query', 'query'],
   ['sort', 'sort'],
-  ['span', 'span'],
-  ['start_date', 'startDate'],
-  ['end_date', 'endDate']
+  ['span', 'span']
 ];
-
 const WRITE_THROTTLER = new Throttler(100);
 
 /**
@@ -150,12 +147,22 @@ const ParameterProvider: FC<PropsWithChildren> = ({ children }) => {
         }
 
         if (key === 'span' && typeof value === 'string' && !value.endsWith('custom')) {
-          pendingChanges.current.startDate = null;
-          pendingChanges.current.endDate = null;
+          pendingChanges.current.startDate = undefined;
+          pendingChanges.current.endDate = undefined;
         }
 
         WRITE_THROTTLER.debounce(() => {
-          _setValues(_current => ({ ..._current, ...pendingChanges.current }));
+          _setValues(current => ({
+            ...current,
+            ...pendingChanges.current,
+            ...(key === 'span' && typeof value === 'string' && !value.endsWith('custom')
+              ? {
+                  startDate: undefined,
+                  endDate: undefined
+                }
+              : {})
+          }));
+
           pendingChanges.current = {};
         });
       },
@@ -286,6 +293,28 @@ const ParameterProvider: FC<PropsWithChildren> = ({ children }) => {
         }
       }
     });
+    const spanValue = values.span;
+    const isCustomSpan = spanValue === 'date.range.custom';
+
+    const urlSpan = params.get('span');
+
+    if (spanValue !== urlSpan) {
+      (changes as any).span = spanValue;
+    }
+
+    // Only emit dates if custom
+    if (isCustomSpan) {
+      if (values.startDate) {
+        (changes as any).start_date = values.startDate;
+      }
+
+      if (values.endDate) {
+        (changes as any).end_date = values.endDate;
+      }
+    } else {
+      (changes as any).start_date = null;
+      (changes as any).end_date = null;
+    }
 
     // Handle filters: compare arrays with isEqual
     const urlFilters = params.getAll('filter');
@@ -340,6 +369,20 @@ const ParameterProvider: FC<PropsWithChildren> = ({ children }) => {
         (changes as any)[stateKey] = urlValue;
       }
     });
+    const isCustomSpan = params.get('span') === 'date.range.custom';
+
+    if (isCustomSpan) {
+      const start = params.get('start_date');
+      const end = params.get('end_date');
+
+      if (start && start !== values.startDate) {
+        (changes as any).startDate = start;
+      }
+
+      if (end && end !== values.endDate) {
+        (changes as any).endDate = end;
+      }
+    }
 
     // Handle filters: compare arrays with isEqual
     const urlFilters = uniq(params.getAll('filter'));

--- a/ui/src/components/routes/hits/search/shared/SearchSpan.tsx
+++ b/ui/src/components/routes/hits/search/shared/SearchSpan.tsx
@@ -95,15 +95,9 @@ const SearchSpan: FC<{
             if (value !== 'date.range.custom') {
               // 1. Create a fresh copy of current params
               const newParams = new URLSearchParams(params);
-
-              // 2. Set the span to the relative value (1 day, 1 week, etc.)
               newParams.set('span', value);
-
-              // 3. EXPLICITLY REMOVE the custom dates from the URL
               newParams.delete('start_date');
               newParams.delete('end_date');
-
-              // 4. Push the clean URL back to the browser
               setParams(newParams);
             } else {
               // If they actually want custom, let the provider handle it

--- a/ui/src/components/routes/hits/search/shared/SearchSpan.tsx
+++ b/ui/src/components/routes/hits/search/shared/SearchSpan.tsx
@@ -7,7 +7,7 @@ import dayjs from 'dayjs';
 import type { FC } from 'react';
 import { memo, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useLocation, useSearchParams } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 import { useContextSelector } from 'use-context-selector';
 import { convertLuceneToDate } from 'utils/utils';
 import CustomSpan from './CustomSpan';
@@ -27,7 +27,7 @@ const SearchSpan: FC<{
 }> = ({ omitCustom = false, size }) => {
   const { t } = useTranslation();
   const location = useLocation();
-  const [params, setParams] = useSearchParams();
+
   const views = useContextSelector(ParameterContext, ctx => ctx.views);
   const span = useContextSelector(ParameterContext, ctx => ctx.span);
   const setSpan = useContextSelector(ParameterContext, ctx => ctx.setSpan);
@@ -85,20 +85,7 @@ const SearchSpan: FC<{
           options={omitCustom ? DATE_RANGES.slice(0, DATE_RANGES.length - 1) : DATE_RANGES}
           renderInput={_params => <TextField {..._params} label={t('hit.search.span')} />}
           getOptionLabel={option => t(option)}
-          onChange={(_, value) => {
-            if (!value) return;
-
-            if (value !== 'date.range.custom') {
-              // Create a fresh copy of current params
-              const newParams = new URLSearchParams(params);
-              newParams.set('span', value);
-              newParams.delete('start_date');
-              newParams.delete('end_date');
-              setParams(newParams);
-            } else {
-              setSpan(value);
-            }
-          }}
+          onChange={(_, value) => setSpan(value)}
           disableClearable
         />
 

--- a/ui/src/components/routes/hits/search/shared/SearchSpan.tsx
+++ b/ui/src/components/routes/hits/search/shared/SearchSpan.tsx
@@ -64,9 +64,6 @@ const SearchSpan: FC<{
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [getCurrentViews, views]);
 
-  // TODO : AG : here rely the bug
-  // I think its looking at the url or a variable and see something is already there thus custom
-  // I'll try that in next update
   return (
     <ChipPopper
       icon={<AvTimer fontSize="small" />}
@@ -87,7 +84,7 @@ const SearchSpan: FC<{
           size={size ?? 'small'}
           value={span}
           options={omitCustom ? DATE_RANGES.slice(0, DATE_RANGES.length - 1) : DATE_RANGES}
-          renderInput={_params => <TextField {..._params} label={t('hit.search.span')} />} // here ?
+          renderInput={_params => <TextField {..._params} label={t('hit.search.span')} />}
           getOptionLabel={option => t(option)}
           onChange={(_, value) => {
             if (!value) return;

--- a/ui/src/components/routes/hits/search/shared/SearchSpan.tsx
+++ b/ui/src/components/routes/hits/search/shared/SearchSpan.tsx
@@ -63,6 +63,7 @@ const SearchSpan: FC<{
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [getCurrentViews, views]);
 
+  // TODO : AG : here rely the bug
   return (
     <ChipPopper
       icon={<AvTimer fontSize="small" />}

--- a/ui/src/components/routes/hits/search/shared/SearchSpan.tsx
+++ b/ui/src/components/routes/hits/search/shared/SearchSpan.tsx
@@ -39,7 +39,6 @@ const SearchSpan: FC<{
     ctx.startDate ? dayjs(ctx.startDate) : defaultStartDate
   );
   const endDate = useContextSelector(ParameterContext, ctx => (ctx.endDate ? dayjs(ctx.endDate) : defaultEndDate));
-  const setCustomSpan = useContextSelector(ParameterContext, ctx => ctx.setCustomSpan); // Add this
 
   const getCurrentViews = useContextSelector(ViewContext, ctx => ctx.getCurrentViews);
 

--- a/ui/src/components/routes/hits/search/shared/SearchSpan.tsx
+++ b/ui/src/components/routes/hits/search/shared/SearchSpan.tsx
@@ -27,7 +27,7 @@ const SearchSpan: FC<{
 }> = ({ omitCustom = false, size }) => {
   const { t } = useTranslation();
   const location = useLocation();
-  const [params, setParams] = useSearchParams(); // Add this at the top of the component
+  const [params, setParams] = useSearchParams();
   const views = useContextSelector(ParameterContext, ctx => ctx.views);
   const span = useContextSelector(ParameterContext, ctx => ctx.span);
   const setSpan = useContextSelector(ParameterContext, ctx => ctx.setSpan);

--- a/ui/src/components/routes/hits/search/shared/SearchSpan.tsx
+++ b/ui/src/components/routes/hits/search/shared/SearchSpan.tsx
@@ -89,17 +89,16 @@ const SearchSpan: FC<{
             if (!value) return;
 
             if (value !== 'date.range.custom') {
-              // 1. Create a fresh copy of current params
+              // Create a fresh copy of current params
               const newParams = new URLSearchParams(params);
               newParams.set('span', value);
               newParams.delete('start_date');
               newParams.delete('end_date');
               setParams(newParams);
             } else {
-              // If they actually want custom, let the provider handle it
               setSpan(value);
             }
-          }} // Got to find a way to clear the url
+          }}
           disableClearable
         />
 

--- a/ui/src/components/routes/hits/search/shared/SearchSpan.tsx
+++ b/ui/src/components/routes/hits/search/shared/SearchSpan.tsx
@@ -7,7 +7,7 @@ import dayjs from 'dayjs';
 import type { FC } from 'react';
 import { memo, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useLocation } from 'react-router-dom';
+import { useLocation, useSearchParams } from 'react-router-dom';
 import { useContextSelector } from 'use-context-selector';
 import { convertLuceneToDate } from 'utils/utils';
 import CustomSpan from './CustomSpan';
@@ -27,7 +27,7 @@ const SearchSpan: FC<{
 }> = ({ omitCustom = false, size }) => {
   const { t } = useTranslation();
   const location = useLocation();
-
+  const [params, setParams] = useSearchParams(); // Add this at the top of the component
   const views = useContextSelector(ParameterContext, ctx => ctx.views);
   const span = useContextSelector(ParameterContext, ctx => ctx.span);
   const setSpan = useContextSelector(ParameterContext, ctx => ctx.setSpan);
@@ -39,6 +39,7 @@ const SearchSpan: FC<{
     ctx.startDate ? dayjs(ctx.startDate) : defaultStartDate
   );
   const endDate = useContextSelector(ParameterContext, ctx => (ctx.endDate ? dayjs(ctx.endDate) : defaultEndDate));
+  const setCustomSpan = useContextSelector(ParameterContext, ctx => ctx.setCustomSpan); // Add this
 
   const getCurrentViews = useContextSelector(ViewContext, ctx => ctx.getCurrentViews);
 
@@ -64,6 +65,8 @@ const SearchSpan: FC<{
   }, [getCurrentViews, views]);
 
   // TODO : AG : here rely the bug
+  // I think its looking at the url or a variable and see something is already there thus custom
+  // I'll try that in next update
   return (
     <ChipPopper
       icon={<AvTimer fontSize="small" />}
@@ -84,9 +87,29 @@ const SearchSpan: FC<{
           size={size ?? 'small'}
           value={span}
           options={omitCustom ? DATE_RANGES.slice(0, DATE_RANGES.length - 1) : DATE_RANGES}
-          renderInput={_params => <TextField {..._params} label={t('hit.search.span')} />}
+          renderInput={_params => <TextField {..._params} label={t('hit.search.span')} />} // here ?
           getOptionLabel={option => t(option)}
-          onChange={(_, value) => setSpan(value)}
+          onChange={(_, value) => {
+            if (!value) return;
+
+            if (value !== 'date.range.custom') {
+              // 1. Create a fresh copy of current params
+              const newParams = new URLSearchParams(params);
+
+              // 2. Set the span to the relative value (1 day, 1 week, etc.)
+              newParams.set('span', value);
+
+              // 3. EXPLICITLY REMOVE the custom dates from the URL
+              newParams.delete('start_date');
+              newParams.delete('end_date');
+
+              // 4. Push the clean URL back to the browser
+              setParams(newParams);
+            } else {
+              // If they actually want custom, let the provider handle it
+              setSpan(value);
+            }
+          }}
           disableClearable
         />
 

--- a/ui/src/components/routes/hits/search/shared/SearchSpan.tsx
+++ b/ui/src/components/routes/hits/search/shared/SearchSpan.tsx
@@ -109,7 +109,7 @@ const SearchSpan: FC<{
               // If they actually want custom, let the provider handle it
               setSpan(value);
             }
-          }}
+          }} // Got to find a way to clear the url
           disableClearable
         />
 


### PR DESCRIPTION
Fixed the bug when passing from custom time to pre determine time. 

made dynamic what parameter are showed in the URI and solve a race condition to allow the return from custom to pre made times ( 1 day ago, 1 week ago etc. ) 

ensured URI stayed clean such as removing the start and end date for the pre determine time period and add it back for the custom time to ensure sharing the URL still work. 