### PR TITLE
feat(ui): add confirm dialogue before deletions

### DIFF
--- a/ui/src/components/app/providers/ModalProvider.tsx
+++ b/ui/src/components/app/providers/ModalProvider.tsx
@@ -1,3 +1,4 @@
+import ConfirmDeleteModal from 'components/elements/display/modals/ConfirmDeleteModal';
 import type { FC, PropsWithChildren, ReactNode } from 'react';
 import { createContext, useCallback, useEffect, useState } from 'react';
 
@@ -13,6 +14,7 @@ const defaultOptions: ModalOptions = {
 
 interface ModalContextType {
   showModal: (children: ReactNode, options?: ModalOptions) => () => void;
+  withConfirmDeleteModal: (onConfirm: () => void, preferDelete?: boolean, preferCancel?: boolean) => () => void;
   content?: ReactNode;
   setContent: (children: ReactNode) => void;
   options?: ModalOptions;
@@ -49,8 +51,19 @@ const ModalProvider: FC<PropsWithChildren> = ({ children }) => {
 
   const close = useCallback(() => setContent(null), []);
 
+  const withConfirmDeleteModal = useCallback(
+    (onConfirm: () => void, preferDelete?: boolean, preferCancel?: boolean) => {
+      return showModal(
+        <ConfirmDeleteModal onConfirm={onConfirm} preferDelete={preferDelete} preferCancel={preferCancel} />
+      );
+    },
+    [showModal]
+  );
+
   return (
-    <ModalContext.Provider value={{ showModal, content, setContent, options, close }}>{children}</ModalContext.Provider>
+    <ModalContext.Provider value={{ showModal, withConfirmDeleteModal, content, setContent, options, close }}>
+      {children}
+    </ModalContext.Provider>
   );
 };
 

--- a/ui/src/components/routes/action/view/ActionDetails.tsx
+++ b/ui/src/components/routes/action/view/ActionDetails.tsx
@@ -12,16 +12,18 @@ import {
 import api from 'api';
 import { useAppUser } from 'commons/components/app/hooks';
 import PageCenter from 'commons/components/pages/PageCenter';
+import { ModalContext } from 'components/app/providers/ModalProvider';
 import FlexOne from 'components/elements/addons/layout/FlexOne';
 import Phrase from 'components/elements/addons/search/phrase/Phrase';
 import HowlerAvatar from 'components/elements/display/HowlerAvatar';
+import ConfirmDeleteModal from 'components/elements/display/modals/ConfirmDeleteModal';
 import useMyApi from 'components/hooks/useMyApi';
 import OperationEntry from 'components/routes/action/shared/OperationEntry';
 import type { ActionOperation } from 'models/ActionTypes';
 import type { HowlerUser } from 'models/entities/HowlerUser';
 import type { Action } from 'models/entities/generated/Action';
 import howlerPluginStore from 'plugins/store';
-import { useCallback, useEffect, useState, type ChangeEventHandler } from 'react';
+import { useCallback, useContext, useEffect, useState, type ChangeEventHandler } from 'react';
 import { useTranslation } from 'react-i18next';
 import { usePluginStore } from 'react-pluggable';
 import { Link, useParams } from 'react-router-dom';
@@ -42,6 +44,8 @@ const ActionDetails = () => {
 
   const [operations, setOperations] = useState<ActionOperation[]>([]);
   const [action, setAction] = useState<Action>();
+
+  const { showModal } = useContext(ModalContext);
 
   const onTriggerChange: ChangeEventHandler<HTMLInputElement> = useCallback(
     async e => {
@@ -121,7 +125,7 @@ const ActionDetails = () => {
               size="small"
               variant="outlined"
               color="error"
-              onClick={() => deleteAction(action?.action_id)}
+              onClick={() => showModal(<ConfirmDeleteModal onConfirm={() => deleteAction(action?.action_id)} />)}
             >
               {t('button.delete')}
             </Button>

--- a/ui/src/components/routes/action/view/ActionDetails.tsx
+++ b/ui/src/components/routes/action/view/ActionDetails.tsx
@@ -16,7 +16,6 @@ import { ModalContext } from 'components/app/providers/ModalProvider';
 import FlexOne from 'components/elements/addons/layout/FlexOne';
 import Phrase from 'components/elements/addons/search/phrase/Phrase';
 import HowlerAvatar from 'components/elements/display/HowlerAvatar';
-import ConfirmDeleteModal from 'components/elements/display/modals/ConfirmDeleteModal';
 import useMyApi from 'components/hooks/useMyApi';
 import OperationEntry from 'components/routes/action/shared/OperationEntry';
 import type { ActionOperation } from 'models/ActionTypes';
@@ -45,7 +44,7 @@ const ActionDetails = () => {
   const [operations, setOperations] = useState<ActionOperation[]>([]);
   const [action, setAction] = useState<Action>();
 
-  const { showModal } = useContext(ModalContext);
+  const { withConfirmDeleteModal } = useContext(ModalContext);
 
   const onTriggerChange: ChangeEventHandler<HTMLInputElement> = useCallback(
     async e => {
@@ -125,7 +124,7 @@ const ActionDetails = () => {
               size="small"
               variant="outlined"
               color="error"
-              onClick={() => showModal(<ConfirmDeleteModal onConfirm={() => deleteAction(action?.action_id)} />)}
+              onClick={() => withConfirmDeleteModal(() => deleteAction(action?.action_id))}
             >
               {t('button.delete')}
             </Button>

--- a/ui/src/components/routes/action/view/ActionSearch.tsx
+++ b/ui/src/components/routes/action/view/ActionSearch.tsx
@@ -17,7 +17,7 @@ import type { HowlerSearchResponse } from 'api/search';
 import { useAppUser } from 'commons/components/app/hooks';
 import { ModalContext } from 'components/app/providers/ModalProvider';
 import FlexOne from 'components/elements/addons/layout/FlexOne';
-import { TuiListProvider, type TuiListItem, type TuiListItemProps } from 'components/elements/addons/lists';
+import { TuiListProvider, type TuiListItemProps } from 'components/elements/addons/lists';
 import { TuiListMethodContext } from 'components/elements/addons/lists/TuiListProvider';
 import HowlerAvatar from 'components/elements/display/HowlerAvatar';
 import ItemManager from 'components/elements/display/ItemManager';
@@ -98,12 +98,20 @@ const ActionSearch: FC = () => {
     [offset, searchParams, setSearchParams]
   );
 
-  const onDeleteAction = useCallback(
-    async (item: TuiListItem<Action>) => {
-      await deleteAction(item.item.action_id);
-      onSearch();
+  const onDelete = useCallback(
+    (e: MouseEvent, actionId: string) => {
+      e.preventDefault();
+      e.stopPropagation();
+      showModal(
+        <ConfirmDeleteModal
+          onConfirm={async () => {
+            await deleteAction(actionId);
+            onSearch();
+          }}
+        />
+      );
     },
-    [deleteAction, onSearch]
+    [deleteAction, onSearch, showModal]
   );
 
   // Effect to initialize list of users.
@@ -177,14 +185,7 @@ const ActionSearch: FC = () => {
                 )}
                 <FlexOne />
                 {((item.item.owner_id === user.username && editRoles) || user.roles?.includes('admin')) && (
-                  <IconButton
-                    size="small"
-                    onClick={(e: MouseEvent) => {
-                      e.preventDefault();
-                      e.stopPropagation();
-                      showModal(<ConfirmDeleteModal onConfirm={() => onDeleteAction(item)} />);
-                    }}
-                  >
+                  <IconButton size="small" onClick={e => onDelete(e, item.item.action_id)}>
                     <Delete />
                   </IconButton>
                 )}
@@ -208,7 +209,7 @@ const ActionSearch: FC = () => {
         </Card>
       );
     },
-    [editRoles, navigate, onDeleteAction, showModal, t, user.roles, user.username]
+    [editRoles, navigate, onDelete, t, user.roles, user.username]
   );
 
   return (

--- a/ui/src/components/routes/action/view/ActionSearch.tsx
+++ b/ui/src/components/routes/action/view/ActionSearch.tsx
@@ -15,16 +15,18 @@ import {
 import api from 'api';
 import type { HowlerSearchResponse } from 'api/search';
 import { useAppUser } from 'commons/components/app/hooks';
+import { ModalContext } from 'components/app/providers/ModalProvider';
 import FlexOne from 'components/elements/addons/layout/FlexOne';
-import { TuiListProvider, type TuiListItemProps } from 'components/elements/addons/lists';
+import { TuiListProvider, type TuiListItem, type TuiListItemProps } from 'components/elements/addons/lists';
 import { TuiListMethodContext } from 'components/elements/addons/lists/TuiListProvider';
 import HowlerAvatar from 'components/elements/display/HowlerAvatar';
 import ItemManager from 'components/elements/display/ItemManager';
+import ConfirmDeleteModal from 'components/elements/display/modals/ConfirmDeleteModal';
 import useMyApi from 'components/hooks/useMyApi';
 import { useMyLocalStorageItem } from 'components/hooks/useMyLocalStorage';
 import type { HowlerUser } from 'models/entities/HowlerUser';
 import type { Action } from 'models/entities/generated/Action';
-import { useCallback, useContext, useEffect, useState, type FC } from 'react';
+import { useCallback, useContext, useEffect, useState, type FC, type MouseEvent } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { StorageKey, VALID_ACTION_TRIGGERS } from 'utils/constants';
@@ -37,6 +39,7 @@ const ActionSearch: FC = () => {
   const { user } = useAppUser<HowlerUser>();
   const { dispatchApi } = useMyApi();
   const { load } = useContext(TuiListMethodContext);
+  const { showModal } = useContext(ModalContext);
   const [searchParams, setSearchParams] = useSearchParams();
   const { deleteAction } = useMyActionFunctions();
   const pageCount = useMyLocalStorageItem(StorageKey.PAGE_COUNT, 25)[0];
@@ -93,6 +96,14 @@ const ActionSearch: FC = () => {
       }
     },
     [offset, searchParams, setSearchParams]
+  );
+
+  const onDeleteAction = useCallback(
+    async (item: TuiListItem<Action>) => {
+      await deleteAction(item.item.action_id);
+      onSearch();
+    },
+    [deleteAction, onSearch]
   );
 
   // Effect to initialize list of users.
@@ -168,11 +179,10 @@ const ActionSearch: FC = () => {
                 {((item.item.owner_id === user.username && editRoles) || user.roles?.includes('admin')) && (
                   <IconButton
                     size="small"
-                    onClick={async e => {
+                    onClick={(e: MouseEvent) => {
                       e.preventDefault();
                       e.stopPropagation();
-                      await deleteAction(item.item.action_id);
-                      onSearch();
+                      showModal(<ConfirmDeleteModal onConfirm={() => onDeleteAction(item)} />);
                     }}
                   >
                     <Delete />
@@ -198,7 +208,7 @@ const ActionSearch: FC = () => {
         </Card>
       );
     },
-    [deleteAction, editRoles, navigate, onSearch, t, user.roles, user.username]
+    [editRoles, navigate, onDeleteAction, showModal, t, user.roles, user.username]
   );
 
   return (

--- a/ui/src/components/routes/action/view/ActionSearch.tsx
+++ b/ui/src/components/routes/action/view/ActionSearch.tsx
@@ -21,7 +21,6 @@ import { TuiListProvider, type TuiListItemProps } from 'components/elements/addo
 import { TuiListMethodContext } from 'components/elements/addons/lists/TuiListProvider';
 import HowlerAvatar from 'components/elements/display/HowlerAvatar';
 import ItemManager from 'components/elements/display/ItemManager';
-import ConfirmDeleteModal from 'components/elements/display/modals/ConfirmDeleteModal';
 import useMyApi from 'components/hooks/useMyApi';
 import { useMyLocalStorageItem } from 'components/hooks/useMyLocalStorage';
 import type { HowlerUser } from 'models/entities/HowlerUser';
@@ -39,7 +38,7 @@ const ActionSearch: FC = () => {
   const { user } = useAppUser<HowlerUser>();
   const { dispatchApi } = useMyApi();
   const { load } = useContext(TuiListMethodContext);
-  const { showModal } = useContext(ModalContext);
+  const { withConfirmDeleteModal } = useContext(ModalContext);
   const [searchParams, setSearchParams] = useSearchParams();
   const { deleteAction } = useMyActionFunctions();
   const pageCount = useMyLocalStorageItem(StorageKey.PAGE_COUNT, 25)[0];
@@ -102,16 +101,12 @@ const ActionSearch: FC = () => {
     (e: MouseEvent, actionId: string) => {
       e.preventDefault();
       e.stopPropagation();
-      showModal(
-        <ConfirmDeleteModal
-          onConfirm={async () => {
-            await deleteAction(actionId);
-            onSearch();
-          }}
-        />
-      );
+      withConfirmDeleteModal(async () => {
+        await deleteAction(actionId);
+        onSearch();
+      });
     },
-    [deleteAction, onSearch, showModal]
+    [deleteAction, onSearch, withConfirmDeleteModal]
   );
 
   // Effect to initialize list of users.

--- a/ui/src/components/routes/analytics/AnalyticDetails.tsx
+++ b/ui/src/components/routes/analytics/AnalyticDetails.tsx
@@ -22,9 +22,11 @@ import api from 'api';
 import { useAppUser } from 'commons/components/app/hooks';
 import PageCenter from 'commons/components/pages/PageCenter';
 import { ApiConfigContext } from 'components/app/providers/ApiConfigProvider';
+import { ModalContext } from 'components/app/providers/ModalProvider';
 import { UserListContext } from 'components/app/providers/UserListProvider';
 import UserList from 'components/elements/UserList';
 import HowlerAvatar from 'components/elements/display/HowlerAvatar';
+import ConfirmDeleteModal from 'components/elements/display/modals/ConfirmDeleteModal';
 import useMyApi from 'components/hooks/useMyApi';
 import useMySnackbar from 'components/hooks/useMySnackbar';
 import type { HowlerUser } from 'models/entities/HowlerUser';
@@ -51,6 +53,7 @@ const AnalyticDetails = () => {
   const { dispatchApi } = useMyApi();
   const theme = useTheme();
   const { showSuccessMessage } = useMySnackbar();
+  const { showModal } = useContext(ModalContext);
   const { users, searchUsers } = useContext(UserListContext);
   const { config } = useContext(ApiConfigContext);
 
@@ -169,7 +172,7 @@ const AnalyticDetails = () => {
                   <SsidChart fontSize="large" color="info" />
                 </Tooltip>
                 {(analytic?.owner === user.username || user.roles.includes('admin')) && (
-                  <IconButton onClick={onDelete}>
+                  <IconButton onClick={() => showModal(<ConfirmDeleteModal onConfirm={onDelete} />)}>
                     <Delete />
                   </IconButton>
                 )}

--- a/ui/src/components/routes/analytics/AnalyticDetails.tsx
+++ b/ui/src/components/routes/analytics/AnalyticDetails.tsx
@@ -96,12 +96,18 @@ const AnalyticDetails = () => {
     [analytic?.analytic_id, dispatchApi]
   );
 
-  const onDelete = useCallback(async () => {
-    await dispatchApi(api.analytic.del(analytic?.analytic_id));
+  const onDelete = useCallback(() => {
+    showModal(
+      <ConfirmDeleteModal
+        onConfirm={async () => {
+          await dispatchApi(api.analytic.del(analytic?.analytic_id));
 
-    showSuccessMessage(t('route.analytics.deleted'));
-    navigate('/analytics');
-  }, [analytic?.analytic_id, dispatchApi, navigate, showSuccessMessage, t]);
+          showSuccessMessage(t('route.analytics.deleted'));
+          navigate('/analytics');
+        }}
+      />
+    );
+  }, [analytic?.analytic_id, dispatchApi, navigate, showModal, showSuccessMessage, t]);
 
   const onEdit = useCallback(async () => {
     if (editingInterval) {
@@ -172,7 +178,7 @@ const AnalyticDetails = () => {
                   <SsidChart fontSize="large" color="info" />
                 </Tooltip>
                 {(analytic?.owner === user.username || user.roles.includes('admin')) && (
-                  <IconButton onClick={() => showModal(<ConfirmDeleteModal onConfirm={onDelete} />)}>
+                  <IconButton onClick={onDelete}>
                     <Delete />
                   </IconButton>
                 )}

--- a/ui/src/components/routes/analytics/AnalyticDetails.tsx
+++ b/ui/src/components/routes/analytics/AnalyticDetails.tsx
@@ -26,7 +26,6 @@ import { ModalContext } from 'components/app/providers/ModalProvider';
 import { UserListContext } from 'components/app/providers/UserListProvider';
 import UserList from 'components/elements/UserList';
 import HowlerAvatar from 'components/elements/display/HowlerAvatar';
-import ConfirmDeleteModal from 'components/elements/display/modals/ConfirmDeleteModal';
 import useMyApi from 'components/hooks/useMyApi';
 import useMySnackbar from 'components/hooks/useMySnackbar';
 import type { HowlerUser } from 'models/entities/HowlerUser';
@@ -53,7 +52,7 @@ const AnalyticDetails = () => {
   const { dispatchApi } = useMyApi();
   const theme = useTheme();
   const { showSuccessMessage } = useMySnackbar();
-  const { showModal } = useContext(ModalContext);
+  const { withConfirmDeleteModal } = useContext(ModalContext);
   const { users, searchUsers } = useContext(UserListContext);
   const { config } = useContext(ApiConfigContext);
 
@@ -97,17 +96,13 @@ const AnalyticDetails = () => {
   );
 
   const onDelete = useCallback(() => {
-    showModal(
-      <ConfirmDeleteModal
-        onConfirm={async () => {
-          await dispatchApi(api.analytic.del(analytic?.analytic_id));
+    withConfirmDeleteModal(async () => {
+      await dispatchApi(api.analytic.del(analytic?.analytic_id));
 
-          showSuccessMessage(t('route.analytics.deleted'));
-          navigate('/analytics');
-        }}
-      />
-    );
-  }, [analytic?.analytic_id, dispatchApi, navigate, showModal, showSuccessMessage, t]);
+      showSuccessMessage(t('route.analytics.deleted'));
+      navigate('/analytics');
+    });
+  }, [analytic?.analytic_id, dispatchApi, navigate, withConfirmDeleteModal, showSuccessMessage, t]);
 
   const onEdit = useCallback(async () => {
     if (editingInterval) {

--- a/ui/src/components/routes/dossiers/Dossiers.tsx
+++ b/ui/src/components/routes/dossiers/Dossiers.tsx
@@ -6,7 +6,6 @@ import { ModalContext } from 'components/app/providers/ModalProvider';
 import { TuiListProvider, type TuiListItem, type TuiListItemProps } from 'components/elements/addons/lists';
 import { TuiListMethodContext, type TuiListMethodsState } from 'components/elements/addons/lists/TuiListProvider';
 import ItemManager from 'components/elements/display/ItemManager';
-import ConfirmDeleteModal from 'components/elements/display/modals/ConfirmDeleteModal';
 import useMyApi from 'components/hooks/useMyApi';
 import { useMyLocalStorageItem } from 'components/hooks/useMyLocalStorage';
 import useMySnackbar from 'components/hooks/useMySnackbar';
@@ -22,7 +21,7 @@ const DossiersBase: FC = () => {
   const navigate = useNavigate();
   const { dispatchApi } = useMyApi();
   const { showSuccessMessage } = useMySnackbar();
-  const { showModal } = useContext(ModalContext);
+  const { withConfirmDeleteModal } = useContext(ModalContext);
   const [searchParams, setSearchParams] = useSearchParams();
   const { load } = useContext<TuiListMethodsState<Dossier>>(TuiListMethodContext);
   const pageCount = useMyLocalStorageItem(StorageKey.PAGE_COUNT, 25)[0];
@@ -96,22 +95,18 @@ const DossiersBase: FC = () => {
       e.preventDefault();
       e.stopPropagation();
 
-      showModal(
-        <ConfirmDeleteModal
-          onConfirm={async () => {
-            try {
-              await dispatchApi(api.dossier.del(id), { throwError: false, showError: true });
-              await onSearch();
-              showSuccessMessage(t('route.dossiers.manager.delete.success'));
-            } catch (_err) {
-              // eslint-disable-next-line no-console
-              console.warn(_err);
-            }
-          }}
-        />
-      );
+      withConfirmDeleteModal(async () => {
+        try {
+          await dispatchApi(api.dossier.del(id), { throwError: false, showError: true });
+          await onSearch();
+          showSuccessMessage(t('route.dossiers.manager.delete.success'));
+        } catch (_err) {
+          // eslint-disable-next-line no-console
+          console.warn(_err);
+        }
+      });
     },
-    [dispatchApi, onSearch, showModal, showSuccessMessage, t]
+    [dispatchApi, onSearch, withConfirmDeleteModal, showSuccessMessage, t]
   );
 
   useEffect(() => {

--- a/ui/src/components/routes/dossiers/Dossiers.tsx
+++ b/ui/src/components/routes/dossiers/Dossiers.tsx
@@ -2,9 +2,11 @@ import { Topic } from '@mui/icons-material';
 import { Typography } from '@mui/material';
 import api from 'api';
 import type { HowlerSearchResponse } from 'api/search';
+import { ModalContext } from 'components/app/providers/ModalProvider';
 import { TuiListProvider, type TuiListItem, type TuiListItemProps } from 'components/elements/addons/lists';
 import { TuiListMethodContext, type TuiListMethodsState } from 'components/elements/addons/lists/TuiListProvider';
 import ItemManager from 'components/elements/display/ItemManager';
+import ConfirmDeleteModal from 'components/elements/display/modals/ConfirmDeleteModal';
 import useMyApi from 'components/hooks/useMyApi';
 import { useMyLocalStorageItem } from 'components/hooks/useMyLocalStorage';
 import useMySnackbar from 'components/hooks/useMySnackbar';
@@ -20,6 +22,7 @@ const DossiersBase: FC = () => {
   const navigate = useNavigate();
   const { dispatchApi } = useMyApi();
   const { showSuccessMessage } = useMySnackbar();
+  const { showModal } = useContext(ModalContext);
   const [searchParams, setSearchParams] = useSearchParams();
   const { load } = useContext<TuiListMethodsState<Dossier>>(TuiListMethodContext);
   const pageCount = useMyLocalStorageItem(StorageKey.PAGE_COUNT, 25)[0];
@@ -89,20 +92,26 @@ const DossiersBase: FC = () => {
   );
 
   const onDelete = useCallback(
-    async (e: React.MouseEvent<HTMLButtonElement, MouseEvent>, id: string) => {
+    (e: React.MouseEvent<HTMLButtonElement, MouseEvent>, id: string) => {
       e.preventDefault();
       e.stopPropagation();
 
-      try {
-        await dispatchApi(api.dossier.del(id), { throwError: false, showError: true });
-        await onSearch();
-        showSuccessMessage(t('route.dossiers.manager.delete.success'));
-      } catch (_err) {
-        // eslint-disable-next-line no-console
-        console.warn(_err);
-      }
+      showModal(
+        <ConfirmDeleteModal
+          onConfirm={async () => {
+            try {
+              await dispatchApi(api.dossier.del(id), { throwError: false, showError: true });
+              await onSearch();
+              showSuccessMessage(t('route.dossiers.manager.delete.success'));
+            } catch (_err) {
+              // eslint-disable-next-line no-console
+              console.warn(_err);
+            }
+          }}
+        />
+      );
     },
-    [dispatchApi, onSearch, showSuccessMessage, t]
+    [dispatchApi, onSearch, showModal, showSuccessMessage, t]
   );
 
   useEffect(() => {

--- a/ui/src/components/routes/overviews/OverviewViewer.tsx
+++ b/ui/src/components/routes/overviews/OverviewViewer.tsx
@@ -25,7 +25,6 @@ import AppInfoPanel from 'commons/components/display/AppInfoPanel';
 import useThemeBuilder from 'commons/components/utils/hooks/useThemeBuilder';
 import { ModalContext } from 'components/app/providers/ModalProvider';
 import { OverviewContext } from 'components/app/providers/OverviewProvider';
-import ConfirmDeleteModal from 'components/elements/display/modals/ConfirmDeleteModal';
 import HitOverview from 'components/elements/hit/HitOverview';
 import useMyApi from 'components/hooks/useMyApi';
 import useMyTheme from 'components/hooks/useMyTheme';
@@ -46,7 +45,7 @@ const OverviewViewer = () => {
   const [params, setParams] = useSearchParams();
   const { getOverviews } = useContext(OverviewContext);
   const { dispatchApi } = useMyApi();
-  const { showModal } = useContext(ModalContext);
+  const { withConfirmDeleteModal } = useContext(ModalContext);
 
   const [overviewList, setOverviewList] = useState<Overview[]>([]);
   const [selectedOverview, setSelectedOverview] = useState<Overview>(null);
@@ -179,20 +178,16 @@ const OverviewViewer = () => {
   }, [analytic, detection, params, setParams]);
 
   const onDelete = useCallback(() => {
-    showModal(
-      <ConfirmDeleteModal
-        onConfirm={async () => {
-          await dispatchApi(api.overview.del(selectedOverview.overview_id), {
-            logError: false,
-            showError: true,
-            throwError: false
-          });
-          setSelectedOverview(null);
-          setContent('');
-        }}
-      />
-    );
-  }, [dispatchApi, selectedOverview?.overview_id, showModal]);
+    withConfirmDeleteModal(async () => {
+      await dispatchApi(api.overview.del(selectedOverview.overview_id), {
+        logError: false,
+        showError: true,
+        throwError: false
+      });
+      setSelectedOverview(null);
+      setContent('');
+    });
+  }, [dispatchApi, selectedOverview?.overview_id, withConfirmDeleteModal]);
 
   const onSave = useCallback(async () => {
     if (analytic && detection) {

--- a/ui/src/components/routes/overviews/OverviewViewer.tsx
+++ b/ui/src/components/routes/overviews/OverviewViewer.tsx
@@ -178,15 +178,21 @@ const OverviewViewer = () => {
     });
   }, [analytic, detection, params, setParams]);
 
-  const onDelete = useCallback(async () => {
-    await dispatchApi(api.overview.del(selectedOverview.overview_id), {
-      logError: false,
-      showError: true,
-      throwError: false
-    });
-    setSelectedOverview(null);
-    setContent('');
-  }, [dispatchApi, selectedOverview?.overview_id]);
+  const onDelete = useCallback(() => {
+    showModal(
+      <ConfirmDeleteModal
+        onConfirm={async () => {
+          await dispatchApi(api.overview.del(selectedOverview.overview_id), {
+            logError: false,
+            showError: true,
+            throwError: false
+          });
+          setSelectedOverview(null);
+          setContent('');
+        }}
+      />
+    );
+  }, [dispatchApi, selectedOverview?.overview_id, showModal]);
 
   const onSave = useCallback(async () => {
     if (analytic && detection) {
@@ -275,11 +281,7 @@ const OverviewViewer = () => {
             </Tooltip>
           )}
           {selectedOverview && (
-            <Button
-              variant="outlined"
-              startIcon={<Delete />}
-              onClick={() => showModal(<ConfirmDeleteModal onConfirm={onDelete} />)}
-            >
+            <Button variant="outlined" startIcon={<Delete />} onClick={onDelete}>
               {t('button.delete')}
             </Button>
           )}

--- a/ui/src/components/routes/overviews/OverviewViewer.tsx
+++ b/ui/src/components/routes/overviews/OverviewViewer.tsx
@@ -23,7 +23,9 @@ import { Check, DarkMode, Delete, SsidChart, WbSunny } from '@mui/icons-material
 import { useApp } from 'commons/components/app/hooks';
 import AppInfoPanel from 'commons/components/display/AppInfoPanel';
 import useThemeBuilder from 'commons/components/utils/hooks/useThemeBuilder';
+import { ModalContext } from 'components/app/providers/ModalProvider';
 import { OverviewContext } from 'components/app/providers/OverviewProvider';
+import ConfirmDeleteModal from 'components/elements/display/modals/ConfirmDeleteModal';
 import HitOverview from 'components/elements/hit/HitOverview';
 import useMyApi from 'components/hooks/useMyApi';
 import useMyTheme from 'components/hooks/useMyTheme';
@@ -44,6 +46,7 @@ const OverviewViewer = () => {
   const [params, setParams] = useSearchParams();
   const { getOverviews } = useContext(OverviewContext);
   const { dispatchApi } = useMyApi();
+  const { showModal } = useContext(ModalContext);
 
   const [overviewList, setOverviewList] = useState<Overview[]>([]);
   const [selectedOverview, setSelectedOverview] = useState<Overview>(null);
@@ -272,7 +275,11 @@ const OverviewViewer = () => {
             </Tooltip>
           )}
           {selectedOverview && (
-            <Button variant="outlined" startIcon={<Delete />} onClick={onDelete}>
+            <Button
+              variant="outlined"
+              startIcon={<Delete />}
+              onClick={() => showModal(<ConfirmDeleteModal onConfirm={onDelete} />)}
+            >
               {t('button.delete')}
             </Button>
           )}

--- a/ui/src/components/routes/overviews/Overviews.tsx
+++ b/ui/src/components/routes/overviews/Overviews.tsx
@@ -6,7 +6,6 @@ import { ModalContext } from 'components/app/providers/ModalProvider';
 import { TuiListProvider, type TuiListItem, type TuiListItemProps } from 'components/elements/addons/lists';
 import { TuiListMethodContext, type TuiListMethodsState } from 'components/elements/addons/lists/TuiListProvider';
 import ItemManager from 'components/elements/display/ItemManager';
-import ConfirmDeleteModal from 'components/elements/display/modals/ConfirmDeleteModal';
 import useMyApi from 'components/hooks/useMyApi';
 import { useMyLocalStorageItem } from 'components/hooks/useMyLocalStorage';
 import useMySnackbar from 'components/hooks/useMySnackbar';
@@ -22,7 +21,7 @@ const OverviewsBase: FC = () => {
   const navigate = useNavigate();
   const { dispatchApi } = useMyApi();
   const { showSuccessMessage } = useMySnackbar();
-  const { showModal } = useContext(ModalContext);
+  const { withConfirmDeleteModal } = useContext(ModalContext);
   const [searchParams, setSearchParams] = useSearchParams();
   const { load } = useContext<TuiListMethodsState<Overview>>(TuiListMethodContext);
   const pageCount = useMyLocalStorageItem(StorageKey.PAGE_COUNT, 25)[0];
@@ -96,22 +95,18 @@ const OverviewsBase: FC = () => {
       e.preventDefault();
       e.stopPropagation();
 
-      showModal(
-        <ConfirmDeleteModal
-          onConfirm={async () => {
-            try {
-              await dispatchApi(api.overview.del(id), { throwError: false, showError: true });
-              await onSearch();
-              showSuccessMessage(t('route.overviews.manager.delete.success'));
-            } catch (_err) {
-              // eslint-disable-next-line no-console
-              console.warn(_err);
-            }
-          }}
-        />
-      );
+      withConfirmDeleteModal(async () => {
+        try {
+          await dispatchApi(api.overview.del(id), { throwError: false, showError: true });
+          await onSearch();
+          showSuccessMessage(t('route.overviews.manager.delete.success'));
+        } catch (_err) {
+          // eslint-disable-next-line no-console
+          console.warn(_err);
+        }
+      });
     },
-    [dispatchApi, onSearch, showModal, showSuccessMessage, t]
+    [dispatchApi, onSearch, withConfirmDeleteModal, showSuccessMessage, t]
   );
 
   useEffect(() => {

--- a/ui/src/components/routes/overviews/Overviews.tsx
+++ b/ui/src/components/routes/overviews/Overviews.tsx
@@ -2,9 +2,11 @@ import { Article } from '@mui/icons-material';
 import { Typography } from '@mui/material';
 import api from 'api';
 import type { HowlerSearchResponse } from 'api/search';
+import { ModalContext } from 'components/app/providers/ModalProvider';
 import { TuiListProvider, type TuiListItem, type TuiListItemProps } from 'components/elements/addons/lists';
 import { TuiListMethodContext, type TuiListMethodsState } from 'components/elements/addons/lists/TuiListProvider';
 import ItemManager from 'components/elements/display/ItemManager';
+import ConfirmDeleteModal from 'components/elements/display/modals/ConfirmDeleteModal';
 import useMyApi from 'components/hooks/useMyApi';
 import { useMyLocalStorageItem } from 'components/hooks/useMyLocalStorage';
 import useMySnackbar from 'components/hooks/useMySnackbar';
@@ -20,6 +22,7 @@ const OverviewsBase: FC = () => {
   const navigate = useNavigate();
   const { dispatchApi } = useMyApi();
   const { showSuccessMessage } = useMySnackbar();
+  const { showModal } = useContext(ModalContext);
   const [searchParams, setSearchParams] = useSearchParams();
   const { load } = useContext<TuiListMethodsState<Overview>>(TuiListMethodContext);
   const pageCount = useMyLocalStorageItem(StorageKey.PAGE_COUNT, 25)[0];
@@ -89,20 +92,26 @@ const OverviewsBase: FC = () => {
   );
 
   const onDelete = useCallback(
-    async (e: React.MouseEvent<HTMLButtonElement, MouseEvent>, id: string) => {
+    (e: React.MouseEvent<HTMLButtonElement, MouseEvent>, id: string) => {
       e.preventDefault();
       e.stopPropagation();
 
-      try {
-        await dispatchApi(api.overview.del(id), { throwError: false, showError: true });
-        await onSearch();
-        showSuccessMessage(t('route.overviews.manager.delete.success'));
-      } catch (_err) {
-        // eslint-disable-next-line no-console
-        console.warn(_err);
-      }
+      showModal(
+        <ConfirmDeleteModal
+          onConfirm={async () => {
+            try {
+              await dispatchApi(api.overview.del(id), { throwError: false, showError: true });
+              await onSearch();
+              showSuccessMessage(t('route.overviews.manager.delete.success'));
+            } catch (_err) {
+              // eslint-disable-next-line no-console
+              console.warn(_err);
+            }
+          }}
+        />
+      );
     },
-    [dispatchApi, onSearch, showSuccessMessage, t]
+    [dispatchApi, onSearch, showModal, showSuccessMessage, t]
   );
 
   useEffect(() => {

--- a/ui/src/components/routes/templates/TemplateViewer.tsx
+++ b/ui/src/components/routes/templates/TemplateViewer.tsx
@@ -14,11 +14,13 @@ import {
 import api from 'api';
 import PageCenter from 'commons/components/pages/PageCenter';
 import TemplateEditor from 'components/routes/templates/TemplateEditor';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { Check, Delete, SsidChart } from '@mui/icons-material';
 import AppInfoPanel from 'commons/components/display/AppInfoPanel';
+import { ModalContext } from 'components/app/providers/ModalProvider';
+import ConfirmDeleteModal from 'components/elements/display/modals/ConfirmDeleteModal';
 import { DEFAULT_FIELDS } from 'components/elements/hit/HitOutline';
 import useMyApi from 'components/hooks/useMyApi';
 import isEqual from 'lodash-es/isEqual';
@@ -33,6 +35,7 @@ const TemplateViewer = () => {
   const { t } = useTranslation();
   const [params, setParams] = useSearchParams();
   const { dispatchApi } = useMyApi();
+  const { showModal } = useContext(ModalContext);
 
   const [templateList, setTemplateList] = useState<Template[]>([]);
   const [selectedTemplate, setSelectedTemplate] = useState<Template>(null);
@@ -318,7 +321,11 @@ const TemplateViewer = () => {
             </ToggleButton>
           </ToggleButtonGroup>
           {selectedTemplate && (
-            <Button variant="outlined" startIcon={<Delete />} onClick={onDelete}>
+            <Button
+              variant="outlined"
+              startIcon={<Delete />}
+              onClick={() => showModal(<ConfirmDeleteModal onConfirm={onDelete} />)}
+            >
               {t('button.delete')}
             </Button>
           )}

--- a/ui/src/components/routes/templates/TemplateViewer.tsx
+++ b/ui/src/components/routes/templates/TemplateViewer.tsx
@@ -163,34 +163,41 @@ const TemplateViewer = () => {
     return { ..._hit };
   }, [analytic]);
 
-  const onDelete = useCallback(async () => {
-    await dispatchApi(api.template.del(selectedTemplate.template_id), {
-      logError: false,
-      showError: true,
-      throwError: false
-    });
-    setSessionTemplateList(l =>
-      l.filter(
-        v =>
-          v.analytic != selectedTemplate.analytic ||
-          v.detection != selectedTemplate.detection ||
-          v.type != selectedTemplate.type
-      )
-    );
-    setTemplateList(l =>
-      l.filter(
-        v =>
-          v.analytic != selectedTemplate.analytic ||
-          v.detection != selectedTemplate.detection ||
-          v.type != selectedTemplate.type
-      )
+  const onDelete = useCallback(() => {
+    showModal(
+      <ConfirmDeleteModal
+        onConfirm={async () => {
+          await dispatchApi(api.template.del(selectedTemplate.template_id), {
+            logError: false,
+            showError: true,
+            throwError: false
+          });
+          setSessionTemplateList(l =>
+            l.filter(
+              v =>
+                v.analytic != selectedTemplate.analytic ||
+                v.detection != selectedTemplate.detection ||
+                v.type != selectedTemplate.type
+            )
+          );
+          setTemplateList(l =>
+            l.filter(
+              v =>
+                v.analytic != selectedTemplate.analytic ||
+                v.detection != selectedTemplate.detection ||
+                v.type != selectedTemplate.type
+            )
+          );
+        }}
+      />
     );
   }, [
     dispatchApi,
     selectedTemplate?.analytic,
     selectedTemplate?.detection,
     selectedTemplate?.template_id,
-    selectedTemplate?.type
+    selectedTemplate?.type,
+    showModal
   ]);
 
   const onSave = useCallback(async () => {
@@ -321,11 +328,7 @@ const TemplateViewer = () => {
             </ToggleButton>
           </ToggleButtonGroup>
           {selectedTemplate && (
-            <Button
-              variant="outlined"
-              startIcon={<Delete />}
-              onClick={() => showModal(<ConfirmDeleteModal onConfirm={onDelete} />)}
-            >
+            <Button variant="outlined" startIcon={<Delete />} onClick={onDelete}>
               {t('button.delete')}
             </Button>
           )}

--- a/ui/src/components/routes/templates/TemplateViewer.tsx
+++ b/ui/src/components/routes/templates/TemplateViewer.tsx
@@ -20,7 +20,6 @@ import { useTranslation } from 'react-i18next';
 import { Check, Delete, SsidChart } from '@mui/icons-material';
 import AppInfoPanel from 'commons/components/display/AppInfoPanel';
 import { ModalContext } from 'components/app/providers/ModalProvider';
-import ConfirmDeleteModal from 'components/elements/display/modals/ConfirmDeleteModal';
 import { DEFAULT_FIELDS } from 'components/elements/hit/HitOutline';
 import useMyApi from 'components/hooks/useMyApi';
 import isEqual from 'lodash-es/isEqual';
@@ -35,7 +34,7 @@ const TemplateViewer = () => {
   const { t } = useTranslation();
   const [params, setParams] = useSearchParams();
   const { dispatchApi } = useMyApi();
-  const { showModal } = useContext(ModalContext);
+  const { withConfirmDeleteModal } = useContext(ModalContext);
 
   const [templateList, setTemplateList] = useState<Template[]>([]);
   const [selectedTemplate, setSelectedTemplate] = useState<Template>(null);
@@ -164,40 +163,36 @@ const TemplateViewer = () => {
   }, [analytic]);
 
   const onDelete = useCallback(() => {
-    showModal(
-      <ConfirmDeleteModal
-        onConfirm={async () => {
-          await dispatchApi(api.template.del(selectedTemplate.template_id), {
-            logError: false,
-            showError: true,
-            throwError: false
-          });
-          setSessionTemplateList(l =>
-            l.filter(
-              v =>
-                v.analytic != selectedTemplate.analytic ||
-                v.detection != selectedTemplate.detection ||
-                v.type != selectedTemplate.type
-            )
-          );
-          setTemplateList(l =>
-            l.filter(
-              v =>
-                v.analytic != selectedTemplate.analytic ||
-                v.detection != selectedTemplate.detection ||
-                v.type != selectedTemplate.type
-            )
-          );
-        }}
-      />
-    );
+    withConfirmDeleteModal(async () => {
+      await dispatchApi(api.template.del(selectedTemplate.template_id), {
+        logError: false,
+        showError: true,
+        throwError: false
+      });
+      setSessionTemplateList(l =>
+        l.filter(
+          v =>
+            v.analytic != selectedTemplate.analytic ||
+            v.detection != selectedTemplate.detection ||
+            v.type != selectedTemplate.type
+        )
+      );
+      setTemplateList(l =>
+        l.filter(
+          v =>
+            v.analytic != selectedTemplate.analytic ||
+            v.detection != selectedTemplate.detection ||
+            v.type != selectedTemplate.type
+        )
+      );
+    });
   }, [
     dispatchApi,
     selectedTemplate?.analytic,
     selectedTemplate?.detection,
     selectedTemplate?.template_id,
     selectedTemplate?.type,
-    showModal
+    withConfirmDeleteModal
   ]);
 
   const onSave = useCallback(async () => {

--- a/ui/src/components/routes/views/Views.tsx
+++ b/ui/src/components/routes/views/Views.tsx
@@ -22,7 +22,6 @@ import { TuiListProvider, type TuiListItemProps } from 'components/elements/addo
 import { TuiListMethodContext, type TuiListMethodsState } from 'components/elements/addons/lists/TuiListProvider';
 import HowlerAvatar from 'components/elements/display/HowlerAvatar';
 import ItemManager from 'components/elements/display/ItemManager';
-import ConfirmDeleteModal from 'components/elements/display/modals/ConfirmDeleteModal';
 import { ViewTitle } from 'components/elements/view/ViewTitle';
 import useMyApi from 'components/hooks/useMyApi';
 import { useMyLocalStorageItem } from 'components/hooks/useMyLocalStorage';
@@ -44,7 +43,7 @@ const ViewsBase: FC = () => {
   const { user } = useAppUser<HowlerUser>();
   const navigate = useNavigate();
   const { dispatchApi } = useMyApi();
-  const { showModal } = useContext(ModalContext);
+  const { withConfirmDeleteModal } = useContext(ModalContext);
 
   const fetchViews = useContextSelector(ViewContext, ctx => ctx.fetchViews);
   const addFavourite = useContextSelector(ViewContext, ctx => ctx.addFavourite);
@@ -147,16 +146,12 @@ const ViewsBase: FC = () => {
       event.preventDefault();
       event.stopPropagation();
 
-      showModal(
-        <ConfirmDeleteModal
-          onConfirm={async () => {
-            await removeView(id);
-            onSearch();
-          }}
-        />
-      );
+      withConfirmDeleteModal(async () => {
+        await removeView(id);
+        onSearch();
+      });
     },
-    [onSearch, removeView, showModal]
+    [onSearch, removeView, withConfirmDeleteModal]
   );
 
   const onFavourite = useCallback(

--- a/ui/src/components/routes/views/Views.tsx
+++ b/ui/src/components/routes/views/Views.tsx
@@ -15,12 +15,14 @@ import {
 import api from 'api';
 import type { HowlerSearchResponse } from 'api/search';
 import { useAppUser } from 'commons/components/app/hooks';
+import { ModalContext } from 'components/app/providers/ModalProvider';
 import { ViewContext } from 'components/app/providers/ViewProvider';
 import FlexOne from 'components/elements/addons/layout/FlexOne';
 import { TuiListProvider, type TuiListItemProps } from 'components/elements/addons/lists';
 import { TuiListMethodContext, type TuiListMethodsState } from 'components/elements/addons/lists/TuiListProvider';
 import HowlerAvatar from 'components/elements/display/HowlerAvatar';
 import ItemManager from 'components/elements/display/ItemManager';
+import ConfirmDeleteModal from 'components/elements/display/modals/ConfirmDeleteModal';
 import { ViewTitle } from 'components/elements/view/ViewTitle';
 import useMyApi from 'components/hooks/useMyApi';
 import { useMyLocalStorageItem } from 'components/hooks/useMyLocalStorage';
@@ -42,6 +44,7 @@ const ViewsBase: FC = () => {
   const { user } = useAppUser<HowlerUser>();
   const navigate = useNavigate();
   const { dispatchApi } = useMyApi();
+  const { showModal } = useContext(ModalContext);
 
   const fetchViews = useContextSelector(ViewContext, ctx => ctx.fetchViews);
   const addFavourite = useContextSelector(ViewContext, ctx => ctx.addFavourite);
@@ -140,15 +143,20 @@ const ViewsBase: FC = () => {
   );
 
   const onDelete = useCallback(
-    async (event: React.MouseEvent<HTMLButtonElement, MouseEvent>, id: string) => {
+    (event: React.MouseEvent<HTMLButtonElement, MouseEvent>, id: string) => {
       event.preventDefault();
       event.stopPropagation();
 
-      await removeView(id);
-
-      onSearch();
+      showModal(
+        <ConfirmDeleteModal
+          onConfirm={async () => {
+            await removeView(id);
+            onSearch();
+          }}
+        />
+      );
     },
-    [onSearch, removeView]
+    [onSearch, removeView, showModal]
   );
 
   const onFavourite = useCallback(


### PR DESCRIPTION
Add a confirmation dialogue before delete of actions, dossiers, overviews, templates, views, and rules.

Notes:
- Confirm delete dialogue is set to default so neither delete or cancel is highlighted