### PR TITLE
chore(config): remove old eureka discovery flag from configuration

### DIFF
--- a/api/howler/odm/models/config.py
+++ b/api/howler/odm/models/config.py
@@ -505,8 +505,6 @@ class Core(BaseModel):
     notebook: Notebook = Notebook()
     "Configuration for Notebook Integration"
 
-    enable_eureka_discovery: bool = Field(default=True, description="Should Eureka discovery be disabled?")
-
 
 root_path = Path("/etc") / APP_NAME.replace("-dev", "").replace("-stg", "")
 


### PR DESCRIPTION
Accidently left the original Core 'enable_eureka_discovery` setting in place, removing that unused setting.