### PR TITLE
fix(ui): display meaningful error for invalid handlebars helper usage

### DIFF
--- a/ui/src/components/elements/display/HandlebarsMarkdown.tsx
+++ b/ui/src/components/elements/display/HandlebarsMarkdown.tsx
@@ -7,7 +7,7 @@ import { useTranslation } from 'react-i18next';
 import Throttler from 'utils/Throttler';
 import { hashCode } from 'utils/utils';
 import Markdown, { type MarkdownProps } from '../display/Markdown';
-import { useHelpers } from './handlebars/helpers';
+import { HowlerHelperError, useHelpers } from './handlebars/helpers';
 
 type HandlebarsInstance = typeof Handlebars;
 
@@ -56,7 +56,7 @@ const HandlebarsMarkdown: FC<HandlebarsMarkdownProps> = ({ md, object = {}, disa
 
       handlebars.registerHelper(helper.keyword, (...args: any[]) => {
         console.debug(`Running helper ${helper.keyword}`);
-
+        args = args.length ? [args[args.length - 1], ...args.slice(0, -1)] : []; // re-sort args so that the context is always the first argument
         if (helper.componentCallback) {
           const id = hashCode(JSON.stringify([helper.keyword, ...args])).toString();
           if (!mdComponents[id]) {
@@ -71,8 +71,17 @@ const HandlebarsMarkdown: FC<HandlebarsMarkdownProps> = ({ md, object = {}, disa
 
           return new Handlebars.SafeString(`\`${id}\``);
         }
-
-        return helper.callback(...args);
+        try {
+          return helper.callback(...args);
+        } catch (err) {
+          if (err instanceof HowlerHelperError) {
+            return new Handlebars.SafeString(
+              `<span style="color: red; font-weight: bold; font-family: monospace;">Invalid Usage [${helper.keyword}]: ${err.message}</span>
+              ${helper.hint ? `<br/><span style="color: gray; font-family: monospace;">${helper.hint}</span>` : ''}`
+            );
+          }
+          throw err;
+        }
       });
     });
   }, [handlebars, helpers, mdComponents]);

--- a/ui/src/components/elements/display/HandlebarsMarkdown.tsx
+++ b/ui/src/components/elements/display/HandlebarsMarkdown.tsx
@@ -69,12 +69,10 @@ const HandlebarsMarkdown: FC<HandlebarsMarkdownProps> = ({ md, object = {}, disa
       handlebars.registerHelper(helper.keyword, (...args: any[]) => {
         console.debug(`Running helper ${helper.keyword}`);
 
-        const options = args.pop();
-
         if (helper.componentCallback) {
           const id = hashCode(JSON.stringify([helper.keyword, ...args])).toString();
           if (!mdComponents[id]) {
-            const result = helper.componentCallback(options, ...args);
+            const result = helper.componentCallback(...args);
 
             if (result instanceof Promise) {
               result.then(_result => setMdComponents(_components => ({ ..._components, [id]: _result })));
@@ -86,7 +84,7 @@ const HandlebarsMarkdown: FC<HandlebarsMarkdownProps> = ({ md, object = {}, disa
           return new Handlebars.SafeString(`\`${id}\``);
         }
         try {
-          return helper.callback(options, ...args);
+          return helper.callback(...args);
         } catch (err) {
           if (err instanceof HowlerHelperError) {
             throw new HowlerHandlebarsRenderError(err.message, helper.keyword, helper.hint);

--- a/ui/src/components/elements/display/HandlebarsMarkdown.tsx
+++ b/ui/src/components/elements/display/HandlebarsMarkdown.tsx
@@ -16,6 +16,18 @@ interface HandlebarsMarkdownProps extends MarkdownProps {
   disableLinks?: boolean;
 }
 
+class HowlerHandlebarsRenderError extends Error {
+  helper: string;
+  hint?: string;
+
+  constructor(message: string, helper: string, hint?: string) {
+    super(message);
+    this.name = 'HowlerHandlebarsRenderError';
+    this.helper = helper;
+    this.hint = hint;
+  }
+}
+
 const THROTTLER = new Throttler(500);
 
 const HandlebarsMarkdown: FC<HandlebarsMarkdownProps> = ({ md, object = {}, disableLinks = false }) => {
@@ -56,11 +68,13 @@ const HandlebarsMarkdown: FC<HandlebarsMarkdownProps> = ({ md, object = {}, disa
 
       handlebars.registerHelper(helper.keyword, (...args: any[]) => {
         console.debug(`Running helper ${helper.keyword}`);
-        args = args.length ? [args[args.length - 1], ...args.slice(0, -1)] : []; // re-sort args so that the context is always the first argument
+
+        const options = args.pop();
+
         if (helper.componentCallback) {
           const id = hashCode(JSON.stringify([helper.keyword, ...args])).toString();
           if (!mdComponents[id]) {
-            const result = helper.componentCallback(...args);
+            const result = helper.componentCallback(options, ...args);
 
             if (result instanceof Promise) {
               result.then(_result => setMdComponents(_components => ({ ..._components, [id]: _result })));
@@ -72,13 +86,10 @@ const HandlebarsMarkdown: FC<HandlebarsMarkdownProps> = ({ md, object = {}, disa
           return new Handlebars.SafeString(`\`${id}\``);
         }
         try {
-          return helper.callback(...args);
+          return helper.callback(options, ...args);
         } catch (err) {
           if (err instanceof HowlerHelperError) {
-            return new Handlebars.SafeString(
-              `<span style="color: red; font-weight: bold; font-family: monospace;">Invalid Usage [${helper.keyword}]: ${err.message}</span>
-              ${helper.hint ? `<br/><span style="color: gray; font-family: monospace;">${helper.hint}</span>` : ''}`
-            );
+            throw new HowlerHandlebarsRenderError(err.message, helper.keyword, helper.hint);
           }
           throw err;
         }
@@ -103,6 +114,15 @@ const HandlebarsMarkdown: FC<HandlebarsMarkdownProps> = ({ md, object = {}, disa
           );
 
           setRendered(await compiled(object));
+          return;
+        }
+
+        if (err instanceof HowlerHandlebarsRenderError) {
+          setRendered(`
+<h2 style="color: red">${t('markdown.error')}</h2>
+<span style="color: red; font-weight: bold; font-family: monospace;">Invalid Usage [${err.helper}]: ${err.message}</span>
+${err.hint ? `<br/><span style="color: gray; font-family: monospace;">${err.hint}</span>` : ''}
+          `);
           return;
         }
 

--- a/ui/src/components/elements/display/HandlebarsMarkdown.tsx
+++ b/ui/src/components/elements/display/HandlebarsMarkdown.tsx
@@ -21,10 +21,10 @@ class HowlerHandlebarsRenderError extends Error {
   hint?: string;
 
   constructor(message: string, helper: string, hint?: string) {
-    super(message);
+    super(Handlebars.escapeExpression(message));
     this.name = 'HowlerHandlebarsRenderError';
-    this.helper = helper;
-    this.hint = hint;
+    this.helper = Handlebars.escapeExpression(helper);
+    this.hint = hint ? Handlebars.escapeExpression(hint) : undefined;
   }
 }
 
@@ -84,7 +84,15 @@ const HandlebarsMarkdown: FC<HandlebarsMarkdownProps> = ({ md, object = {}, disa
           return new Handlebars.SafeString(`\`${id}\``);
         }
         try {
-          return helper.callback(...args);
+          const result = helper.callback(...args);
+          return result instanceof Promise
+            ? result.catch(err => {
+                if (err instanceof HowlerHelperError) {
+                  throw new HowlerHandlebarsRenderError(err.message, helper.keyword, helper.hint);
+                }
+                throw err;
+              })
+            : result;
         } catch (err) {
           if (err instanceof HowlerHelperError) {
             throw new HowlerHandlebarsRenderError(err.message, helper.keyword, helper.hint);

--- a/ui/src/components/elements/display/handlebars/helpers.tsx
+++ b/ui/src/components/elements/display/handlebars/helpers.tsx
@@ -51,7 +51,10 @@ export const useHelpers = (opts = { async: true, components: true }): HowlerHelp
             en: 'Checks the equality of the string representation of the two arguments.',
             fr: "Vérifie l'égalité de la représentation en chaîne de caractères des deux arguments."
           },
-          callback: (_, arg1, arg2) => {
+          callback: (...args) => {
+            args.pop(); // remove options
+            const [arg1, arg2] = args;
+
             if (isNil(arg1) || isNil(arg2)) {
               throw new HowlerHelperError('Both arguments must be provided.');
             }
@@ -65,7 +68,12 @@ export const useHelpers = (opts = { async: true, components: true }): HowlerHelp
             en: 'Runs the comparison `arg1 && arg2`, and returns the result.',
             fr: 'Exécute la comparaison `arg1 && arg2`, et retourne le résultat.'
           },
-          callback: (_, arg1, arg2) => arg1 && arg2
+          callback: (...args) => {
+            args.pop(); // remove options
+            const [arg1, arg2] = args;
+
+            return arg1 && arg2;
+          }
         },
         {
           keyword: 'or',
@@ -73,7 +81,12 @@ export const useHelpers = (opts = { async: true, components: true }): HowlerHelp
             en: 'Runs the comparison `arg1 || arg2`, and returns the result.',
             fr: 'Exécute la comparaison `arg1 || arg2`, et retourne le résultat.'
           },
-          callback: (_, arg1, arg2) => arg1 || arg2
+          callback: (...args) => {
+            args.pop(); // remove options
+            const [arg1, arg2] = args;
+
+            return arg1 || arg2;
+          }
         },
         {
           keyword: 'not',
@@ -81,7 +94,12 @@ export const useHelpers = (opts = { async: true, components: true }): HowlerHelp
             en: 'Runs the comparison `!arg`, and returns the result.',
             fr: 'Exécute la comparaison `!arg`, et retourne le résultat.'
           },
-          callback: (_, arg) => !arg
+          callback: (...args) => {
+            args.pop(); // remove options
+            const arg = args[0];
+
+            return !arg;
+          }
         },
         {
           keyword: 'curly',
@@ -89,7 +107,12 @@ export const useHelpers = (opts = { async: true, components: true }): HowlerHelp
             en: 'Wraps the given argument in curly braces.',
             fr: "Entoure l'argument donné d'accolades."
           },
-          callback: (_, arg1) => new Handlebars.SafeString(`{{${arg1}}}`)
+          callback: (...args) => {
+            args.pop(); // remove options
+            const arg1 = args[0];
+
+            return new Handlebars.SafeString(`{{${arg1}}}`);
+          }
         },
         {
           keyword: 'join',
@@ -97,8 +120,12 @@ export const useHelpers = (opts = { async: true, components: true }): HowlerHelp
             en: 'Joins two string arguments with a given string `sep`, or the empty string as a default.',
             fr: 'Joint deux arguments de chaîne avec une chaîne donnée `sep`, ou la chaîne vide par défaut.'
           },
-          callback: (context, arg1: string, arg2: string) =>
-            [arg1?.toString() ?? '', arg2?.toString() ?? ''].join(context.hash?.sep ?? '')
+          callback: (...args) => {
+            const context = args.pop();
+            const [arg1, arg2] = args;
+
+            return [arg1?.toString() ?? '', arg2?.toString() ?? ''].join(context.hash?.sep ?? '');
+          }
         },
         {
           keyword: 'upper',
@@ -106,7 +133,10 @@ export const useHelpers = (opts = { async: true, components: true }): HowlerHelp
             en: 'Returns the uppercase representation of a string argument.',
             fr: "Retourne la représentation en majuscules d'un argument de chaîne."
           },
-          callback: (_, val: string) => {
+          callback: (...args) => {
+            args.pop(); // remove options
+            const val = args[0];
+
             if (isNil(val)) {
               throw new HowlerHelperError('Upper expects a string argument');
             }
@@ -120,7 +150,10 @@ export const useHelpers = (opts = { async: true, components: true }): HowlerHelp
             en: 'Returns the lowercase representation of a string argument.',
             fr: "Retourne la représentation en minuscules d'un argument de chaîne."
           },
-          callback: (_, val: string) => {
+          callback: (...args) => {
+            args.pop(); // remove options
+            const val = args[0];
+
             if (isNil(val)) {
               throw new HowlerHelperError('Lower expects a string argument');
             }
@@ -135,7 +168,10 @@ export const useHelpers = (opts = { async: true, components: true }): HowlerHelp
             fr: "Récupère l'URL fournie et retourne la clé donnée (aplatie) de l'objet JSON retourné. Notez que le résultat doit être du JSON !"
           },
           async: true,
-          callback: async (_, url, key) => {
+          callback: async (...args) => {
+            args.pop(); // remove options
+            const [url, key] = args;
+
             try {
               if (!FETCH_RESULTS[url]) {
                 FETCH_RESULTS[url] = fetch(url).then(res => res.json());
@@ -155,7 +191,10 @@ export const useHelpers = (opts = { async: true, components: true }): HowlerHelp
             en: 'Given a howler hit ID, this helper renders a hit card for that ID.',
             fr: 'Étant donné un ID de résultat howler, cet assistant affiche une carte de résultat pour cet ID.'
           },
-          componentCallback: (_, id) => {
+          componentCallback: (...args) => {
+            args.pop(); // remove options
+            const id = args[0];
+
             if (!id) {
               return <AppListEmpty />;
             }
@@ -169,7 +208,10 @@ export const useHelpers = (opts = { async: true, components: true }): HowlerHelp
             en: 'Given a dict, return an array of {key, value} objects.',
             fr: "Étant donné un dictionnaire, retourne un tableau d'objets {key, value}."
           },
-          callback: (_, obj) => {
+          callback: (...args) => {
+            args.pop(); // remove options
+            const obj = args[0];
+
             if (!isObject(obj)) {
               return new Handlebars.SafeString('Invalid Object.');
             }
@@ -183,7 +225,10 @@ export const useHelpers = (opts = { async: true, components: true }): HowlerHelp
             en: 'Given JSON data, this helper renders a JSON viewer component.',
             fr: 'Étant donné des données JSON, cet assistant affiche un composant de visualisation JSON.'
           },
-          componentCallback: (_, data) => {
+          componentCallback: (...args) => {
+            args.pop(); // remove options
+            const data = args[0];
+
             if (!data) {
               return <AppListEmpty />;
             }
@@ -197,7 +242,10 @@ export const useHelpers = (opts = { async: true, components: true }): HowlerHelp
             en: 'Convert any object into a JSON string.',
             fr: "Convertit n'importe quel objet en chaîne JSON."
           },
-          callback: (_, obj) => {
+          callback: (...args) => {
+            args.pop(); // remove options
+            const obj = args[0];
+
             return new Handlebars.SafeString(JSON.stringify(obj));
           }
         },
@@ -207,7 +255,10 @@ export const useHelpers = (opts = { async: true, components: true }): HowlerHelp
             en: 'Convert a JSON string into an object.',
             fr: 'Convertit une chaîne JSON en objet.'
           },
-          callback: (_, str) => {
+          callback: (...args) => {
+            args.pop(); // remove options
+            const str = args[0];
+
             if (isNil(str)) {
               throw new HowlerHelperError('Parse JSON expects a string argument');
             }
@@ -225,7 +276,10 @@ export const useHelpers = (opts = { async: true, components: true }): HowlerHelp
             en: 'Returns the given (flattened) key from the provided object.',
             fr: "Retourne la clé donnée (aplatie) de l'objet fourni."
           },
-          callback: (_, data, key) => {
+          callback: (...args) => {
+            args.pop(); // remove options
+            const [data, key] = args;
+
             try {
               return get(data, key);
             } catch (e) {
@@ -239,7 +293,10 @@ export const useHelpers = (opts = { async: true, components: true }): HowlerHelp
             en: 'Checks if field is in string',
             fr: 'Vérifie si le champ est dans la chaîne'
           },
-          callback: (_, arg1, arg2) => {
+          callback: (...args) => {
+            args.pop(); // remove options
+            const [arg1, arg2] = args;
+
             return !!arg2 && !!arg1?.includes(arg2);
           }
         },
@@ -250,7 +307,10 @@ export const useHelpers = (opts = { async: true, components: true }): HowlerHelp
             en: 'Render a table in markdown given an array of cells',
             fr: "Affiche un tableau en markdown à partir d'un tableau de cellules"
           },
-          componentCallback: (_, cells: Cell[]) => {
+          componentCallback: (...args) => {
+            args.pop(); // remove options
+            const cells: Cell[] = args[0];
+
             const columns = Object.keys(groupBy(cells, 'column'));
             const rows = groupBy(cells, 'row');
 
@@ -294,7 +354,10 @@ export const useHelpers = (opts = { async: true, components: true }): HowlerHelp
             en: 'Execute a howler action given a specific action ID (from the URL when viewing the action, i.e. yaIKVqiKhWpyCsWdqsE4D)',
             fr: "Exécute une action howler à partir d'un ID d'action spécifique (de l'URL lors de la visualisation de l'action, par ex. yaIKVqiKhWpyCsWdqsE4D)"
           },
-          componentCallback: (context, actionId: string, hitId: string) => {
+          componentCallback: (...args) => {
+            const context = args.pop(); // remove options
+            const [actionId, hitId] = args;
+
             return <ActionButton actionId={actionId} hitId={hitId} {...(context.hash ?? {})} />;
           }
         },
@@ -305,7 +368,10 @@ export const useHelpers = (opts = { async: true, components: true }): HowlerHelp
             en: '',
             fr: ''
           },
-          callback: (_, str: string, searchValue: string, replaceValue: string) => {
+          callback: (...args) => {
+            args.pop(); // remove options
+            const [str, searchValue, replaceValue] = args;
+
             if (isNil(str) || isNil(searchValue) || isNil(replaceValue)) {
               throw new HowlerHelperError('Replace expects three arguments');
             }

--- a/ui/src/components/elements/display/handlebars/helpers.tsx
+++ b/ui/src/components/elements/display/handlebars/helpers.tsx
@@ -73,7 +73,8 @@ export const useHelpers = (opts = { async: true, components: true }): HowlerHelp
             const [arg1, arg2] = args;
 
             return arg1 && arg2;
-          }
+          },
+          hint: 'Usage: {{and arg1 arg2}}'
         },
         {
           keyword: 'or',
@@ -86,7 +87,8 @@ export const useHelpers = (opts = { async: true, components: true }): HowlerHelp
             const [arg1, arg2] = args;
 
             return arg1 || arg2;
-          }
+          },
+          hint: 'Usage: {{or arg1 arg2}}'
         },
         {
           keyword: 'not',
@@ -99,7 +101,8 @@ export const useHelpers = (opts = { async: true, components: true }): HowlerHelp
             const arg = args[0];
 
             return !arg;
-          }
+          },
+          hint: 'Usage: {{not arg}}'
         },
         {
           keyword: 'curly',
@@ -112,7 +115,8 @@ export const useHelpers = (opts = { async: true, components: true }): HowlerHelp
             const arg1 = args[0];
 
             return new Handlebars.SafeString(`{{${arg1}}}`);
-          }
+          },
+          hint: 'Usage: {{curly arg}}'
         },
         {
           keyword: 'join',
@@ -125,7 +129,8 @@ export const useHelpers = (opts = { async: true, components: true }): HowlerHelp
             const [arg1, arg2] = args;
 
             return [arg1?.toString() ?? '', arg2?.toString() ?? ''].join(context.hash?.sep ?? '');
-          }
+          },
+          hint: 'Usage: {{join arg1 arg2 sep=string}}'
         },
         {
           keyword: 'upper',
@@ -183,7 +188,8 @@ export const useHelpers = (opts = { async: true, components: true }): HowlerHelp
             } catch (e) {
               return '';
             }
-          }
+          },
+          hint: 'Usage: {{fetch url key}}'
         },
         {
           keyword: 'howler',
@@ -200,7 +206,8 @@ export const useHelpers = (opts = { async: true, components: true }): HowlerHelp
             }
 
             return <HitCard id={id} layout={HitLayout.NORMAL} />;
-          }
+          },
+          hint: 'Usage: {{howler hitId}}'
         },
         {
           keyword: 'entries',
@@ -217,7 +224,8 @@ export const useHelpers = (opts = { async: true, components: true }): HowlerHelp
             }
 
             return Object.entries(obj).map(([key, value]) => ({ key, value }));
-          }
+          },
+          hint: 'Usage: {{entries obj}}'
         },
         {
           keyword: 'render_json',
@@ -234,7 +242,8 @@ export const useHelpers = (opts = { async: true, components: true }): HowlerHelp
             }
 
             return <JSONViewer data={data} />;
-          }
+          },
+          hint: 'Usage: {{render_json obj}}'
         },
         {
           keyword: 'to_json',
@@ -247,7 +256,8 @@ export const useHelpers = (opts = { async: true, components: true }): HowlerHelp
             const obj = args[0];
 
             return new Handlebars.SafeString(JSON.stringify(obj));
-          }
+          },
+          hint: 'Usage: {{to_json obj}}'
         },
         {
           keyword: 'parse_json',
@@ -285,7 +295,8 @@ export const useHelpers = (opts = { async: true, components: true }): HowlerHelp
             } catch (e) {
               return '';
             }
-          }
+          },
+          hint: 'Usage: {{get obj key}}'
         },
         {
           keyword: 'includes',
@@ -298,7 +309,8 @@ export const useHelpers = (opts = { async: true, components: true }): HowlerHelp
             const [arg1, arg2] = args;
 
             return !!arg2 && !!arg1?.includes(arg2);
-          }
+          },
+          hint: 'Usage: {{includes str substr}}'
         },
 
         {
@@ -345,7 +357,8 @@ export const useHelpers = (opts = { async: true, components: true }): HowlerHelp
                 </Table>
               </Paper>
             );
-          }
+          },
+          hint: 'Usage: {{table cells}}'
         },
 
         {
@@ -359,7 +372,8 @@ export const useHelpers = (opts = { async: true, components: true }): HowlerHelp
             const [actionId, hitId] = args;
 
             return <ActionButton actionId={actionId} hitId={hitId} {...(context.hash ?? {})} />;
-          }
+          },
+          hint: 'Usage: {{action actionId hitId}}'
         },
 
         {

--- a/ui/src/components/elements/display/handlebars/helpers.tsx
+++ b/ui/src/components/elements/display/handlebars/helpers.tsx
@@ -5,7 +5,7 @@ import HitCard from 'components/elements/hit/HitCard';
 import { HitLayout } from 'components/elements/hit/HitLayout';
 import { flatten } from 'flat';
 import Handlebars from 'handlebars';
-import { capitalize, get, groupBy, isObject } from 'lodash-es';
+import { capitalize, get, groupBy, isNil, isObject } from 'lodash-es';
 import howlerPluginStore from 'plugins/store';
 import { useMemo, type ReactElement } from 'react';
 import { usePluginStore } from 'react-pluggable';
@@ -52,7 +52,7 @@ export const useHelpers = (opts = { async: true, components: true }): HowlerHelp
             fr: "Vérifie l'égalité de la représentation en chaîne de caractères des deux arguments."
           },
           callback: (_, arg1, arg2) => {
-            if (arg1 == undefined || arg2 == undefined) {
+            if (isNil(arg1) || isNil(arg2)) {
               throw new HowlerHelperError('Both arguments must be provided.');
             }
             return arg1.toString() === arg2.toString();
@@ -107,7 +107,7 @@ export const useHelpers = (opts = { async: true, components: true }): HowlerHelp
             fr: "Retourne la représentation en majuscules d'un argument de chaîne."
           },
           callback: (_, val: string) => {
-            if (val == undefined) {
+            if (isNil(val)) {
               throw new HowlerHelperError('Upper expects a string argument');
             }
             return val.toString().toLocaleUpperCase();
@@ -121,7 +121,7 @@ export const useHelpers = (opts = { async: true, components: true }): HowlerHelp
             fr: "Retourne la représentation en minuscules d'un argument de chaîne."
           },
           callback: (_, val: string) => {
-            if (val == undefined) {
+            if (isNil(val)) {
               throw new HowlerHelperError('Lower expects a string argument');
             }
             return val.toString().toLocaleLowerCase();
@@ -208,7 +208,7 @@ export const useHelpers = (opts = { async: true, components: true }): HowlerHelp
             fr: 'Convertit une chaîne JSON en objet.'
           },
           callback: (_, str) => {
-            if (str == undefined) {
+            if (isNil(str)) {
               throw new HowlerHelperError('Parse JSON expects a string argument');
             }
             try {
@@ -306,7 +306,7 @@ export const useHelpers = (opts = { async: true, components: true }): HowlerHelp
             fr: ''
           },
           callback: (_, str: string, searchValue: string, replaceValue: string) => {
-            if (str == undefined || searchValue == undefined || replaceValue == undefined) {
+            if (isNil(str) || isNil(searchValue) || isNil(replaceValue)) {
               throw new HowlerHelperError('Replace expects three arguments');
             }
             return str.toString().replaceAll(searchValue ?? '', replaceValue ?? '');

--- a/ui/src/components/elements/display/handlebars/helpers.tsx
+++ b/ui/src/components/elements/display/handlebars/helpers.tsx
@@ -19,6 +19,7 @@ export interface HowlerHelper {
     fr: string;
   };
   async?: boolean;
+  hint?: string;
   callback?: Handlebars.HelperDelegate;
   componentCallback?: (...args: any[]) => ReactElement | Promise<ReactElement>;
 }
@@ -27,6 +28,13 @@ interface Cell {
   column: string;
   row: string;
   value: string;
+}
+
+export class HowlerHelperError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'HowlerHelperError';
+  }
 }
 
 const FETCH_RESULTS: { [url: string]: Promise<any> } = {};
@@ -43,7 +51,13 @@ export const useHelpers = (opts = { async: true, components: true }): HowlerHelp
             en: 'Checks the equality of the string representation of the two arguments.',
             fr: "Vérifie l'égalité de la représentation en chaîne de caractères des deux arguments."
           },
-          callback: (arg1, arg2) => arg1?.toString() === arg2.toString()
+          callback: (_, arg1, arg2) => {
+            if (arg1 == undefined || arg2 == undefined) {
+              throw new HowlerHelperError('Both arguments must be provided.');
+            }
+            return arg1.toString() === arg2.toString();
+          },
+          hint: 'Usage: {{equals arg1 arg2}}'
         },
         {
           keyword: 'and',
@@ -51,7 +65,7 @@ export const useHelpers = (opts = { async: true, components: true }): HowlerHelp
             en: 'Runs the comparison `arg1 && arg2`, and returns the result.',
             fr: 'Exécute la comparaison `arg1 && arg2`, et retourne le résultat.'
           },
-          callback: (arg1, arg2) => arg1 && arg2
+          callback: (_, arg1, arg2) => arg1 && arg2
         },
         {
           keyword: 'or',
@@ -59,7 +73,7 @@ export const useHelpers = (opts = { async: true, components: true }): HowlerHelp
             en: 'Runs the comparison `arg1 || arg2`, and returns the result.',
             fr: 'Exécute la comparaison `arg1 || arg2`, et retourne le résultat.'
           },
-          callback: (arg1, arg2) => arg1 || arg2
+          callback: (_, arg1, arg2) => arg1 || arg2
         },
         {
           keyword: 'not',
@@ -67,7 +81,7 @@ export const useHelpers = (opts = { async: true, components: true }): HowlerHelp
             en: 'Runs the comparison `!arg`, and returns the result.',
             fr: 'Exécute la comparaison `!arg`, et retourne le résultat.'
           },
-          callback: arg => !arg
+          callback: (_, arg) => !arg
         },
         {
           keyword: 'curly',
@@ -75,7 +89,7 @@ export const useHelpers = (opts = { async: true, components: true }): HowlerHelp
             en: 'Wraps the given argument in curly braces.',
             fr: "Entoure l'argument donné d'accolades."
           },
-          callback: arg1 => new Handlebars.SafeString(`{{${arg1}}}`)
+          callback: (_, arg1) => new Handlebars.SafeString(`{{${arg1}}}`)
         },
         {
           keyword: 'join',
@@ -83,7 +97,7 @@ export const useHelpers = (opts = { async: true, components: true }): HowlerHelp
             en: 'Joins two string arguments with a given string `sep`, or the empty string as a default.',
             fr: 'Joint deux arguments de chaîne avec une chaîne donnée `sep`, ou la chaîne vide par défaut.'
           },
-          callback: (arg1: string, arg2: string, context) =>
+          callback: (context, arg1: string, arg2: string) =>
             [arg1?.toString() ?? '', arg2?.toString() ?? ''].join(context.hash?.sep ?? '')
         },
         {
@@ -92,7 +106,13 @@ export const useHelpers = (opts = { async: true, components: true }): HowlerHelp
             en: 'Returns the uppercase representation of a string argument.',
             fr: "Retourne la représentation en majuscules d'un argument de chaîne."
           },
-          callback: (val: string) => val.toLocaleUpperCase()
+          callback: (_, val: string) => {
+            if (val == undefined) {
+              throw new HowlerHelperError('Upper expects a string argument');
+            }
+            return val.toString().toLocaleUpperCase();
+          },
+          hint: 'Usage: {{upper val}}'
         },
         {
           keyword: 'lower',
@@ -100,7 +120,13 @@ export const useHelpers = (opts = { async: true, components: true }): HowlerHelp
             en: 'Returns the lowercase representation of a string argument.',
             fr: "Retourne la représentation en minuscules d'un argument de chaîne."
           },
-          callback: (val: string) => val.toLocaleLowerCase()
+          callback: (_, val: string) => {
+            if (val == undefined) {
+              throw new HowlerHelperError('Lower expects a string argument');
+            }
+            return val.toString().toLocaleLowerCase();
+          },
+          hint: 'Usage: {{lower val}}'
         },
         {
           keyword: 'fetch',
@@ -109,7 +135,7 @@ export const useHelpers = (opts = { async: true, components: true }): HowlerHelp
             fr: "Récupère l'URL fournie et retourne la clé donnée (aplatie) de l'objet JSON retourné. Notez que le résultat doit être du JSON !"
           },
           async: true,
-          callback: async (url, key) => {
+          callback: async (_, url, key) => {
             try {
               if (!FETCH_RESULTS[url]) {
                 FETCH_RESULTS[url] = fetch(url).then(res => res.json());
@@ -129,7 +155,7 @@ export const useHelpers = (opts = { async: true, components: true }): HowlerHelp
             en: 'Given a howler hit ID, this helper renders a hit card for that ID.',
             fr: 'Étant donné un ID de résultat howler, cet assistant affiche une carte de résultat pour cet ID.'
           },
-          componentCallback: id => {
+          componentCallback: (_, id) => {
             if (!id) {
               return <AppListEmpty />;
             }
@@ -143,7 +169,7 @@ export const useHelpers = (opts = { async: true, components: true }): HowlerHelp
             en: 'Given a dict, return an array of {key, value} objects.',
             fr: "Étant donné un dictionnaire, retourne un tableau d'objets {key, value}."
           },
-          callback: obj => {
+          callback: (_, obj) => {
             if (!isObject(obj)) {
               return new Handlebars.SafeString('Invalid Object.');
             }
@@ -157,7 +183,7 @@ export const useHelpers = (opts = { async: true, components: true }): HowlerHelp
             en: 'Given JSON data, this helper renders a JSON viewer component.',
             fr: 'Étant donné des données JSON, cet assistant affiche un composant de visualisation JSON.'
           },
-          componentCallback: data => {
+          componentCallback: (_, data) => {
             if (!data) {
               return <AppListEmpty />;
             }
@@ -171,7 +197,7 @@ export const useHelpers = (opts = { async: true, components: true }): HowlerHelp
             en: 'Convert any object into a JSON string.',
             fr: "Convertit n'importe quel objet en chaîne JSON."
           },
-          callback: obj => {
+          callback: (_, obj) => {
             return new Handlebars.SafeString(JSON.stringify(obj));
           }
         },
@@ -181,9 +207,17 @@ export const useHelpers = (opts = { async: true, components: true }): HowlerHelp
             en: 'Convert a JSON string into an object.',
             fr: 'Convertit une chaîne JSON en objet.'
           },
-          callback: str => {
-            return JSON.parse(str);
-          }
+          callback: (_, str) => {
+            if (str == undefined) {
+              throw new HowlerHelperError('Parse JSON expects a string argument');
+            }
+            try {
+              return JSON.parse(str);
+            } catch (e) {
+              throw new HowlerHelperError('Invalid JSON string');
+            }
+          },
+          hint: 'Usage: {{parse_json str}}'
         },
         {
           keyword: 'get',
@@ -191,7 +225,7 @@ export const useHelpers = (opts = { async: true, components: true }): HowlerHelp
             en: 'Returns the given (flattened) key from the provided object.',
             fr: "Retourne la clé donnée (aplatie) de l'objet fourni."
           },
-          callback: (data, key) => {
+          callback: (_, data, key) => {
             try {
               return get(data, key);
             } catch (e) {
@@ -205,7 +239,7 @@ export const useHelpers = (opts = { async: true, components: true }): HowlerHelp
             en: 'Checks if field is in string',
             fr: 'Vérifie si le champ est dans la chaîne'
           },
-          callback: (arg1, arg2) => {
+          callback: (_, arg1, arg2) => {
             return !!arg2 && !!arg1?.includes(arg2);
           }
         },
@@ -216,7 +250,7 @@ export const useHelpers = (opts = { async: true, components: true }): HowlerHelp
             en: 'Render a table in markdown given an array of cells',
             fr: "Affiche un tableau en markdown à partir d'un tableau de cellules"
           },
-          componentCallback: (cells: Cell[]) => {
+          componentCallback: (_, cells: Cell[]) => {
             const columns = Object.keys(groupBy(cells, 'column'));
             const rows = groupBy(cells, 'row');
 
@@ -260,7 +294,7 @@ export const useHelpers = (opts = { async: true, components: true }): HowlerHelp
             en: 'Execute a howler action given a specific action ID (from the URL when viewing the action, i.e. yaIKVqiKhWpyCsWdqsE4D)',
             fr: "Exécute une action howler à partir d'un ID d'action spécifique (de l'URL lors de la visualisation de l'action, par ex. yaIKVqiKhWpyCsWdqsE4D)"
           },
-          componentCallback: (actionId: string, hitId: string, context) => {
+          componentCallback: (context, actionId: string, hitId: string) => {
             return <ActionButton actionId={actionId} hitId={hitId} {...(context.hash ?? {})} />;
           }
         },
@@ -271,9 +305,13 @@ export const useHelpers = (opts = { async: true, components: true }): HowlerHelp
             en: '',
             fr: ''
           },
-          callback: (str: string, searchValue: string, replaceValue: string) => {
-            return str.replaceAll(searchValue ?? '', replaceValue ?? '');
-          }
+          callback: (_, str: string, searchValue: string, replaceValue: string) => {
+            if (str == undefined || searchValue == undefined || replaceValue == undefined) {
+              throw new HowlerHelperError('Replace expects three arguments');
+            }
+            return str.toString().replaceAll(searchValue ?? '', replaceValue ?? '');
+          },
+          hint: 'Usage: {{replace str searchValue replaceValue}}'
         },
 
         ...howlerPluginStore.plugins.flatMap(plugin => pluginStore.executeFunction(`${plugin}.helpers`) as HowlerHelper)


### PR DESCRIPTION
Check for invalid argument list in helper callbacks and display a meaningful error message instead of failing. This removes the error messages like "str.replaceAll is not a function" when the argument passed is not a string.

The errors are not rendered in line but are displayed as an error overview page the same way that parse errors and other errors are rendered. As a result, it is not as easy to identify the location of the error as with a missing helper error, but the message states the name of the erroring helper and a message / hint, making it easier to identify the cause than with the original raw error message.

**Changes:**
- pass options as the first argument so it is easier for helpers to validate their args length
- add a `hint` field to the helper spec
- check for invalid arguments in helpers and throw a HowlerHelperError
- catch and render the helper errors with the helper name and hint in the markdown

Example error message:

<img width="922" height="151" alt="image" src="https://github.com/user-attachments/assets/d818bc0e-c06c-436b-af44-e28c7ee61d1d" />