### PR TITLE
feat(ui): added ability to change case escalation

### DIFF
--- a/api/howler/odm/constants.py
+++ b/api/howler/odm/constants.py
@@ -24,10 +24,9 @@ class CaseEscalation(str, HowlerEnum):
     """Enum representing the escalation of a case in Howler.
 
     Args:
-      OPEN (str): Record is open and unresolved.
-      IN_PROGRESS (str): Record is currently being investigated.
-      ON_HOLD (str): Record processing is on hold.
-      RESOLVED (str): Record has been resolved.
+      NORMAL (str): Default escalation level.
+      FOCUS (str): Elevated escalation level requiring extra attention.
+      CRISIS (str): Highest escalation level requiring urgent response.
     """
 
     NORMAL = "normal"

--- a/api/howler/odm/constants.py
+++ b/api/howler/odm/constants.py
@@ -18,3 +18,21 @@ class Status(str, HowlerEnum):
 
     def __str__(self) -> str:
         return self.value
+
+
+class CaseEscalation(str, HowlerEnum):
+    """Enum representing the escalation of a case in Howler.
+
+    Args:
+      OPEN (str): Record is open and unresolved.
+      IN_PROGRESS (str): Record is currently being investigated.
+      ON_HOLD (str): Record processing is on hold.
+      RESOLVED (str): Record has been resolved.
+    """
+
+    NORMAL = "normal"
+    FOCUS = "focus"
+    CRISIS = "crisis"
+
+    def __str__(self) -> str:
+        return self.value

--- a/api/howler/odm/models/case.py
+++ b/api/howler/odm/models/case.py
@@ -1,9 +1,9 @@
-from typing import Any, Optional
+from typing import Any, Literal, Optional
 
 from howler import odm
 from howler.common.exceptions import HowlerValueError
 from howler.config import CLASSIFICATION
-from howler.odm.constants import Status
+from howler.odm.constants import CaseEscalation, Status
 from howler.odm.mixins import DatastoreMixin
 from howler.utils.compat import StrEnum
 
@@ -130,8 +130,10 @@ class Case(DatastoreMixin["Case"], odm.Model):
     title: str = odm.Keyword(description="Case title.")
     summary: str = odm.Text(description="Short case summary.")
     overview: str = odm.Optional(odm.Text(description="Markdown overview of the case."))
-    escalation: str = odm.Optional(odm.Keyword(description="Escalation of the case."))
-    status = odm.Enum(values=Status, default=Status.OPEN, description="Status of the case.")
+    escalation: Literal["normal", "focus", "crisis"] = odm.Enum(
+        values=CaseEscalation, default=CaseEscalation.NORMAL, description="Escalation of the case."
+    )
+    status: str = odm.Enum(values=Status, default=Status.OPEN, description="Status of the case.")
     created: str = odm.Optional(odm.Date(default="NOW", description="Date/time when the case was created."))
     visible: bool = odm.Boolean(default=True, description="Whether the case is visible/accessible in the frontend.")
     updated: Optional[str] = odm.Optional(

--- a/api/howler/services/config_service.py
+++ b/api/howler/services/config_service.py
@@ -12,6 +12,7 @@ from howler.common.logging import get_logger
 from howler.config import CLASSIFICATION, config, get_branch, get_commit, get_version
 from howler.helper.discover import get_apps_list
 from howler.helper.search import list_all_fields
+from howler.odm.constants import CaseEscalation
 from howler.odm.models.howler_data import Assessment, Escalation, Scrutiny, Status
 from howler.odm.models.user import User
 from howler.plugins import get_plugins
@@ -85,6 +86,7 @@ def get_configuration(user: User | None, **kwargs):
 
     return {
         "lookups": {
+            "case.escalation": CaseEscalation.list(),
             "howler.status": Status.list(),
             "howler.scrutiny": Scrutiny.list(),
             "howler.escalation": Escalation.list(),

--- a/api/test/unit/endpoints/test_case_endpoint.py
+++ b/api/test/unit/endpoints/test_case_endpoint.py
@@ -61,7 +61,7 @@ class TestGetCase:
             "title": "Test Case",
             "summary": "summary",
             "overview": "overview",
-            "escalation": "high",
+            "escalation": "crisis",
         }
         mock_datastore.return_value.case.get_if_exists.return_value = case_data
 
@@ -76,7 +76,7 @@ class TestGetCase:
             body = result.get_json()
             assert body["api_response"]["case_id"] == "case-001"
             assert body["api_response"]["title"] == "Test Case"
-            assert body["api_response"]["escalation"] == "high"
+            assert body["api_response"]["escalation"] == "crisis"
             mock_datastore.return_value.case.get_if_exists.assert_called_once_with(key="case-001", as_obj=False)
 
     @patch("howler.api.v2.case.datastore")
@@ -291,7 +291,7 @@ class TestUpdateCaseEndpoint:
                 "title": "Updated Title",
                 "summary": "S",
                 "overview": "O",
-                "escalation": "low",
+                "escalation": "normal",
             }
         )
         mock_case_service.update_case.return_value = updated

--- a/api/test/unit/odm/test_case.py
+++ b/api/test/unit/odm/test_case.py
@@ -372,7 +372,7 @@ class TestCase:
                 "title": "Incident Alpha",
                 "summary": "Summary text",
                 "overview": "## Overview markdown",
-                "escalation": "high",
+                "escalation": "focus",
             }
         )
 
@@ -380,7 +380,7 @@ class TestCase:
         assert case.title == "Incident Alpha"
         assert case.summary == "Summary text"
         assert case.overview == "## Overview markdown"
-        assert case.escalation == "high"
+        assert case.escalation == "focus"
         assert isinstance(case.created, datetime)  # default NOW produces a real datetime
         assert (
             abs((case.created - datetime.now(timezone.utc)).total_seconds()) < 60

--- a/api/test/unit/odm/test_case.py
+++ b/api/test/unit/odm/test_case.py
@@ -23,11 +23,11 @@ class TestCaseLog:
     def test_create_case_log_without_explanation_requires_timestamp_new_value_user(self):
         """CaseLog without explanation requires timestamp, new_value, and user."""
         log = CaseLog(
-            {"timestamp": "NOW", "key": "escalation", "previous_value": "low", "new_value": "high", "user": "bob"}
+            {"timestamp": "NOW", "key": "escalation", "previous_value": "low", "new_value": "crisis", "user": "bob"}
         )
 
         assert log.user == "bob"
-        assert log.new_value == "high"
+        assert log.new_value == "crisis"
         assert log.previous_value == "low"
         assert log.key == "escalation"
 
@@ -39,7 +39,7 @@ class TestCaseLog:
     def test_create_case_log_missing_user_without_explanation_raises(self):
         """CaseLog raises HowlerValueError when explanation is absent and user is missing."""
         with pytest.raises(HowlerValueError):
-            CaseLog({"timestamp": "NOW", "new_value": "high"})  # no explanation and no user
+            CaseLog({"timestamp": "NOW", "new_value": "crisis"})  # no explanation and no user
 
     def test_case_log_as_primitives(self):
         """as_primitives returns a plain dict containing all stored fields."""
@@ -48,7 +48,7 @@ class TestCaseLog:
                 "timestamp": "NOW",
                 "key": "escalation",
                 "previous_value": "low",
-                "new_value": "high",
+                "new_value": "crisis",
                 "user": "alice",
             }
         )
@@ -56,7 +56,7 @@ class TestCaseLog:
 
         assert isinstance(primitives, dict)
         assert primitives["user"] == "alice"
-        assert primitives["new_value"] == "high"
+        assert primitives["new_value"] == "crisis"
         assert primitives["previous_value"] == "low"
         assert primitives["key"] == "escalation"
 
@@ -350,7 +350,7 @@ class TestCase:
                     # missing 'title'
                     "summary": "S",
                     "overview": "O",
-                    "escalation": "high",
+                    "escalation": "crisis",
                 }
             )
 
@@ -360,7 +360,7 @@ class TestCase:
                     "title": "T",
                     # missing 'summary'
                     "overview": "O",
-                    "escalation": "high",
+                    "escalation": "crisis",
                 }
             )
 
@@ -447,7 +447,7 @@ class TestCase:
                 "title": "With Rules",
                 "summary": "S",
                 "overview": "O",
-                "escalation": "high",
+                "escalation": "crisis",
                 "rules": [
                     {"destination": "/critical", "query": "howler.score:>90", "author": "analyst"},
                 ],
@@ -491,7 +491,7 @@ class TestCase:
                 "title": "With Enrichments",
                 "summary": "S",
                 "overview": "O",
-                "escalation": "high",
+                "escalation": "crisis",
                 "enrichments": [
                     {"path": "/obs/ip", "annotations": ["ann-1"]},
                 ],
@@ -577,7 +577,7 @@ class TestCase:
                 "title": "Hidden Case",
                 "summary": "S",
                 "overview": "O",
-                "escalation": "high",
+                "escalation": "crisis",
                 "visible": False,
             }
         )

--- a/api/test/unit/odm/test_case.py
+++ b/api/test/unit/odm/test_case.py
@@ -405,7 +405,7 @@ class TestCase:
                 "title": "Incident Beta",
                 "summary": "Summary",
                 "overview": "Overview",
-                "escalation": "low",
+                "escalation": "normal",
                 "targets": ["server-1", "server-2"],
                 "threats": ["apt-29"],
                 "indicators": ["ioc-hash-abc"],
@@ -427,7 +427,7 @@ class TestCase:
                 "title": "With Items",
                 "summary": "S",
                 "overview": "O",
-                "escalation": "medium",
+                "escalation": "focus",
                 "items": [
                     {"path": "/events", "type": "event", "value": "1.2.3.4", "id": "obs-1"},
                     {"path": "/hits", "type": "hit", "value": "hit-abc"},
@@ -466,7 +466,7 @@ class TestCase:
                 "title": "With Tasks",
                 "summary": "S",
                 "overview": "O",
-                "escalation": "low",
+                "escalation": "normal",
                 "tasks": [
                     {
                         "id": "00000000-0000-0000-0000-000000000010",
@@ -509,7 +509,7 @@ class TestCase:
                 "title": "Roundtrip",
                 "summary": "Summary",
                 "overview": "Overview",
-                "escalation": "medium",
+                "escalation": "focus",
                 "targets": ["t1"],
                 "items": [{"path": "/a", "type": "hit", "value": "v1"}],
                 "rules": [{"destination": "/b", "query": "q", "author": "admin"}],
@@ -563,7 +563,7 @@ class TestCase:
                 "title": "Visibility Default",
                 "summary": "S",
                 "overview": "O",
-                "escalation": "low",
+                "escalation": "normal",
             }
         )
 
@@ -592,7 +592,7 @@ class TestCase:
                 "title": "T",
                 "summary": "S",
                 "overview": "O",
-                "escalation": "medium",
+                "escalation": "focus",
             }
         )
 
@@ -608,7 +608,7 @@ class TestCase:
                 "title": "Dates",
                 "summary": "S",
                 "overview": "O",
-                "escalation": "low",
+                "escalation": "normal",
                 "start": "2025-01-01T00:00:00Z",
                 "end": "2025-12-31T23:59:59Z",
             }
@@ -632,7 +632,7 @@ class TestCase:
                     "title": "T",
                     "summary": "S",
                     "overview": "O",
-                    "escalation": "low",
+                    "escalation": "normal",
                     "start": "not-a-date",
                 }
             )
@@ -645,7 +645,7 @@ class TestCase:
                 "title": "T",
                 "summary": "S",
                 "overview": "O",
-                "escalation": "low",
+                "escalation": "normal",
                 "log": [
                     {"timestamp": "NOW", "explanation": "Case created", "user": "admin"},
                 ],

--- a/api/test/unit/services/test_case_service.py
+++ b/api/test/unit/services/test_case_service.py
@@ -153,7 +153,7 @@ class TestUpdateCase:
                 "title": "T",
                 "summary": "S",
                 "overview": "O",
-                "escalation": "low",
+                "escalation": "normal",
             }
         )
 
@@ -174,7 +174,7 @@ class TestUpdateCase:
                 "title": "Old Title",
                 "summary": "S",
                 "overview": "O",
-                "escalation": "low",
+                "escalation": "normal",
             }
         )
 
@@ -198,7 +198,7 @@ class TestUpdateCase:
         mock_ds = MagicMock()
         mock_ds_fn.return_value = mock_ds
         mock_ds.case.get.return_value = Case(
-            {"case_id": "case-001", "title": "T", "summary": "S", "overview": "O", "escalation": "low"}
+            {"case_id": "case-001", "title": "T", "summary": "S", "overview": "O", "escalation": "normal"}
         )
         mock_user = MagicMock()
         mock_user.uname = "analyst"
@@ -212,7 +212,7 @@ class TestUpdateCase:
         mock_ds = MagicMock()
         mock_ds_fn.return_value = mock_ds
         mock_ds.case.get.return_value = Case(
-            {"case_id": "case-001", "title": "T", "summary": "S", "overview": "O", "escalation": "low"}
+            {"case_id": "case-001", "title": "T", "summary": "S", "overview": "O", "escalation": "normal"}
         )
         mock_user = MagicMock()
         mock_user.uname = "analyst"
@@ -228,7 +228,7 @@ class TestUpdateCase:
         mock_ds = MagicMock()
         mock_ds_fn.return_value = mock_ds
         mock_ds.case.get.return_value = Case(
-            {"case_id": "case-001", "title": "T", "summary": "S", "overview": "O", "escalation": "low"}
+            {"case_id": "case-001", "title": "T", "summary": "S", "overview": "O", "escalation": "normal"}
         )
         mock_user = MagicMock()
         mock_user.uname = "analyst"
@@ -247,7 +247,7 @@ class TestUpdateCase:
                 "title": "T",
                 "summary": "S",
                 "overview": "O",
-                "escalation": "low",
+                "escalation": "normal",
                 "targets": ["host-a", "host-b"],
             }
         )
@@ -270,7 +270,7 @@ class TestUpdateCase:
                 "title": "T",
                 "summary": "S",
                 "overview": "O",
-                "escalation": "low",
+                "escalation": "normal",
                 "targets": ["host-a"],
             }
         )
@@ -289,7 +289,7 @@ class TestUpdateCase:
         mock_ds = MagicMock()
         mock_ds_fn.return_value = mock_ds
         mock_ds.case.get.return_value = Case(
-            {"case_id": "case-001", "title": "T", "summary": "S", "overview": "O", "escalation": "low"}
+            {"case_id": "case-001", "title": "T", "summary": "S", "overview": "O", "escalation": "normal"}
         )
         mock_user = MagicMock()
         mock_user.uname = "analyst"
@@ -1497,7 +1497,7 @@ class TestCaseEventEmission:
         mock_ds = MagicMock()
         mock_ds_fn.return_value = mock_ds
         mock_ds.case.get.return_value = Case(
-            {"case_id": "case-001", "title": "T", "summary": "S", "overview": "O", "escalation": "low"}
+            {"case_id": "case-001", "title": "T", "summary": "S", "overview": "O", "escalation": "normal"}
         )
 
         mock_user = MagicMock()
@@ -1534,7 +1534,7 @@ class TestCaseEventEmission:
         mock_ds = MagicMock()
         mock_ds_fn.return_value = mock_ds
 
-        mock_case = Case({"case_id": "case-001", "title": "T", "summary": "S", "overview": "O", "escalation": "low"})
+        mock_case = Case({"case_id": "case-001", "title": "T", "summary": "S", "overview": "O", "escalation": "normal"})
         mock_hit = MagicMock()
         mock_hit.howler.related = []
         mock_hit.howler.id = "hit-001"
@@ -1559,7 +1559,7 @@ class TestCaseEventEmission:
         mock_ds = MagicMock()
         mock_ds_fn.return_value = mock_ds
 
-        mock_case = Case({"case_id": "case-001", "title": "T", "summary": "S", "overview": "O", "escalation": "low"})
+        mock_case = Case({"case_id": "case-001", "title": "T", "summary": "S", "overview": "O", "escalation": "normal"})
         mock_hit = MagicMock()
         mock_hit.howler.related = []
         mock_hit.howler.id = "hit-001"
@@ -1590,7 +1590,7 @@ class TestAddCaseRule:
         mock_ds = MagicMock()
         mock_ds_fn.return_value = mock_ds
 
-        mock_case = Case({"case_id": "case-001", "title": "T", "summary": "S", "overview": "O", "escalation": "low"})
+        mock_case = Case({"case_id": "case-001", "title": "T", "summary": "S", "overview": "O", "escalation": "normal"})
         mock_ds.case.get.return_value = mock_case
 
         user = MagicMock()
@@ -1617,7 +1617,7 @@ class TestAddCaseRule:
         mock_ds = MagicMock()
         mock_ds_fn.return_value = mock_ds
 
-        mock_case = Case({"case_id": "case-001", "title": "T", "summary": "S", "overview": "O", "escalation": "low"})
+        mock_case = Case({"case_id": "case-001", "title": "T", "summary": "S", "overview": "O", "escalation": "normal"})
         mock_ds.case.get.return_value = mock_case
 
         user = MagicMock()
@@ -1654,7 +1654,7 @@ class TestAddCaseRule:
         mock_ds = MagicMock()
         mock_ds_fn.return_value = mock_ds
 
-        mock_case = Case({"case_id": "case-001", "title": "T", "summary": "S", "overview": "O", "escalation": "low"})
+        mock_case = Case({"case_id": "case-001", "title": "T", "summary": "S", "overview": "O", "escalation": "normal"})
         mock_ds.case.get.return_value = mock_case
 
         user = MagicMock()
@@ -1669,7 +1669,7 @@ class TestAddCaseRule:
         mock_ds = MagicMock()
         mock_ds_fn.return_value = mock_ds
 
-        mock_case = Case({"case_id": "case-001", "title": "T", "summary": "S", "overview": "O", "escalation": "low"})
+        mock_case = Case({"case_id": "case-001", "title": "T", "summary": "S", "overview": "O", "escalation": "normal"})
         mock_ds.case.get.return_value = mock_case
 
         user = MagicMock()
@@ -1685,7 +1685,7 @@ class TestAddCaseRule:
         mock_ds = MagicMock()
         mock_ds_fn.return_value = mock_ds
 
-        mock_case = Case({"case_id": "case-001", "title": "T", "summary": "S", "overview": "O", "escalation": "low"})
+        mock_case = Case({"case_id": "case-001", "title": "T", "summary": "S", "overview": "O", "escalation": "normal"})
         mock_ds.case.get.return_value = mock_case
 
         user = MagicMock()
@@ -1716,7 +1716,7 @@ class TestRemoveCaseRule:
         mock_ds_fn.return_value = mock_ds
 
         rule = CaseRule({"query": "*:*", "destination": "alerts/all", "author": "admin"})
-        mock_case = Case({"case_id": "case-001", "title": "T", "summary": "S", "overview": "O", "escalation": "low"})
+        mock_case = Case({"case_id": "case-001", "title": "T", "summary": "S", "overview": "O", "escalation": "normal"})
         mock_case.rules.append(rule)
         mock_ds.case.get.return_value = mock_case
 
@@ -1734,7 +1734,7 @@ class TestRemoveCaseRule:
         mock_ds = MagicMock()
         mock_ds_fn.return_value = mock_ds
 
-        mock_case = Case({"case_id": "case-001", "title": "T", "summary": "S", "overview": "O", "escalation": "low"})
+        mock_case = Case({"case_id": "case-001", "title": "T", "summary": "S", "overview": "O", "escalation": "normal"})
         mock_ds.case.get.return_value = mock_case
 
         user = MagicMock()
@@ -1773,7 +1773,7 @@ class TestUpdateCaseRule:
         mock_ds_fn.return_value = mock_ds
 
         rule = CaseRule({"query": "*:*", "destination": "alerts/all", "author": "admin", "enabled": True})
-        mock_case = Case({"case_id": "case-001", "title": "T", "summary": "S", "overview": "O", "escalation": "low"})
+        mock_case = Case({"case_id": "case-001", "title": "T", "summary": "S", "overview": "O", "escalation": "normal"})
         mock_case.rules.append(rule)
         mock_ds.case.get.return_value = mock_case
 
@@ -1793,7 +1793,7 @@ class TestUpdateCaseRule:
         mock_ds_fn.return_value = mock_ds
 
         rule = CaseRule({"query": "old:query", "destination": "alerts/all", "author": "admin"})
-        mock_case = Case({"case_id": "case-001", "title": "T", "summary": "S", "overview": "O", "escalation": "low"})
+        mock_case = Case({"case_id": "case-001", "title": "T", "summary": "S", "overview": "O", "escalation": "normal"})
         mock_case.rules.append(rule)
         mock_ds.case.get.return_value = mock_case
 
@@ -1811,7 +1811,7 @@ class TestUpdateCaseRule:
         mock_ds_fn.return_value = mock_ds
 
         rule = CaseRule({"query": "*:*", "destination": "alerts/all", "author": "admin"})
-        mock_case = Case({"case_id": "case-001", "title": "T", "summary": "S", "overview": "O", "escalation": "low"})
+        mock_case = Case({"case_id": "case-001", "title": "T", "summary": "S", "overview": "O", "escalation": "normal"})
         mock_case.rules.append(rule)
         mock_ds.case.get.return_value = mock_case
 
@@ -1827,7 +1827,7 @@ class TestUpdateCaseRule:
         mock_ds = MagicMock()
         mock_ds_fn.return_value = mock_ds
 
-        mock_case = Case({"case_id": "case-001", "title": "T", "summary": "S", "overview": "O", "escalation": "low"})
+        mock_case = Case({"case_id": "case-001", "title": "T", "summary": "S", "overview": "O", "escalation": "normal"})
         mock_ds.case.get.return_value = mock_case
 
         user = MagicMock()

--- a/ui/src/components/routes/cases/detail/CaseDetails.test.tsx
+++ b/ui/src/components/routes/cases/detail/CaseDetails.test.tsx
@@ -137,7 +137,7 @@ describe('CaseDetails', () => {
     render(<CaseDetails case={testCase} />, { wrapper: Wrapper });
 
     expect(screen.getByText('page.cases.detail.escalation')).toBeInTheDocument();
-    expect(screen.getByDisplayValue('hit')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('normal')).toBeInTheDocument();
   });
 
   describe('status changes', () => {

--- a/ui/src/components/routes/cases/detail/CaseDetails.test.tsx
+++ b/ui/src/components/routes/cases/detail/CaseDetails.test.tsx
@@ -69,7 +69,7 @@ vi.mock('../modals/ResolveModal', () => ({
 const mockConfig = {
   lookups: {
     'howler.status': ['open', 'in-progress', 'on-hold', 'resolved'],
-    'case.escalation': ['miss', 'hit', 'alert', 'evidence'],
+    'case.escalation': ['normal', 'focus', 'crisis'],
     'howler.escalation': ['miss', 'hit', 'alert', 'evidence']
   }
 } as any;
@@ -115,7 +115,7 @@ describe('CaseDetails', () => {
     user = userEvent.setup();
     vi.clearAllMocks();
     mockUpdate.mockResolvedValue(undefined);
-    testCase = createMockCase({ case_id: 'test-case-id', status: 'open', escalation: 'hit' }) as Case;
+    testCase = createMockCase({ case_id: 'test-case-id', status: 'open', escalation: 'normal' }) as Case;
     Object.keys(mockViewers).forEach(k => delete mockViewers[k]);
   });
 
@@ -167,11 +167,11 @@ describe('CaseDetails', () => {
     it('calls update with the new escalation when an option is selected', async () => {
       render(<CaseDetails case={testCase} />, { wrapper: Wrapper });
 
-      await user.click(screen.getByDisplayValue('hit'));
-      await user.click(await screen.findByRole('option', { name: 'alert' }));
+      await user.click(screen.getByDisplayValue('normal'));
+      await user.click(await screen.findByRole('option', { name: 'focus' }));
 
       await waitFor(() => {
-        expect(mockUpdate).toHaveBeenCalledWith({ escalation: 'alert' });
+        expect(mockUpdate).toHaveBeenCalledWith({ escalation: 'focus' });
       });
     });
   });

--- a/ui/src/components/routes/cases/detail/CaseDetails.test.tsx
+++ b/ui/src/components/routes/cases/detail/CaseDetails.test.tsx
@@ -1,0 +1,195 @@
+/// <reference types="vitest" />
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent, { type UserEvent } from '@testing-library/user-event';
+import { ApiConfigContext } from 'components/app/providers/ApiConfigProvider';
+import { SocketContext } from 'components/app/providers/SocketProvider';
+import type { Case } from 'models/entities/generated/Case';
+import { type FC, type PropsWithChildren } from 'react';
+import { createMockCase } from 'tests/utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+// ---------------------------------------------------------------------------
+// Hoisted stubs
+// ---------------------------------------------------------------------------
+
+const mockUpdate = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const mockShowModal = vi.hoisted(() => vi.fn());
+
+// ---------------------------------------------------------------------------
+// Module mocks (registered before the dynamic import below)
+// ---------------------------------------------------------------------------
+
+vi.mock('../hooks/useCase', () => ({
+  default: ({ case: c }: { case: Case }) => ({
+    case: c,
+    update: mockUpdate,
+    loading: false,
+    missing: false
+  })
+}));
+
+vi.mock('components/app/providers/ModalProvider', async () => {
+  const { createContext } = await import('react');
+  return {
+    ModalContext: createContext({
+      showModal: mockShowModal,
+      close: vi.fn(),
+      setContent: vi.fn(),
+      withConfirmDeleteModal: vi.fn()
+    })
+  };
+});
+
+vi.mock('components/elements/UserList', () => ({
+  default: () => <div id="user-list" />
+}));
+
+vi.mock('components/elements/display/HowlerAvatar', () => ({
+  default: ({ userId }: { userId: string }) => <div>{userId}</div>
+}));
+
+vi.mock('components/elements/display/icons/SocketBadge', () => ({
+  default: () => <span />
+}));
+
+vi.mock('./aggregates/SourceAggregate', () => ({
+  default: () => <span />
+}));
+
+vi.mock('../modals/ResolveModal', () => ({
+  default: () => null
+}));
+
+// ---------------------------------------------------------------------------
+// Shared provider config
+// ---------------------------------------------------------------------------
+
+const mockConfig = {
+  lookups: {
+    'howler.status': ['open', 'in-progress', 'on-hold', 'resolved'],
+    'case.escalation': ['miss', 'hit', 'alert', 'evidence'],
+    'howler.escalation': ['miss', 'hit', 'alert', 'evidence']
+  }
+} as any;
+
+const mockViewers: Record<string, string[]> = {};
+
+const Wrapper: FC<PropsWithChildren> = ({ children }) => (
+  <ApiConfigContext.Provider value={{ config: mockConfig, setConfig: vi.fn() }}>
+    <SocketContext.Provider
+      value={
+        {
+          emit: vi.fn(),
+          open: true,
+          fetchViewers: vi.fn(),
+          addListener: vi.fn(),
+          removeListener: vi.fn(),
+          status: 1,
+          reconnect: vi.fn(),
+          viewers: { ...mockViewers }
+        } as any
+      }
+    >
+      {children}
+    </SocketContext.Provider>
+  </ApiConfigContext.Provider>
+);
+
+// ---------------------------------------------------------------------------
+// Import after mocks
+// ---------------------------------------------------------------------------
+
+const { default: CaseDetails } = await import('./CaseDetails');
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('CaseDetails', () => {
+  let user: UserEvent;
+  let testCase: Case;
+
+  beforeEach(() => {
+    user = userEvent.setup();
+    vi.clearAllMocks();
+    mockUpdate.mockResolvedValue(undefined);
+    testCase = createMockCase({ case_id: 'test-case-id', status: 'open', escalation: 'hit' }) as Case;
+    Object.keys(mockViewers).forEach(k => delete mockViewers[k]);
+  });
+
+  it('renders a skeleton and no controls when the case is null', () => {
+    render(<CaseDetails case={null as any} />, { wrapper: Wrapper });
+
+    expect(document.querySelector('.MuiSkeleton-root')).toBeTruthy();
+    expect(screen.queryByRole('combobox')).toBeNull();
+  });
+
+  it('renders the status label and current status value', () => {
+    render(<CaseDetails case={testCase} />, { wrapper: Wrapper });
+
+    expect(screen.getByText('page.cases.detail.status')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('open')).toBeInTheDocument();
+  });
+
+  it('renders the escalation label and current escalation value', () => {
+    render(<CaseDetails case={testCase} />, { wrapper: Wrapper });
+
+    expect(screen.getByText('page.cases.detail.escalation')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('hit')).toBeInTheDocument();
+  });
+
+  describe('status changes', () => {
+    it('calls update with the new status when a non-resolved option is selected', async () => {
+      render(<CaseDetails case={testCase} />, { wrapper: Wrapper });
+
+      await user.click(screen.getByDisplayValue('open'));
+      await user.click(await screen.findByRole('option', { name: 'in-progress' }));
+
+      await waitFor(() => {
+        expect(mockUpdate).toHaveBeenCalledWith({ status: 'in-progress' });
+      });
+    });
+
+    it('opens the resolve modal instead of calling update when "resolved" is selected', async () => {
+      render(<CaseDetails case={testCase} />, { wrapper: Wrapper });
+
+      await user.click(screen.getByDisplayValue('open'));
+      await user.click(await screen.findByRole('option', { name: 'resolved' }));
+
+      expect(mockShowModal).toHaveBeenCalledOnce();
+      expect(mockUpdate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('escalation changes', () => {
+    it('calls update with the new escalation when an option is selected', async () => {
+      render(<CaseDetails case={testCase} />, { wrapper: Wrapper });
+
+      await user.click(screen.getByDisplayValue('hit'));
+      await user.click(await screen.findByRole('option', { name: 'alert' }));
+
+      await waitFor(() => {
+        expect(mockUpdate).toHaveBeenCalledWith({ escalation: 'alert' });
+      });
+    });
+  });
+
+  describe('viewers section', () => {
+    it('hides the viewers section when no viewers are active', () => {
+      render(<CaseDetails case={testCase} />, { wrapper: Wrapper });
+
+      expect(screen.queryByText('page.cases.detail.viewers')).toBeNull();
+    });
+
+    it('shows the viewers section and renders viewer avatars when active viewers are present', () => {
+      mockViewers['test-case-id'] = ['user-1', 'user-2'];
+      render(<CaseDetails case={testCase} />, { wrapper: Wrapper });
+
+      expect(screen.getByText('page.cases.detail.viewers')).toBeInTheDocument();
+      expect(screen.getByText('user-1')).toBeInTheDocument();
+      expect(screen.getByText('user-2')).toBeInTheDocument();
+    });
+  });
+});

--- a/ui/src/components/routes/cases/detail/CaseDetails.tsx
+++ b/ui/src/components/routes/cases/detail/CaseDetails.tsx
@@ -1,9 +1,16 @@
-import { Check, FormatListBulleted, HourglassBottom, Pause, People, WarningRounded } from '@mui/icons-material';
+import {
+  Check,
+  FormatListBulleted,
+  HourglassBottom,
+  Pause,
+  People,
+  TrendingUp,
+  WarningRounded
+} from '@mui/icons-material';
 import {
   Autocomplete,
   AvatarGroup,
   Card,
-  Chip,
   Divider,
   LinearProgress,
   Skeleton,
@@ -25,6 +32,7 @@ import dayjs from 'dayjs';
 import type { Case } from 'models/entities/generated/Case';
 import { useContext, useState, type FC } from 'react';
 import { useTranslation } from 'react-i18next';
+import { ESCALATION_COLOR_MAP } from '../constants';
 import useCase from '../hooks/useCase';
 import ResolveModal from '../modals/ResolveModal';
 import SourceAggregate from './aggregates/SourceAggregate';
@@ -107,6 +115,19 @@ const CaseDetails: FC<{ case: Case }> = ({ case: providedCase }) => {
             renderInput={params => <TextField {...params} size="small" />}
             onChange={(_ev, status) => handleStatus(status)}
           />
+
+          <Stack direction="row" spacing={1} alignItems="center">
+            <TrendingUp color={ESCALATION_COLOR_MAP[_case.escalation]} />
+            <Typography variant="body1">{t('page.cases.detail.escalation')}</Typography>
+          </Stack>
+          <Autocomplete
+            size="small"
+            disabled={loading}
+            value={_case.escalation ?? null}
+            options={config.lookups['case.escalation']}
+            renderInput={params => <TextField {...params} size="small" />}
+            onChange={(_ev, escalation) => wrappedUpdate({ escalation })}
+          />
         </Stack>
         <Divider />
         <Stack spacing={1}>
@@ -158,14 +179,6 @@ const CaseDetails: FC<{ case: Case }> = ({ case: providedCase }) => {
           </Stack>
           <Table sx={{ '& td': { p: 1 } }}>
             <TableBody>
-              <TableRow>
-                <TableCell>
-                  <Typography variant="caption">{t('page.cases.escalation')}</Typography>
-                </TableCell>
-                <TableCell>
-                  <Chip size="small" label={_case.escalation} />
-                </TableCell>
-              </TableRow>
               <TableRow>
                 <TableCell>
                   <Typography variant="caption">{t('page.cases.created')}</Typography>

--- a/ui/src/components/routes/cases/detail/CaseDetails.tsx
+++ b/ui/src/components/routes/cases/detail/CaseDetails.tsx
@@ -110,10 +110,15 @@ const CaseDetails: FC<{ case: Case }> = ({ case: providedCase }) => {
           <Autocomplete
             size="small"
             disabled={loading}
+            disableClearable
             value={_case.status}
             options={config.lookups['howler.status']}
             renderInput={params => <TextField {...params} size="small" />}
-            onChange={(_ev, status) => handleStatus(status)}
+            onChange={(_ev, status) => {
+              if (status) {
+                handleStatus(status);
+              }
+            }}
           />
 
           <Stack direction="row" spacing={1} alignItems="center">
@@ -123,10 +128,15 @@ const CaseDetails: FC<{ case: Case }> = ({ case: providedCase }) => {
           <Autocomplete
             size="small"
             disabled={loading}
+            disableClearable
             value={_case.escalation ?? null}
             options={config.lookups['case.escalation']}
             renderInput={params => <TextField {...params} size="small" />}
-            onChange={(_ev, escalation) => wrappedUpdate({ escalation })}
+            onChange={(_ev, escalation) => {
+              if (escalation) {
+                wrappedUpdate({ escalation });
+              }
+            }}
           />
         </Stack>
         <Divider />

--- a/ui/src/locales/en/translation.json
+++ b/ui/src/locales/en/translation.json
@@ -420,6 +420,7 @@
   "page.cases.detail.participants": "Participants",
   "page.cases.detail.properties": "Properties",
   "page.cases.detail.status": "Status",
+  "page.cases.detail.escalation": "Escalation",
   "page.cases.detail.viewers": "Active Viewers",
   "page.cases.escalation": "Escalation",
   "page.cases.folder.drop.root": "Place here to move to root",

--- a/ui/src/locales/fr/translation.json
+++ b/ui/src/locales/fr/translation.json
@@ -420,6 +420,7 @@
   "page.cases.detail.participants": "Participants",
   "page.cases.detail.properties": "Propriétés",
   "page.cases.detail.status": "Statut",
+  "page.cases.detail.escalation": "Escalade",
   "page.cases.detail.viewers": "Spectateurs actifs",
   "page.cases.escalation": "Escalade",
   "page.cases.folder.drop.root": "Déposer ici pour déplacer à la racine",


### PR DESCRIPTION
Add ability to change case escalation from the case details section

Related Issue: SPBK-4184

---

This pull request introduces a new `CaseEscalation` enum to standardize escalation levels for cases, updates the backend and frontend to use this enum, and refactors how escalation is displayed and edited in the UI. It also adds comprehensive frontend tests for the `CaseDetails` component. The most important changes are summarized below:

---

**Backend: Case Escalation Standardization**
* Added a new `CaseEscalation` enum (`"normal"`, `"focus"`, `"crisis"`) to `howler/odm/constants.py` for consistent escalation values.
* Updated the `Case` model to use the new `CaseEscalation` enum and restrict escalation to `"normal"`, `"focus"`, or `"crisis"` (instead of a free-form string).
* Updated the configuration service to expose the new escalation values in the API lookup data.

**Tests and Data Consistency**
* Updated backend tests to use valid escalation values (e.g., `"focus"` instead of `"high"`) to match the new enum.

**Frontend: UI Refactor and Tests**
* Refactored the `CaseDetails` UI to display and allow editing of escalation using the new enum values, including a new icon and color mapping for escalation. [[1]](diffhunk://#diff-819b5df459b6ae3a94e0d893e875d0971f040a67dab8ecc5558a5399c0372a4cR118-R130) [[2]](diffhunk://#diff-819b5df459b6ae3a94e0d893e875d0971f040a67dab8ecc5558a5399c0372a4cL161-L168) [[3]](diffhunk://#diff-819b5df459b6ae3a94e0d893e875d0971f040a67dab8ecc5558a5399c0372a4cL1-L6) [[4]](diffhunk://#diff-819b5df459b6ae3a94e0d893e875d0971f040a67dab8ecc5558a5399c0372a4cR35)
* Added a comprehensive test suite for the `CaseDetails` component, covering rendering, status/escalation changes, and viewer display logic.