### PR TITLE
feat(retention): implement dynamic retention rules for hit deletion

### DIFF
--- a/api/howler/cronjobs/retention.py
+++ b/api/howler/cronjobs/retention.py
@@ -43,8 +43,8 @@ def _execute_rules(ds: HowlerDatastore) -> None:
     Iterates each enabled rule, computes its cutoff date, and deletes
     hits that match the rule's query and are older than the cutoff.
     Errors for individual rules are logged and skipped so that
-    remaining rules still execute. Emits a structured summary log
-    after all rules have been processed.
+    remaining rules still execute. Emits a structured result log
+    for each rule execution.
 
     Note: Rules are independent. If multiple rules match the same hit,
     the hit is deleted by whichever rule runs first; subsequent matching
@@ -69,7 +69,8 @@ def _execute_rules(ds: HowlerDatastore) -> None:
             continue
 
         delta_kwargs = {str(rule.limit_unit): rule.limit_amount}
-        cutoff = (datetime.now() - timedelta(**delta_kwargs)).strftime("%Y-%m-%d")
+        cutoff_dt = datetime.now(tz=timezone("UTC")) - timedelta(**delta_kwargs)
+        cutoff = cutoff_dt.strftime("%Y-%m-%dT%H:%M:%SZ")
         combined_query = f"({rule.query}) AND event.created:{{* TO {cutoff}}}"
 
         logger.debug(
@@ -80,7 +81,7 @@ def _execute_rules(ds: HowlerDatastore) -> None:
         )
 
         try:
-            count = ds.hit.count(combined_query, filters=None)
+            count = ds.hit.count(combined_query, filters=None).get("count", -1)
             ds.hit.delete_by_query(combined_query)
             ds.hit.commit()
             logger.debug("Retention rule '%s' complete", rule.name)

--- a/api/howler/cronjobs/retention.py
+++ b/api/howler/cronjobs/retention.py
@@ -31,12 +31,73 @@ def execute():
 
     logger.debug("Deletion complete")
 
+    _execute_rules(ds)
+
     logger.debug("Cleaning analytics with no matching hits")
     _remove_analytics_without_hits(ds)
 
 
-def _remove_analytics_without_hits(ds: HowlerDatastore):
+def _execute_rules(ds: HowlerDatastore) -> None:
+    """Execute dynamic retention rules from config.
 
+    Iterates each enabled rule, computes its cutoff date, and deletes
+    hits that match the rule's query and are older than the cutoff.
+    Errors for individual rules are logged and skipped so that
+    remaining rules still execute. Emits a structured summary log
+    after all rules have been processed.
+
+    Note: Rules are independent. If multiple rules match the same hit,
+    the hit is deleted by whichever rule runs first; subsequent matching
+    rules will no-op against the already-deleted document.
+
+    Args:
+        ds: Active HowlerDatastore instance.
+    """
+    rules = config.system.retention.rules
+    if not rules:
+        return
+
+    logger.info("Processing dynamic retention rules:")
+
+    for rule in rules:
+        result = {}
+
+        if not rule.enabled:
+            logger.debug("Skipping disabled retention rule '%s'", rule.name)
+            result = {"rule": rule.name, "status": "skipped", "reason": "disabled"}
+            logger.info("Rule result: '%s'", result)
+            continue
+
+        delta_kwargs = {str(rule.limit_unit): rule.limit_amount}
+        cutoff = (datetime.now() - timedelta(**delta_kwargs)).strftime("%Y-%m-%d")
+        combined_query = f"({rule.query}) AND event.created:{{* TO {cutoff}}}"
+
+        logger.debug(
+            "Executing retention rule '%s': query=%s cutoff=%s",
+            rule.name,
+            rule.query,
+            cutoff,
+        )
+
+        try:
+            count = ds.hit.count(combined_query, filters=None)
+            ds.hit.delete_by_query(combined_query)
+            ds.hit.commit()
+            logger.debug("Retention rule '%s' complete", rule.name)
+            result = {"rule": rule.name, "status": "ok", "deleted": count, "cutoff": cutoff}
+        except Exception:
+            logger.error(
+                "Retention rule '%s' failed — skipping. query=%s",
+                rule.name,
+                combined_query,
+                exc_info=True,
+            )
+            result = {"rule": rule.name, "status": "error", "query": combined_query}
+
+        logger.info("Rule result: '%s'", result)
+
+
+def _remove_analytics_without_hits(ds: HowlerDatastore):
     matched_analytics = _find_analytics_with_hits(ds)
 
     if matched_analytics is not None:
@@ -66,7 +127,6 @@ def _remove_analytics_without_hits(ds: HowlerDatastore):
 
 
 def _find_analytics_with_hits(ds: HowlerDatastore) -> list[str] | None:
-
     total_analytics = ds.analytic.count("id:*", filters=None)["count"]
 
     if total_analytics:
@@ -127,3 +187,7 @@ def setup_job(sched: BaseScheduler):
         **_kwargs,
     )
     logger.debug("Initialization complete")
+
+
+if __name__ == "__main__":
+    execute()

--- a/api/howler/odm/models/config.py
+++ b/api/howler/odm/models/config.py
@@ -356,6 +356,26 @@ class Auth(BaseModel):
     oauth: OAuth = OAuth()
 
 
+class RetentionRule(BaseModel):
+    """A dynamic, query-scoped retention rule.
+
+    Pairs a Lucene query with a retention window. During the retention
+    cronjob run, hits matching the query that are older than the
+    specified window will be deleted.
+    """
+
+    name: str = Field(description="A human-readable label for this rule (used in logs).")
+    enabled: bool = Field(default=True, description="Whether this rule is active.")
+    query: str = Field(description="Lucene query that scopes which hits this rule applies to.")
+    limit_unit: Literal["days", "seconds", "microseconds", "milliseconds", "minutes", "hours", "weeks"] = Field(
+        default="days",
+        description="The unit to use when computing the retention limit for this rule.",
+    )
+    limit_amount: int = Field(
+        description="The number of limit_units to use when computing the retention limit for this rule.",
+    )
+
+
 class Retention(BaseModel):
     """Hit retention policy configuration.
 
@@ -381,6 +401,13 @@ class Retention(BaseModel):
     crontab: str = Field(
         default="0 0 * * *",
         description="The crontab that denotes how often to run the retention job",
+    )
+    rules: list[RetentionRule] = Field(
+        default=[],
+        description=(
+            "Optional list of dynamic retention rules. Each rule pairs a Lucene query "
+            "with a retention window. Rules run after the global sweep."
+        ),
     )
 
 

--- a/api/test/integration/cronjobs/test_retention.py
+++ b/api/test/integration/cronjobs/test_retention.py
@@ -1,10 +1,14 @@
+from datetime import datetime
+
 import pytest
 
-from howler.cronjobs.retention import _find_analytics_with_hits, _remove_analytics_without_hits
+from howler.cronjobs import retention as retention_cronjob
+from howler.cronjobs.retention import _execute_rules, _find_analytics_with_hits, _remove_analytics_without_hits
 from howler.datastore.howler_store import HowlerDatastore
 from howler.odm import random_data
 from howler.odm.helper import EXAMPLE_ANALYTICS
 from howler.odm.models.analytic import Analytic
+from howler.odm.models.config import RetentionRule
 from howler.odm.randomizer import random_model_obj
 
 
@@ -89,6 +93,27 @@ def datastore_connection_no_hits(datastore_connection_with_rule_analytics):
     yield datastore_connection_with_rule_analytics
 
 
+@pytest.fixture(scope="function")
+def retention_rule_factory():
+    def _build_rule(
+        name: str = "test-retention-rule",
+        *,
+        enabled: bool = True,
+        query: str = "howler.id:*",
+        limit_unit: str = "days",
+        limit_amount: int = 36500,
+    ) -> RetentionRule:
+        return RetentionRule(
+            name=name,
+            enabled=enabled,
+            query=query,
+            limit_unit=limit_unit,
+            limit_amount=limit_amount,
+        )
+
+    return _build_rule
+
+
 def lists_equivalent(l1: list[str], l2: list[str]):
     return sorted(s.lower() for s in l1) == sorted(s.lower() for s in l2)
 
@@ -97,6 +122,21 @@ def get_analytic_names(ds: HowlerDatastore):
     search_result = ds.analytic.search("id:*")
     analytic_names = [item["name"] for item in search_result["items"]]
     return analytic_names
+
+
+def get_hit_count(ds: HowlerDatastore) -> int:
+    return ds.hit.search("howler.id:*", rows=0, track_total_hits=True)["total"]
+
+
+def set_all_hit_created(ds: HowlerDatastore, created_at: str) -> None:
+    hits = ds.hit.search("howler.id:*", rows=1000)["items"]
+
+    for hit in hits:
+        hit.event.created = created_at
+        hit.timestamp = created_at
+        ds.hit.save(hit.howler.id, hit)
+
+    ds.hit.commit()
 
 
 def test_find_analytics_with_hits(datastore_connection_with_hits, expected_analytics):
@@ -180,3 +220,109 @@ def test_too_many_analytics_does_not_run_cleanup(monkeypatch, datastore_connecti
 
     after_delete = get_analytic_names(datastore_connection)
     assert lists_equivalent(after_delete, before_delete)
+
+
+def test_execute_rules_deletes_matching_hits(
+    datastore_connection_no_extra_analytics: HowlerDatastore, monkeypatch, retention_rule_factory
+):
+    ds = datastore_connection_no_extra_analytics
+    set_all_hit_created(ds, "1900-01-01T00:00:00Z")
+    rule = retention_rule_factory(query="howler.id:*", limit_amount=36500)
+    monkeypatch.setattr(retention_cronjob.config.system.retention, "rules", [rule])
+    before_count = get_hit_count(ds)
+
+    assert before_count > 0
+
+    _execute_rules(ds)
+
+    after_count = get_hit_count(ds)
+    assert after_count == 0
+
+
+def test_execute_rules_preserves_non_matching_hits(
+    datastore_connection_no_extra_analytics: HowlerDatastore, monkeypatch, retention_rule_factory
+):
+    ds = datastore_connection_no_extra_analytics
+    rule = retention_rule_factory(query="howler.analytic:NonExistentAnalytic99999")
+    monkeypatch.setattr(retention_cronjob.config.system.retention, "rules", [rule])
+    before_count = get_hit_count(ds)
+
+    _execute_rules(ds)
+
+    after_count = get_hit_count(ds)
+    assert after_count == before_count
+
+
+def test_execute_rules_preserves_recent_hits(
+    datastore_connection_no_extra_analytics: HowlerDatastore, monkeypatch, retention_rule_factory
+):
+    ds = datastore_connection_no_extra_analytics
+    set_all_hit_created(ds, f"{datetime.now().isoformat()}Z")
+    rule = retention_rule_factory(query="howler.id:*", limit_amount=0)
+    monkeypatch.setattr(retention_cronjob.config.system.retention, "rules", [rule])
+    before_count = get_hit_count(ds)
+
+    _execute_rules(ds)
+
+    after_count = get_hit_count(ds)
+    assert after_count == before_count
+
+
+def test_execute_rules_skips_disabled_rule(
+    datastore_connection_no_extra_analytics: HowlerDatastore, monkeypatch, retention_rule_factory
+):
+    ds = datastore_connection_no_extra_analytics
+    set_all_hit_created(ds, "1900-01-01T00:00:00Z")
+    rule = retention_rule_factory(enabled=False, query="howler.id:*", limit_amount=36500)
+    monkeypatch.setattr(retention_cronjob.config.system.retention, "rules", [rule])
+    before_count = get_hit_count(ds)
+
+    _execute_rules(ds)
+
+    after_count = get_hit_count(ds)
+    assert after_count == before_count
+
+
+def test_execute_rules_no_rules_is_noop(datastore_connection_no_extra_analytics: HowlerDatastore, monkeypatch):
+    ds = datastore_connection_no_extra_analytics
+    monkeypatch.setattr(retention_cronjob.config.system.retention, "rules", [])
+    before_count = get_hit_count(ds)
+
+    _execute_rules(ds)
+
+    after_count = get_hit_count(ds)
+    assert after_count == before_count
+
+
+def test_execute_rules_continues_after_bad_rule(
+    datastore_connection_no_extra_analytics: HowlerDatastore, monkeypatch, retention_rule_factory
+):
+    ds = datastore_connection_no_extra_analytics
+    set_all_hit_created(ds, "1900-01-01T00:00:00Z")
+    rules = [
+        retention_rule_factory(name="bad-rule", query="howler.id:*", limit_amount=36500),
+        retention_rule_factory(name="good-rule", query="howler.id:*", limit_amount=36500),
+    ]
+    monkeypatch.setattr(retention_cronjob.config.system.retention, "rules", rules)
+
+    original_delete_by_query = ds.hit.delete_by_query
+    call_state = {"count": 0}
+
+    def flaky_delete_by_query(query: str, *args, **kwargs):
+        call_state["count"] += 1
+
+        if call_state["count"] == 1:
+            raise Exception("simulated delete failure")
+
+        return original_delete_by_query(query, *args, **kwargs)
+
+    monkeypatch.setattr(ds.hit, "delete_by_query", flaky_delete_by_query)
+    before_count = get_hit_count(ds)
+
+    assert before_count > 0
+
+    _execute_rules(ds)
+
+    after_count = get_hit_count(ds)
+    assert call_state["count"] == 2
+    assert after_count == 0

--- a/api/test/integration/cronjobs/test_retention.py
+++ b/api/test/integration/cronjobs/test_retention.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
@@ -257,7 +257,8 @@ def test_execute_rules_preserves_recent_hits(
     datastore_connection_no_extra_analytics: HowlerDatastore, monkeypatch, retention_rule_factory
 ):
     ds = datastore_connection_no_extra_analytics
-    set_all_hit_created(ds, f"{datetime.now().isoformat()}Z")
+    future = (datetime.now(tz=timezone.utc) + timedelta(days=1)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    set_all_hit_created(ds, future)
     rule = retention_rule_factory(query="howler.id:*", limit_amount=0)
     monkeypatch.setattr(retention_cronjob.config.system.retention, "rules", [rule])
     before_count = get_hit_count(ds)


### PR DESCRIPTION
# Description

Extends the Howler retention cronjob to support dynamic, query-scoped retention rules. Previously, the retention job enforced a single global age-based policy for all hits. This change adds an optional list of rules to the system config, each pairing a Lucene query with its own retention window, enabling fine-grained per-population retention policies (e.g. keep phishing hits for 90 days, keep low-severity resolved hits for 30 days).

### What changed

- **`api/howler/odm/models/config.py`** — New `RetentionRule` Pydantic model (`name`, `enabled`, `query`, `limit_unit`, `limit_amount`) and a `rules: list[RetentionRule]` field added to the existing `Retention` config class (defaults to `[]` — fully backward compatible).
- **`api/howler/cronjobs/retention.py`** — New `_execute_rules(ds)` helper that iterates enabled rules after the global sweep, counts matching hits via `ds.hit.count()`, deletes via `ds.hit.delete_by_query()`, and emits a structured result log per rule execution. Bad rules are logged and skipped; remaining rules continue.
- **`api/test/integration/cronjobs/test_retention.py`** — 6 new integration tests covering: deletes matching hits, preserves non-matching hits, preserves recent hits, skips disabled rules, no-rules noop, and continues after a failing rule.

### Behaviour

1. Global age-based sweep runs first (unchanged).
2. Dynamic rules run after, independently of one another.
3. Overlapping rules (matching the same hit) are expected — later rules no-op on already-deleted documents.
4. Invalid queries fail at runtime only — logged and skipped, job continues.
5. A structured result log is emitted on each rule execution.

### Example config

```yaml
system:
  retention:
    enabled: true
    limit_unit: days
    limit_amount: 350
    crontab: "0 0 * * *"
    rules:
      - name: "Short-lived phishing hits"
        enabled: true
        query: "howler.analytic:PhishingDetector"
        limit_unit: days
        limit_amount: 90
```

---