### PR TITLE
feat(config): add option to disable eureka discovery

### DIFF
--- a/api/howler/helper/discover.py
+++ b/api/howler/helper/discover.py
@@ -17,7 +17,7 @@ def get_apps_list(discovery_url: Optional[str]) -> list[dict[str, str]]:
     Returns:
         list[dict[str, str]]: A list of other apps
     """
-    if config.core.disable_eureka_discovery:
+    if not config.core.enable_eureka_discovery or discovery_url is None:
         return []
 
     if discovery_url not in DISCO_CACHE:

--- a/api/howler/helper/discover.py
+++ b/api/howler/helper/discover.py
@@ -17,6 +17,9 @@ def get_apps_list(discovery_url: Optional[str]) -> list[dict[str, str]]:
     Returns:
         list[dict[str, str]]: A list of other apps
     """
+    if config.core.disable_eureka_discovery:
+        return []
+
     if discovery_url not in DISCO_CACHE:
         apps = []
 

--- a/api/howler/helper/discover.py
+++ b/api/howler/helper/discover.py
@@ -17,7 +17,7 @@ def get_apps_list(discovery_url: Optional[str]) -> list[dict[str, str]]:
     Returns:
         list[dict[str, str]]: A list of other apps
     """
-    if not config.core.enable_eureka_discovery or discovery_url is None:
+    if not config.discovery.enabled or discovery_url is None:
         return []
 
     if discovery_url not in DISCO_CACHE:
@@ -28,7 +28,7 @@ def get_apps_list(discovery_url: Optional[str]) -> list[dict[str, str]]:
 
         try:
             resp = requests.get(
-                typing.cast(str, discovery_url or config.ui.discover_url),
+                typing.cast(str, discovery_url or config.discovery.url),
                 headers={"accept": "application/json"},
                 timeout=5,
             )

--- a/api/howler/odm/helper.py
+++ b/api/howler/odm/helper.py
@@ -31,7 +31,7 @@ from howler.security.utils import get_password_hash
 from howler.utils.constants import TESTING
 from howler.utils.uid import get_random_id
 
-APPS = get_apps_list(discovery_url=config.ui.discover_url)
+APPS = get_apps_list(discovery_url=config.discovery.url)
 ESCALATIONS = Escalation.list()
 EXAMPLE_ANALYTICS = ["Password Checker", "Bad Guy Finder", "Exploit Patcher"]
 

--- a/api/howler/odm/models/config.py
+++ b/api/howler/odm/models/config.py
@@ -478,6 +478,8 @@ class Core(BaseModel):
     notebook: Notebook = Notebook()
     "Configuration for Notebook Integration"
 
+    disable_eureka_discovery: bool = Field(default=False, description="Should Eureka discovery be disabled?")
+
 
 root_path = Path("/etc") / APP_NAME.replace("-dev", "").replace("-stg", "")
 

--- a/api/howler/odm/models/config.py
+++ b/api/howler/odm/models/config.py
@@ -478,7 +478,7 @@ class Core(BaseModel):
     notebook: Notebook = Notebook()
     "Configuration for Notebook Integration"
 
-    disable_eureka_discovery: bool = Field(default=False, description="Should Eureka discovery be disabled?")
+    enable_eureka_discovery: bool = Field(default=True, description="Should Eureka discovery be disabled?")
 
 
 root_path = Path("/etc") / APP_NAME.replace("-dev", "").replace("-stg", "")

--- a/api/howler/odm/models/config.py
+++ b/api/howler/odm/models/config.py
@@ -456,6 +456,18 @@ class Telemetry(BaseModel):
     )
 
 
+class Discovery(BaseModel):
+    """Service discovery configuration for Howler.
+
+    Defines settings for enabling and configuring service discovery,
+    allowing Howler instances to locate and communicate with each other
+    in distributed deployments.
+    """
+
+    url: Optional[str] = Field(default=None, description="Discovery URL")
+    enabled: bool = Field(default=False, description="Should discovery be enabled?")
+
+
 class Core(BaseModel):
     """Core application configuration for Howler.
 
@@ -540,6 +552,8 @@ class Config(BaseSettings):
     logging: Logging = Logging()
     system: System = System()
     ui: UI = UI()
+    discovery: Discovery = Discovery()
+
     mapping: dict[str, str] = Field(description="Mapping of alert keys to clue types", default={})
 
     model_config = SettingsConfigDict(

--- a/api/howler/security/utils.py
+++ b/api/howler/security/utils.py
@@ -182,6 +182,6 @@ def get_disco_url(host_url: Optional[str]):
 
             return f"https://{hostname}/eureka/apps"
         else:
-            return config.ui.discover_url
+            return config.discovery.url
     else:
-        return config.ui.discover_url
+        return config.discovery.url

--- a/api/test/unit/helper/test_discover.py
+++ b/api/test/unit/helper/test_discover.py
@@ -1,0 +1,43 @@
+from unittest.mock import patch
+
+from howler.config import config
+from howler.helper.discover import get_apps_list
+
+
+def test_get_apps_list_returns_empty_when_discovery_disabled():
+    """When enable_eureka_discovery is False, get_apps_list should return [] immediately."""
+    original = config.core.enable_eureka_discovery
+    try:
+        config.core.enable_eureka_discovery = False
+        result = get_apps_list(discovery_url="https://discover.example.com/eureka/apps")
+        assert result == []
+    finally:
+        config.core.enable_eureka_discovery = original
+
+
+def test_get_apps_list_returns_empty_when_discovery_url_is_none():
+    """When discovery_url is None, get_apps_list should return [] regardless of config."""
+    original = config.core.enable_eureka_discovery
+    try:
+        config.core.enable_eureka_discovery = True
+        result = get_apps_list(discovery_url=None)
+        assert result == []
+    finally:
+        config.core.enable_eureka_discovery = original
+
+
+@patch("howler.helper.discover.requests.get")
+def test_get_apps_list_calls_discovery_when_enabled(mock_get):
+    """When enable_eureka_discovery is True and a URL is provided, discovery is attempted."""
+    original = config.core.enable_eureka_discovery
+    try:
+        config.core.enable_eureka_discovery = True
+        mock_get.return_value.ok = True
+        mock_get.return_value.json.return_value = {"applications": {"application": []}}
+
+        # Use a unique URL to avoid cache hits
+        result = get_apps_list(discovery_url="https://discover.test-enabled.com/eureka/apps")
+        assert result == []
+        mock_get.assert_called_once()
+    finally:
+        config.core.enable_eureka_discovery = original

--- a/api/test/unit/helper/test_discover.py
+++ b/api/test/unit/helper/test_discover.py
@@ -6,32 +6,32 @@ from howler.helper.discover import get_apps_list
 
 def test_get_apps_list_returns_empty_when_discovery_disabled():
     """When enable_eureka_discovery is False, get_apps_list should return [] immediately."""
-    original = config.core.enable_eureka_discovery
+    original = config.discovery.enabled
     try:
-        config.core.enable_eureka_discovery = False
+        config.discovery.enabled = False
         result = get_apps_list(discovery_url="https://discover.example.com/eureka/apps")
         assert result == []
     finally:
-        config.core.enable_eureka_discovery = original
+        config.discovery.enabled = original
 
 
 def test_get_apps_list_returns_empty_when_discovery_url_is_none():
     """When discovery_url is None, get_apps_list should return [] regardless of config."""
-    original = config.core.enable_eureka_discovery
+    original = config.discovery.enabled
     try:
-        config.core.enable_eureka_discovery = True
+        config.discovery.enabled = True
         result = get_apps_list(discovery_url=None)
         assert result == []
     finally:
-        config.core.enable_eureka_discovery = original
+        config.discovery.enabled = original
 
 
 @patch("howler.helper.discover.requests.get")
 def test_get_apps_list_calls_discovery_when_enabled(mock_get):
     """When enable_eureka_discovery is True and a URL is provided, discovery is attempted."""
-    original = config.core.enable_eureka_discovery
+    original = config.discovery.enabled
     try:
-        config.core.enable_eureka_discovery = True
+        config.discovery.enabled = True
         mock_get.return_value.ok = True
         mock_get.return_value.json.return_value = {"applications": {"application": []}}
 
@@ -40,4 +40,4 @@ def test_get_apps_list_calls_discovery_when_enabled(mock_get):
         assert result == []
         mock_get.assert_called_once()
     finally:
-        config.core.enable_eureka_discovery = original
+        config.discovery.enabled = original

--- a/api/test/unit/services/test_config_service.py
+++ b/api/test/unit/services/test_config_service.py
@@ -32,7 +32,7 @@ def test_config_service_config_on_oauth():
 
 
 def test_config_service_apps_empty_when_eureka_disabled():
-    config.core.enable_eureka_discovery = False
+    config.discovery.enabled = False
 
     jwt_service.decode = MagicMock(return_value={"exp": time.timestamp()})
 
@@ -48,4 +48,4 @@ def test_config_service_apps_empty_when_eureka_disabled():
 
         assert result["configuration"]["ui"]["apps"] == []
 
-    config.core.enable_eureka_discovery = True
+    config.discovery.enabled = True

--- a/api/test/unit/services/test_config_service.py
+++ b/api/test/unit/services/test_config_service.py
@@ -29,3 +29,23 @@ def test_config_service_config_on_oauth():
 
         assert result["configuration"]["auth"]["max_apikey_duration_amount"] <= 10
         assert result["configuration"]["auth"]["max_apikey_duration_unit"] <= "seconds"
+
+
+def test_config_service_apps_empty_when_eureka_disabled():
+    config.core.enable_eureka_discovery = False
+
+    jwt_service.decode = MagicMock(return_value={"exp": time.timestamp()})
+
+    request = MagicMock()
+    request.headers = {"Authorization": "Bearer ."}
+
+    with mock.patch("howler.services.config_service.request", request):
+        from howler.services import config_service
+
+        result = config_service.get_configuration(
+            user=cast(User, None), discovery_url="https://discover.example.com/eureka/apps"
+        )
+
+        assert result["configuration"]["ui"]["apps"] == []
+
+    config.core.enable_eureka_discovery = True

--- a/api/test/unit/utils/test_disco_url.py
+++ b/api/test/unit/utils/test_disco_url.py
@@ -21,4 +21,4 @@ def test_local_url():
 
     converted_url = get_disco_url(url)
 
-    assert converted_url == config.ui.discover_url
+    assert converted_url == config.discovery.url


### PR DESCRIPTION
## Summary

Add a configuration option to disable Eureka service discovery, allowing deployments to opt out of Eureka registration/discovery when it is not needed or available.