### PR TITLE
feat(api): add special-use and private tlds to domain validation

### DIFF
--- a/api/howler/common/net.py
+++ b/api/howler/common/net.py
@@ -9,11 +9,11 @@ from howler.common.net_static import TLDS_ALPHA_BY_DOMAIN
 # https://www.iana.org/assignments/special-use-domain-names/special-use-domain-names.xhtml
 IANA_SPECIAL_USE_TLDS = {
     "LOCALHOST",  # RFC 6761 - loopback address
-    "TEST",       # RFC 6761 - testing
-    "EXAMPLE",    # RFC 6761 - documentation examples
-    "INVALID",    # RFC 6761 - invalid domain names
-    "LOCAL",      # RFC 6762 - mDNS/Bonjour local network names
-    "ONION",      # RFC 7686 - Tor hidden services
+    "TEST",  # RFC 6761 - testing
+    "EXAMPLE",  # RFC 6761 - documentation examples
+    "INVALID",  # RFC 6761 - invalid domain names
+    "LOCAL",  # RFC 6762 - mDNS/Bonjour local network names
+    "ONION",  # RFC 7686 - Tor hidden services
 }
 
 # Common private network suffixes used in enterprise environments
@@ -38,16 +38,27 @@ def is_valid_port(value: Union[int, str, float]) -> bool:
     return False
 
 
-def is_valid_domain(domain: str, allow_private_suffixes: bool = True) -> bool:
+def is_valid_domain(
+    domain: str,
+    allow_special_use_tlds: bool = True,
+    allow_private_suffixes: bool = True,
+) -> bool:
     """Check if a domain is valid.
 
     Args:
         domain: The domain to validate.
-        allow_private_suffixes: If True, accepts common private network suffixes
-            (.internal, .lan, .home, .corp, .localdomain) in addition to IANA
-            special-use TLDs. Set to False for stricter validation in
-            security-sensitive contexts (e.g., SSRF protection).
+        allow_special_use_tlds: If True, accepts IANA special-use TLDs
+            (.localhost, .local, .onion, .test, .example, .invalid).
+            Set to False to reject these domains.
             Defaults to True for backward compatibility.
+        allow_private_suffixes: If True, accepts common private network suffixes
+            (.internal, .lan, .home, .corp, .localdomain).
+            Set to False to reject these domains.
+            Defaults to True for backward compatibility.
+
+    Note:
+        To validate public internet domains only (e.g., for SSRF protection),
+        set both allow_special_use_tlds=False and allow_private_suffixes=False.
 
     Returns:
         True if the domain has a valid TLD, False otherwise.
@@ -57,7 +68,9 @@ def is_valid_domain(domain: str, allow_private_suffixes: bool = True) -> bool:
 
     if "." in domain:
         tld = domain.split(".")[-1].upper()
-        if tld in TLDS_ALPHA_BY_DOMAIN or tld in IANA_SPECIAL_USE_TLDS:
+        if tld in TLDS_ALPHA_BY_DOMAIN:
+            return True
+        if allow_special_use_tlds and tld in IANA_SPECIAL_USE_TLDS:
             return True
         if allow_private_suffixes and tld in PRIVATE_NETWORK_SUFFIXES:
             return True

--- a/api/howler/common/net.py
+++ b/api/howler/common/net.py
@@ -5,6 +5,22 @@ from typing import Union
 
 from howler.common.net_static import TLDS_ALPHA_BY_DOMAIN
 
+# Special-use TLDs per RFC 6761 and RFC 7686
+# These are reserved by IANA for specific purposes and not in the standard TLD list
+SPECIAL_USE_TLDS = {
+    "LOCAL",      # RFC 6762 - mDNS/Bonjour local network names
+    "LOCALHOST",  # RFC 6761 - loopback address
+    "TEST",       # RFC 6761 - testing
+    "EXAMPLE",    # RFC 6761 - documentation examples
+    "INVALID",    # RFC 6761 - invalid domain names
+    "ONION",      # RFC 7686 - Tor hidden services
+    "INTERNAL",   # Common internal network TLD
+    "LAN",        # Common internal network TLD
+    "HOME",       # Common internal network TLD
+    "CORP",       # Common internal network TLD
+    "LOCALDOMAIN",  # Common internal network TLD
+}
+
 
 def is_valid_port(value: Union[int, str, float]) -> bool:
     "Check if a port is valid"
@@ -23,8 +39,8 @@ def is_valid_domain(domain: str) -> bool:
         return False
 
     if "." in domain:
-        tld = domain.split(".")[-1]
-        return tld.upper() in TLDS_ALPHA_BY_DOMAIN
+        tld = domain.split(".")[-1].upper()
+        return tld in TLDS_ALPHA_BY_DOMAIN or tld in SPECIAL_USE_TLDS
 
     return False
 

--- a/api/howler/common/net.py
+++ b/api/howler/common/net.py
@@ -5,20 +5,25 @@ from typing import Union
 
 from howler.common.net_static import TLDS_ALPHA_BY_DOMAIN
 
-# Special-use TLDs per RFC 6761 and RFC 7686
-# These are reserved by IANA for specific purposes and not in the standard TLD list
-SPECIAL_USE_TLDS = {
-    "LOCAL",      # RFC 6762 - mDNS/Bonjour local network names
+# IANA Special-Use Domain Names Registry
+# https://www.iana.org/assignments/special-use-domain-names/special-use-domain-names.xhtml
+IANA_SPECIAL_USE_TLDS = {
     "LOCALHOST",  # RFC 6761 - loopback address
     "TEST",       # RFC 6761 - testing
     "EXAMPLE",    # RFC 6761 - documentation examples
     "INVALID",    # RFC 6761 - invalid domain names
+    "LOCAL",      # RFC 6762 - mDNS/Bonjour local network names
     "ONION",      # RFC 7686 - Tor hidden services
-    "INTERNAL",   # Common internal network TLD
-    "LAN",        # Common internal network TLD
-    "HOME",       # Common internal network TLD
-    "CORP",       # Common internal network TLD
-    "LOCALDOMAIN",  # Common internal network TLD
+}
+
+# Common private network suffixes used in enterprise environments
+# These are NOT IANA-registered but are widely used organizational conventions
+PRIVATE_NETWORK_SUFFIXES = {
+    "INTERNAL",
+    "LAN",
+    "HOME",
+    "CORP",
+    "LOCALDOMAIN",
 }
 
 
@@ -33,14 +38,29 @@ def is_valid_port(value: Union[int, str, float]) -> bool:
     return False
 
 
-def is_valid_domain(domain: str) -> bool:
-    "Check if a domain is valid"
+def is_valid_domain(domain: str, allow_private_suffixes: bool = True) -> bool:
+    """Check if a domain is valid.
+
+    Args:
+        domain: The domain to validate.
+        allow_private_suffixes: If True, accepts common private network suffixes
+            (.internal, .lan, .home, .corp, .localdomain) in addition to IANA
+            special-use TLDs. Set to False for stricter validation in
+            security-sensitive contexts (e.g., SSRF protection).
+            Defaults to True for backward compatibility.
+
+    Returns:
+        True if the domain has a valid TLD, False otherwise.
+    """
     if "@" in domain:
         return False
 
     if "." in domain:
         tld = domain.split(".")[-1].upper()
-        return tld in TLDS_ALPHA_BY_DOMAIN or tld in SPECIAL_USE_TLDS
+        if tld in TLDS_ALPHA_BY_DOMAIN or tld in IANA_SPECIAL_USE_TLDS:
+            return True
+        if allow_private_suffixes and tld in PRIVATE_NETWORK_SUFFIXES:
+            return True
 
     return False
 

--- a/api/test/unit/test_net.py
+++ b/api/test/unit/test_net.py
@@ -25,6 +25,17 @@ def test_valid_domain():
     assert not is_valid_domain("user@cyber.gc.ca")
     assert not is_valid_domain("user")
 
+    # Special-use TLDs (RFC 6761, RFC 7686)
+    assert is_valid_domain("server.local")
+    assert is_valid_domain("machine.localhost")
+    assert is_valid_domain("example.test")
+    assert is_valid_domain("site.example")
+    assert is_valid_domain("hidden.onion")
+    assert is_valid_domain("server.internal")
+    assert is_valid_domain("pc.lan")
+    assert is_valid_domain("router.home")
+    assert is_valid_domain("domain.localdomain")
+
 
 def test_valid_ip():
     assert is_valid_ip("5.5.5.5")

--- a/api/test/unit/test_net.py
+++ b/api/test/unit/test_net.py
@@ -25,16 +25,53 @@ def test_valid_domain():
     assert not is_valid_domain("user@cyber.gc.ca")
     assert not is_valid_domain("user")
 
-    # Special-use TLDs (RFC 6761, RFC 7686)
-    assert is_valid_domain("server.local")
+
+def test_valid_domain_iana_special_use():
+    """Test IANA Special-Use Domain Names Registry entries.
+
+    These are always valid regardless of allow_private_suffixes setting.
+    See: https://www.iana.org/assignments/special-use-domain-names/
+    """
+    # RFC 6761 - Special-Use Domain Names
     assert is_valid_domain("machine.localhost")
     assert is_valid_domain("example.test")
     assert is_valid_domain("site.example")
+    assert is_valid_domain("bad.invalid")
+
+    # RFC 6762 - mDNS/Bonjour
+    assert is_valid_domain("server.local")
+
+    # RFC 7686 - Tor hidden services
     assert is_valid_domain("hidden.onion")
+
+    # IANA special-use TLDs remain valid even with allow_private_suffixes=False
+    assert is_valid_domain("machine.localhost", allow_private_suffixes=False)
+    assert is_valid_domain("example.test", allow_private_suffixes=False)
+    assert is_valid_domain("site.example", allow_private_suffixes=False)
+    assert is_valid_domain("bad.invalid", allow_private_suffixes=False)
+    assert is_valid_domain("server.local", allow_private_suffixes=False)
+    assert is_valid_domain("hidden.onion", allow_private_suffixes=False)
+
+
+def test_valid_domain_private_suffixes():
+    """Test common private network suffixes.
+
+    These are NOT IANA-registered but are widely used organizational conventions.
+    They are accepted by default but can be rejected with allow_private_suffixes=False.
+    """
+    # Private network suffixes - valid by default (allow_private_suffixes=True)
     assert is_valid_domain("server.internal")
     assert is_valid_domain("pc.lan")
     assert is_valid_domain("router.home")
-    assert is_valid_domain("domain.localdomain")
+    assert is_valid_domain("domain.corp")
+    assert is_valid_domain("host.localdomain")
+
+    # Private suffixes rejected when allow_private_suffixes=False
+    assert not is_valid_domain("server.internal", allow_private_suffixes=False)
+    assert not is_valid_domain("pc.lan", allow_private_suffixes=False)
+    assert not is_valid_domain("router.home", allow_private_suffixes=False)
+    assert not is_valid_domain("domain.corp", allow_private_suffixes=False)
+    assert not is_valid_domain("host.localdomain", allow_private_suffixes=False)
 
 
 def test_valid_ip():

--- a/api/test/unit/test_net.py
+++ b/api/test/unit/test_net.py
@@ -29,28 +29,11 @@ def test_valid_domain():
 def test_valid_domain_iana_special_use():
     """Test IANA Special-Use Domain Names Registry entries.
 
-    These are always valid regardless of allow_private_suffixes setting.
     See: https://www.iana.org/assignments/special-use-domain-names/
     """
-    # RFC 6761 - Special-Use Domain Names
-    assert is_valid_domain("machine.localhost")
-    assert is_valid_domain("example.test")
-    assert is_valid_domain("site.example")
-    assert is_valid_domain("bad.invalid")
-
-    # RFC 6762 - mDNS/Bonjour
     assert is_valid_domain("server.local")
-
-    # RFC 7686 - Tor hidden services
-    assert is_valid_domain("hidden.onion")
-
-    # IANA special-use TLDs remain valid even with allow_private_suffixes=False
-    assert is_valid_domain("machine.localhost", allow_private_suffixes=False)
-    assert is_valid_domain("example.test", allow_private_suffixes=False)
-    assert is_valid_domain("site.example", allow_private_suffixes=False)
-    assert is_valid_domain("bad.invalid", allow_private_suffixes=False)
-    assert is_valid_domain("server.local", allow_private_suffixes=False)
-    assert is_valid_domain("hidden.onion", allow_private_suffixes=False)
+    assert is_valid_domain("server.local", allow_special_use_tlds=True)
+    assert not is_valid_domain("server.local", allow_special_use_tlds=False)
 
 
 def test_valid_domain_private_suffixes():
@@ -59,19 +42,36 @@ def test_valid_domain_private_suffixes():
     These are NOT IANA-registered but are widely used organizational conventions.
     They are accepted by default but can be rejected with allow_private_suffixes=False.
     """
-    # Private network suffixes - valid by default (allow_private_suffixes=True)
     assert is_valid_domain("server.internal")
-    assert is_valid_domain("pc.lan")
-    assert is_valid_domain("router.home")
-    assert is_valid_domain("domain.corp")
-    assert is_valid_domain("host.localdomain")
-
-    # Private suffixes rejected when allow_private_suffixes=False
     assert not is_valid_domain("server.internal", allow_private_suffixes=False)
-    assert not is_valid_domain("pc.lan", allow_private_suffixes=False)
-    assert not is_valid_domain("router.home", allow_private_suffixes=False)
-    assert not is_valid_domain("domain.corp", allow_private_suffixes=False)
-    assert not is_valid_domain("host.localdomain", allow_private_suffixes=False)
+
+
+def test_valid_domain_public_only():
+    """Test public internet domain validation.
+
+    Setting both allow_special_use_tlds=False and allow_private_suffixes=False
+    validates only IANA-registered public TLDs, useful for SSRF protection.
+    """
+    # Public internet domains
+    assert is_valid_domain(
+        "cyber.gc.ca", allow_special_use_tlds=False, allow_private_suffixes=False
+    )
+    assert is_valid_domain(
+        "example.com", allow_special_use_tlds=False, allow_private_suffixes=False
+    )
+
+    # IANA special-use TLDs - rejected
+    assert not is_valid_domain(
+        "server.local", allow_special_use_tlds=False, allow_private_suffixes=False
+    )
+    assert not is_valid_domain(
+        "hidden.onion", allow_special_use_tlds=False, allow_private_suffixes=False
+    )
+
+    # Private network suffixes - rejected
+    assert not is_valid_domain(
+        "server.internal", allow_special_use_tlds=False, allow_private_suffixes=False
+    )
 
 
 def test_valid_ip():


### PR DESCRIPTION
This pull request expands the domain validation logic to recognize special-use top-level domains (TLDs) as valid, in accordance with RFC 6761 and RFC 7686. It also updates the test suite to ensure these TLDs are correctly handled.

**Domain validation enhancements:**

* Added a `SPECIAL_USE_TLDS` set in `net.py` to include special-use and common internal TLDs such as `LOCAL`, `LOCALHOST`, `TEST`, `EXAMPLE`, `ONION`, `INTERNAL`, `LAN`, `HOME`, `CORP`, and `LOCALDOMAIN`.
* Updated the `is_valid_domain` function to consider domains ending with any of the `SPECIAL_USE_TLDS` as valid, in addition to standard TLDs.

**Testing improvements:**

* Expanded `test_valid_domain` to include assertions for domains using special-use TLDs, ensuring these cases are now covered by unit tests.