### PR TITLE
fix(api)!: updated integer to long for file.size

### DIFF
--- a/api/howler/odm/models/ecs/file.py
+++ b/api/howler/odm/models/ecs/file.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from howler import odm
 from howler.odm.models.ecs.code_signature import CodeSignature
 from howler.odm.models.ecs.elf import ELF
@@ -17,67 +15,67 @@ FILE_TYPE = ["file", "dir", "symlink"]
     description="A file is defined as a set of information that has been created on, or has existed on a filesystem.",
 )
 class File(odm.Model):
-    accessed: Optional[str] = odm.Optional(odm.Date(description="Last time the file was accessed."))
-    attributes: Optional[list[str]] = odm.Optional(odm.List(odm.Keyword(), description="Array of file attributes."))
-    created: Optional[str] = odm.Optional(odm.Date(description="File creation time."))
-    ctime: Optional[str] = odm.Optional(odm.Date(description="Last time the file attributes or metadata changed."))
-    device: Optional[str] = odm.Optional(odm.Keyword(description="Device that is the source of the file."))
-    directory: Optional[str] = odm.Optional(
+    accessed: str | None = odm.Optional(odm.Date(description="Last time the file was accessed."))
+    attributes: list[str] | None = odm.Optional(odm.List(odm.Keyword(), description="Array of file attributes."))
+    created: str | None = odm.Optional(odm.Date(description="File creation time."))
+    ctime: str | None = odm.Optional(odm.Date(description="Last time the file attributes or metadata changed."))
+    device: str | None = odm.Optional(odm.Keyword(description="Device that is the source of the file."))
+    directory: str | None = odm.Optional(
         odm.Keyword(
             description="Directory where the file is located. It should include the drive letter, when appropriate."
         )
     )
-    drive_letter: Optional[str] = odm.Optional(
+    drive_letter: str | None = odm.Optional(
         odm.Keyword(description="Drive letter where the file is located. This field is only relevant on Windows.")
     )
-    extension: Optional[str] = odm.Optional(odm.Keyword(description="File extension, excluding the leading dot."))
-    fork_name: Optional[str] = odm.Optional(
+    extension: str | None = odm.Optional(odm.Keyword(description="File extension, excluding the leading dot."))
+    fork_name: str | None = odm.Optional(
         odm.Keyword(description="A fork is additional data associated with a filesystem object.")
     )
-    gid: Optional[str] = odm.Optional(odm.Keyword(description="Primary group ID (GID) of the file."))
-    group: Optional[str] = odm.Optional(odm.Keyword(description="Primary group name of the file."))
-    inode: Optional[str] = odm.Optional(odm.Keyword(description="Inode representing the file in the filesystem."))
-    mime_type: Optional[str] = odm.Optional(
+    gid: str | None = odm.Optional(odm.Keyword(description="Primary group ID (GID) of the file."))
+    group: str | None = odm.Optional(odm.Keyword(description="Primary group name of the file."))
+    inode: str | None = odm.Optional(odm.Keyword(description="Inode representing the file in the filesystem."))
+    mime_type: str | None = odm.Optional(
         odm.Keyword(
             description="MIME type should identify the format of the file or stream of "
             "bytes using IANA official types, where possible."
         )
     )
-    mode: Optional[str] = odm.Optional(odm.Keyword(description="Mode of the file in octal representation."))
-    mtime: Optional[str] = odm.Optional(odm.Date(description="Last time the file content was modified."))
-    name: Optional[str] = odm.Optional(
+    mode: str | None = odm.Optional(odm.Keyword(description="Mode of the file in octal representation."))
+    mtime: str | None = odm.Optional(odm.Date(description="Last time the file content was modified."))
+    name: str | None = odm.Optional(
         odm.Keyword(description="Name of the file including the extension, without the directory.")
     )
-    owner: Optional[str] = odm.Optional(odm.Keyword(description="File owner’s username."))
-    path: Optional[str] = odm.Optional(
+    owner: str | None = odm.Optional(odm.Keyword(description="File owner’s username."))
+    path: str | None = odm.Optional(
         odm.Keyword(
             description="Full path to the file, including the file name. "
             "It should include the drive letter, when appropriate."
         )
     )
-    size: Optional[int] = odm.Integer(description="File size in bytes.", optional=True)
-    target_path: Optional[str] = odm.Optional(odm.Keyword(description="Target path for symlinks."))
-    type: Optional[str] = odm.Optional(odm.Enum(values=FILE_TYPE, description="File type (file, dir, or symlink)."))
-    uid: Optional[str] = odm.Optional(
+    size: int | None = odm.Long(description="File size in bytes.", optional=True)
+    target_path: str | None = odm.Optional(odm.Keyword(description="Target path for symlinks."))
+    type: str | None = odm.Optional(odm.Enum(values=FILE_TYPE, description="File type (file, dir, or symlink)."))
+    uid: str | None = odm.Optional(
         odm.Keyword(description="The user ID (UID) or security identifier (SID) of the file owner.")
     )
 
-    code_signature: Optional[CodeSignature] = odm.Optional(
+    code_signature: CodeSignature | None = odm.Optional(
         odm.Compound(
             CodeSignature,
             description="These fields contain information about binary code signatures.",
         )
     )
-    elf: Optional[ELF] = odm.Optional(
+    elf: ELF | None = odm.Optional(
         odm.Compound(
             ELF,
             description="These fields contain Linux Executable Linkable Format (ELF) metadata.",
         )
     )
-    hash: Optional[Hashes] = odm.Optional(
+    hash: Hashes | None = odm.Optional(
         odm.Compound(
             Hashes,
             description="These fields contain Windows Portable Executable (PE) metadata.",
         )
     )
-    pe: Optional[PE] = odm.Optional(odm.Compound(PE, description="Hashes, usually file hashes."))
+    pe: PE | None = odm.Optional(odm.Compound(PE, description="Hashes, usually file hashes."))

--- a/api/howler/odm/models/ecs/file.py
+++ b/api/howler/odm/models/ecs/file.py
@@ -78,4 +78,4 @@ class File(odm.Model):
             description="These fields contain Windows Portable Executable (PE) metadata.",
         )
     )
-    pe: PE | None = odm.Optional(odm.Compound(PE, description="Hashes, usually file hashes."))
+    pe: PE | None = odm.Optional(odm.Compound(PE, description="These fields contain Windows Portable Executable (PE) metadata."))

--- a/api/howler/odm/models/ecs/file.py
+++ b/api/howler/odm/models/ecs/file.py
@@ -75,7 +75,7 @@ class File(odm.Model):
     hash: Hashes | None = odm.Optional(
         odm.Compound(
             Hashes,
-            description="These fields contain Windows Portable Executable (PE) metadata.",
+            description="Hashes, usually file hashes.",
         )
     )
     pe: PE | None = odm.Optional(odm.Compound(PE, description="These fields contain Windows Portable Executable (PE) metadata."))

--- a/api/howler/odm/models/ecs/file.py
+++ b/api/howler/odm/models/ecs/file.py
@@ -78,4 +78,6 @@ class File(odm.Model):
             description="Hashes, usually file hashes.",
         )
     )
-    pe: PE | None = odm.Optional(odm.Compound(PE, description="These fields contain Windows Portable Executable (PE) metadata."))
+    pe: PE | None = odm.Optional(
+        odm.Compound(PE, description="These fields contain Windows Portable Executable (PE) metadata.")
+    )


### PR DESCRIPTION
This PR removes the usage of typing.Optional from the ECS file module, and changes the elasticsearch type of `file.size` from "Integer" to "Long".