### PR TITLE
fix(api): added more searchable fields into normalizer

### DIFF
--- a/api/howler/datastore/constants.py
+++ b/api/howler/datastore/constants.py
@@ -81,6 +81,9 @@ NORMALIZER_MAPPING = {
     HowlerHash: "lowercase_normalizer",
     MD5: "lowercase_normalizer",
     CaseInsensitiveKeyword: "lowercase_normalizer",
+    UUID: "lowercase_normalizer",
+    Keyword: "lowercase_normalizer",
+    Text: "lowercase_normalizer",
 }
 
 # TODO: We might want to use custom analyzers for Classification and Enum and not create special backmapping cases

--- a/api/howler/datastore/constants.py
+++ b/api/howler/datastore/constants.py
@@ -82,8 +82,6 @@ NORMALIZER_MAPPING = {
     MD5: "lowercase_normalizer",
     CaseInsensitiveKeyword: "lowercase_normalizer",
     UUID: "lowercase_normalizer",
-    Keyword: "lowercase_normalizer",
-    Text: "lowercase_normalizer",
 }
 
 # TODO: We might want to use custom analyzers for Classification and Enum and not create special backmapping cases


### PR DESCRIPTION
This PR addresses a fix for some fields in howler that were case sensitive when being searched. To mediate this, the normalizer had fields added to it which were used commonly for searching within Howler.

Further clarity needed from PO, before review