### PR TITLE
fix(ui): add response.rows to dependency list for search

### DIFF
--- a/ui/src/components/app/providers/HitSearchProvider.tsx
+++ b/ui/src/components/app/providers/HitSearchProvider.tsx
@@ -4,7 +4,7 @@ import useMyApi from 'components/hooks/useMyApi';
 import useMyLocalStorage, { useMyLocalStorageItem } from 'components/hooks/useMyLocalStorage';
 import dayjs from 'dayjs';
 import i18n from 'i18n';
-import { cloneDeep } from 'lodash-es';
+import { cloneDeep, isNil } from 'lodash-es';
 import isNull from 'lodash-es/isNull';
 import isUndefined from 'lodash-es/isUndefined';
 import type { Hit } from 'models/entities/generated/Hit';
@@ -166,7 +166,7 @@ const HitSearchProvider: FC<PropsWithChildren> = ({ children }) => {
         try {
           const _response = await dispatchApi(
             api.search.hit.post({
-              offset: appendResults && response?.rows ? response.rows : offset,
+              offset: appendResults && !isNil(response?.rows) ? response.rows : offset,
               rows: pageCount,
               query: _query || DEFAULT_QUERY,
               sort,

--- a/ui/src/components/app/providers/HitSearchProvider.tsx
+++ b/ui/src/components/app/providers/HitSearchProvider.tsx
@@ -166,7 +166,7 @@ const HitSearchProvider: FC<PropsWithChildren> = ({ children }) => {
         try {
           const _response = await dispatchApi(
             api.search.hit.post({
-              offset: appendResults && response ? response.rows : offset,
+              offset: appendResults && response?.rows ? response.rows : offset,
               rows: pageCount,
               query: _query || DEFAULT_QUERY,
               sort,
@@ -204,27 +204,21 @@ const HitSearchProvider: FC<PropsWithChildren> = ({ children }) => {
         }
       });
     },
-    // We skip reloading when the response changes
-    // eslint-disable-next-line react-hooks/exhaustive-deps
     [
       sort,
       span,
       query,
-      startDate,
-      endDate,
-      filters,
       setQuery,
-      location.pathname,
-      routeParams.id,
-      views,
-      dispatchApi,
+      setQueryHistory,
+      queryHistory,
+      response.rows,
       offset,
+      dispatchApi,
       pageCount,
+      getFilters,
       trackTotalHits,
       loadHits,
-      getCurrentViews,
-      setOffset,
-      getFilters
+      setOffset
     ]
   );
 

--- a/ui/src/components/app/providers/HitSearchProvider.tsx
+++ b/ui/src/components/app/providers/HitSearchProvider.tsx
@@ -211,7 +211,7 @@ const HitSearchProvider: FC<PropsWithChildren> = ({ children }) => {
       setQuery,
       setQueryHistory,
       queryHistory,
-      response.rows,
+      response?.rows,
       offset,
       dispatchApi,
       pageCount,


### PR DESCRIPTION
Fixes issue where the search button in the grid table to fetch more rows would append the same 25 existing rows to the table instead of getting the next 25 hits.

The repeated hits being loaded into grid views was because the search request was being done with offset=0 every time. We use response.rows for the offset when appending the results in grid views, but since it wasn't in the dependency list the callback wasn't redefined to use the new value.