### PR TITLE
fix(ui): persist template edits on tab change

### DIFF
--- a/ui/src/components/routes/templates/TemplateViewer.tsx
+++ b/ui/src/components/routes/templates/TemplateViewer.tsx
@@ -166,9 +166,29 @@ const TemplateViewer = () => {
       showError: true,
       throwError: false
     });
-    setSelectedTemplate(null);
-    setDisplayFields(DEFAULT_FIELDS);
-  }, [dispatchApi, selectedTemplate?.template_id]);
+    setSessionTemplateList(l =>
+      l.filter(
+        v =>
+          v.analytic != selectedTemplate.analytic ||
+          v.detection != selectedTemplate.detection ||
+          v.type != selectedTemplate.type
+      )
+    );
+    setTemplateList(l =>
+      l.filter(
+        v =>
+          v.analytic != selectedTemplate.analytic ||
+          v.detection != selectedTemplate.detection ||
+          v.type != selectedTemplate.type
+      )
+    );
+  }, [
+    dispatchApi,
+    selectedTemplate?.analytic,
+    selectedTemplate?.detection,
+    selectedTemplate?.template_id,
+    selectedTemplate?.type
+  ]);
 
   const onSave = useCallback(async () => {
     if (analytic && detection) {

--- a/ui/src/components/routes/templates/TemplateViewer.tsx
+++ b/ui/src/components/routes/templates/TemplateViewer.tsx
@@ -212,25 +212,27 @@ const TemplateViewer = () => {
 
   const onTypeToggle = useCallback(
     (_type: string) => {
-      if (!noFieldChange) {
-        const sessionTemplate = {
-          analytic: analytic,
-          detection: detection !== 'ANY' ? detection : null,
-          type: type,
-          keys: displayFields
-        };
-        const newList = [sessionTemplate, ...sessionTemplateList];
-        setSessionTemplateList(
-          newList.filter(
-            (v1, i) =>
-              newList.findIndex(
-                v2 => v1.analytic === v2.analytic && v1.detection === v2.detection && v1.type === v2.type
-              ) === i
-          )
-        );
+      setType(_type);
+
+      if (noFieldChange) {
+        return;
       }
 
-      setType(_type);
+      const sessionTemplate = {
+        analytic: analytic,
+        detection: detection !== 'ANY' ? detection : null,
+        type: type,
+        keys: displayFields
+      };
+      const newList = [sessionTemplate, ...sessionTemplateList];
+      setSessionTemplateList(
+        newList.filter(
+          (v1, i) =>
+            newList.findIndex(
+              v2 => v1.analytic === v2.analytic && v1.detection === v2.detection && v1.type === v2.type
+            ) === i
+        )
+      );
     },
     [analytic, detection, displayFields, noFieldChange, sessionTemplateList, type]
   );

--- a/ui/src/components/routes/templates/TemplateViewer.tsx
+++ b/ui/src/components/routes/templates/TemplateViewer.tsx
@@ -36,6 +36,7 @@ const TemplateViewer = () => {
 
   const [templateList, setTemplateList] = useState<Template[]>([]);
   const [selectedTemplate, setSelectedTemplate] = useState<Template>(null);
+  const [sessionTemplateList, setSessionTemplateList] = useState<Template[]>([]);
   const [displayFields, setDisplayFields] = useState<string[]>([]);
 
   const [analytics, setAnalytics] = useState<Analytic[]>([]);
@@ -104,22 +105,28 @@ const TemplateViewer = () => {
 
   useEffect(() => {
     if (analytic && detection) {
-      const template = (templateList ?? []).find(
-        _template =>
-          _template.analytic === analytic &&
-          ((detection === 'ANY' && !_template.detection) || _template.detection === detection) &&
-          _template.type === type
-      );
+      const findTemplate = (_templateList: Template[]) =>
+        (_templateList ?? []).find(
+          _template =>
+            _template.analytic === analytic &&
+            ((detection === 'ANY' && !_template.detection) || _template.detection === detection) &&
+            _template.type === type
+        );
+
+      const template = findTemplate(templateList);
+
+      // check if a template has been modified in the session but not saved to the datastore
+      const sessionTemplate = findTemplate(sessionTemplateList);
 
       if (template) {
         setSelectedTemplate(template);
-        setDisplayFields(template.keys);
+        setDisplayFields(sessionTemplate ? sessionTemplate.keys : template.keys);
       } else {
         setSelectedTemplate(null);
-        setDisplayFields(DEFAULT_FIELDS);
+        setDisplayFields(sessionTemplate ? sessionTemplate.keys : DEFAULT_FIELDS);
       }
     }
-  }, [analytic, detection, templateList, type]);
+  }, [analytic, detection, sessionTemplateList, templateList, type]);
 
   useEffect(() => {
     if (analytic) {
@@ -198,6 +205,31 @@ const TemplateViewer = () => {
     [displayFields, selectedTemplate?.keys]
   );
 
+  const onTypeToggle = useCallback(
+    (_type: string) => {
+      if (!noFieldChange) {
+        const sessionTemplate = {
+          analytic: analytic,
+          detection: detection !== 'ANY' ? detection : null,
+          type: type,
+          keys: displayFields
+        };
+        const newList = [sessionTemplate, ...sessionTemplateList];
+        setSessionTemplateList(
+          newList.filter(
+            (v1, i) =>
+              newList.findIndex(
+                v2 => v1.analytic === v2.analytic && v1.detection === v2.detection && v1.type === v2.type
+              ) === i
+          )
+        );
+      }
+
+      setType(_type);
+    },
+    [analytic, detection, displayFields, noFieldChange, sessionTemplateList, type]
+  );
+
   return (
     <PageCenter maxWidth="1500px" textAlign="left" height="100%">
       <LinearProgress sx={{ mb: 1, opacity: +loading }} />
@@ -209,7 +241,10 @@ const TemplateViewer = () => {
               options={analytics.sort((a, b) => a.name.toLowerCase().localeCompare(b.name.toLowerCase()))}
               getOptionLabel={option => option.name}
               value={analytics.find(a => a.name === analytic) || null}
-              onChange={(__, newValue) => setAnalytic(newValue ? newValue.name : '')}
+              onChange={(__, newValue) => {
+                setAnalytic(newValue ? newValue.name : '');
+                setSessionTemplateList([]); // do not keep session memory if analytic or detection is changed
+              }}
               renderInput={autocompleteAnalyticParams => (
                 <TextField {...autocompleteAnalyticParams} label={t('route.templates.analytic')} size="small" />
               )}
@@ -222,7 +257,10 @@ const TemplateViewer = () => {
                 options={['ANY', ...detections.sort()]}
                 getOptionLabel={option => option}
                 value={detection ?? ''}
-                onChange={(__, newValue) => setDetection(newValue)}
+                onChange={(__, newValue) => {
+                  setDetection(newValue);
+                  setSessionTemplateList([]); // do not keep session memory if analytic or detection is changed
+                }}
                 renderInput={autocompleteDetectionParams => (
                   <TextField {...autocompleteDetectionParams} label={t('route.templates.detection')} size="small" />
                 )}
@@ -241,7 +279,7 @@ const TemplateViewer = () => {
             disabled={analyticOrDetectionMissing}
             onChange={(__, _type) => {
               if (_type) {
-                setType(_type);
+                onTypeToggle(_type);
               }
             }}
           >

--- a/ui/src/components/routes/templates/TemplateViewer.tsx
+++ b/ui/src/components/routes/templates/TemplateViewer.tsx
@@ -193,11 +193,16 @@ const TemplateViewer = () => {
         setSelectedTemplate(result);
         const newList = [result, ...templateList];
         setTemplateList(newList.filter((v1, i) => newList.findIndex(v2 => v1.template_id === v2.template_id) === i));
+
+        const updatedSessionList = sessionTemplateList.filter(
+          v => v.analytic !== result.analytic || v.detection !== result.detection || v.type !== result.type
+        );
+        setSessionTemplateList(updatedSessionList);
       } finally {
         setTemplateLoading(false);
       }
     }
-  }, [analytic, detection, dispatchApi, displayFields, selectedTemplate, templateList, type]);
+  }, [analytic, detection, dispatchApi, displayFields, selectedTemplate, sessionTemplateList, templateList, type]);
 
   const analyticOrDetectionMissing = useMemo(() => !analytic || !detection, [analytic, detection]);
   const noFieldChange = useMemo(


### PR DESCRIPTION
In the template editor, remember user changes to keys (adding or deleting) when the user switches the tab between personal and global views. The active changes are *not* copied over to the new view. When the user switches back to the tab, the changes are restored.

When the selected analytic or detection is changed, any memory of active changes is cleared. 

**Changes:**

TemplateViewer:
- add a new state `sessionTemplateList` to hold active changes to a template that haven't been saved
- in the toggle click callback check if there are changes to the current template and save them in the `sessionTemplateList` state
- in the template loading effect, display the saved session keys if they exist