### PR TITLE
fix(api): generate swagger docs for query params from signature and docstring

### DIFF
--- a/api/howler/common/swagger.py
+++ b/api/howler/common/swagger.py
@@ -79,7 +79,7 @@ def generate_swagger_docs(responses: dict[int, str] = {}):  # noqa: C901
                 "required": True,
             }
             for param_name, param in func_signature.parameters.items()
-            if param_name not in ["kwargs", "_"]
+            if param_name not in ["kwargs", "_", "user"]
             and not param_name.startswith("_")
             and param.kind != inspect.Parameter.KEYWORD_ONLY
         ]

--- a/api/howler/common/swagger.py
+++ b/api/howler/common/swagger.py
@@ -62,34 +62,17 @@ def generate_swagger_docs(responses: dict[int, str] = {}):  # noqa: C901
 
         path_params = [
             {
-                "name": param,
+                "name": param_name,
                 "in": "path",
                 "type": "string",
             }
-            for param in func_signature.parameters
-            if param not in ["kwargs", "_"] and not param.startswith("_")
+            for param_name, param in func_signature.parameters.items()
+            if param_name not in ["kwargs", "_"]
+            and not param_name.startswith("_")
+            and param.kind != inspect.Parameter.KEYWORD_ONLY
         ]
 
-        query_params: list[dict[str, Any]] = []
-        if func_doc:
-            for section in func_doc.split("\n\n"):
-                lines = section.splitlines()
-                if not lines[0].lower().endswith("arguments:"):
-                    continue
-
-                lines = [re.sub(r" =>.+", "", line).strip() for line in lines[1:]]
-
-                for line in lines:
-                    if line.lower() == "none" or "=>" not in line:
-                        continue
-
-                    if ": " in line:
-                        name, type = line.split(": ")
-                    else:
-                        name = line
-                        type = None
-
-                    query_params.append({"name": name, "in": "query", "type": type})
+        query_params: list[dict[str, Any]] = _get_query_parameters(func_signature, func_doc)
 
         tags: list[str] = []
         if module := inspect.getmodule(function):
@@ -116,3 +99,43 @@ def generate_swagger_docs(responses: dict[int, str] = {}):  # noqa: C901
         return wrapper
 
     return decorator
+
+
+def _get_query_parameters(func_signature: inspect.Signature, func_doc: Optional[str]) -> list[dict[str, Any]]:
+    query_params = [
+        {
+            "name": param_name,
+            "in": "query",
+            "type": None if param.annotation == inspect.Parameter.empty else _get_annotated_classname(param),
+        }
+        for param_name, param in func_signature.parameters.items()
+        if param.kind == inspect.Parameter.KEYWORD_ONLY  # query parameters requested using @parse_parameters
+    ]
+
+    # compatibility with old method of docstring-based query parameter definitions, prefer params in signature
+    if func_doc:
+        for section in func_doc.split("\n\n"):
+            lines = section.splitlines()
+            if not lines[0].lower().endswith("arguments:"):
+                continue
+
+            for line in lines:
+                if line.lower() == "none" or "=>" not in line:
+                    continue
+
+                arg_def = re.sub(r" =>.+", "", line).strip()
+
+                if ": " in arg_def:
+                    name, type = arg_def.split(": ")
+                else:
+                    name = arg_def
+                    type = None
+
+                if not any(param["name"] == name for param in query_params):
+                    query_params.append({"name": name, "in": "query", "type": type})
+
+    return query_params
+
+
+def _get_annotated_classname(param: inspect.Parameter) -> str:
+    return param.annotation.__name__ if hasattr(param.annotation, "__name__") else str(param.annotation)

--- a/api/howler/common/swagger.py
+++ b/api/howler/common/swagger.py
@@ -50,12 +50,12 @@ RESPONSES = {
 
 
 PYTHON_TO_SWAGGER_TYPE_MAP = {
-    str: "string",
-    int: "integer",
-    float: "number",
-    bool: "boolean",
-    list: "array",
-    dict: "object",
+    "str": "string",
+    "int": "integer",
+    "float": "number",
+    "bool": "boolean",
+    "list": "array",
+    "dict": "object",
 }
 
 
@@ -81,7 +81,7 @@ def generate_swagger_docs(responses: dict[int, str] = {}):  # noqa: C901
             for param_name, param in func_signature.parameters.items()
             if param_name not in ["kwargs", "_", "user"]
             and not param_name.startswith("_")
-            and param.kind != inspect.Parameter.KEYWORD_ONLY
+            and param.kind not in (inspect.Parameter.KEYWORD_ONLY, inspect.Parameter.VAR_KEYWORD)
         ]
 
         query_params: list[dict[str, Any]] = _get_query_parameters(func_signature, func_doc)
@@ -133,8 +133,11 @@ def _get_query_parameters(func_signature: inspect.Signature, func_doc: Optional[
 
                 arg_def = re.sub(r" =>.+", "", line).strip()
 
+                type: str | None
                 if ": " in arg_def:
                     name, type = arg_def.split(": ")
+                    if type not in PYTHON_TO_SWAGGER_TYPE_MAP.values():
+                        type = PYTHON_TO_SWAGGER_TYPE_MAP.get(type.strip(), None)
                 else:
                     name = arg_def
                     type = None
@@ -145,13 +148,28 @@ def _get_query_parameters(func_signature: inspect.Signature, func_doc: Optional[
     return query_params
 
 
-def _get_annotated_classname(param: inspect.Parameter) -> dict[str, list[dict[str, str]] | str | bool | None]:
+def _get_annotated_classname(param: inspect.Parameter) -> dict[str, list[dict[str, str | None]] | str | bool | None]:
     if param.annotation == inspect.Parameter.empty:
         return {"type": None}
 
+    param_type = param.annotation
+    required = True
+
     if isinstance(param.annotation, types.UnionType):
         required = types.NoneType not in param.annotation.__args__
-        types_list = [PYTHON_TO_SWAGGER_TYPE_MAP.get(t, "object") for t in param.annotation.__args__]
-        return {"oneOf": [{"type": t} for t in types_list], "required": required}
+        types_without_none = (
+            tuple(t for t in param.annotation.__args__ if t is not types.NoneType)
+            if not required
+            else param.annotation.__args__
+        )
 
-    return {"type": PYTHON_TO_SWAGGER_TYPE_MAP.get(param.annotation, "object"), "required": True}
+        if len(types_without_none) == 1:
+            param_type = types_without_none[0]
+        else:
+            types_list = [PYTHON_TO_SWAGGER_TYPE_MAP.get(getattr(t, "__name__", "")) for t in types_without_none]
+            return {"oneOf": [{"type": t} for t in types_list], "required": required}
+
+    return {
+        "type": PYTHON_TO_SWAGGER_TYPE_MAP.get(getattr(param_type, "__name__", "")),
+        "required": required,
+    }

--- a/api/howler/common/swagger.py
+++ b/api/howler/common/swagger.py
@@ -1,5 +1,6 @@
 import inspect
 import re
+import types
 from functools import wraps
 from typing import Any, Callable, Optional, cast
 
@@ -48,6 +49,16 @@ RESPONSES = {
 }
 
 
+PYTHON_TO_SWAGGER_TYPE_MAP = {
+    str: "string",
+    int: "integer",
+    float: "number",
+    bool: "boolean",
+    list: "array",
+    dict: "object",
+}
+
+
 def generate_swagger_docs(responses: dict[int, str] = {}):  # noqa: C901
     "Generate swagger documentation for a given endpoint"
 
@@ -65,6 +76,7 @@ def generate_swagger_docs(responses: dict[int, str] = {}):  # noqa: C901
                 "name": param_name,
                 "in": "path",
                 "type": "string",
+                "required": True,
             }
             for param_name, param in func_signature.parameters.items()
             if param_name not in ["kwargs", "_"]
@@ -103,11 +115,7 @@ def generate_swagger_docs(responses: dict[int, str] = {}):  # noqa: C901
 
 def _get_query_parameters(func_signature: inspect.Signature, func_doc: Optional[str]) -> list[dict[str, Any]]:
     query_params = [
-        {
-            "name": param_name,
-            "in": "query",
-            "type": None if param.annotation == inspect.Parameter.empty else _get_annotated_classname(param),
-        }
+        {"name": param_name, "in": "query", **_get_annotated_classname(param)}
         for param_name, param in func_signature.parameters.items()
         if param.kind == inspect.Parameter.KEYWORD_ONLY  # query parameters requested using @parse_parameters
     ]
@@ -137,5 +145,13 @@ def _get_query_parameters(func_signature: inspect.Signature, func_doc: Optional[
     return query_params
 
 
-def _get_annotated_classname(param: inspect.Parameter) -> str:
-    return param.annotation.__name__ if hasattr(param.annotation, "__name__") else str(param.annotation)
+def _get_annotated_classname(param: inspect.Parameter) -> dict[str, list[dict[str, str]] | str | bool | None]:
+    if param.annotation == inspect.Parameter.empty:
+        return {"type": None}
+
+    if isinstance(param.annotation, types.UnionType):
+        required = types.NoneType not in param.annotation.__args__
+        types_list = [PYTHON_TO_SWAGGER_TYPE_MAP.get(t, "object") for t in param.annotation.__args__]
+        return {"oneOf": [{"type": t} for t in types_list], "required": required}
+
+    return {"type": PYTHON_TO_SWAGGER_TYPE_MAP.get(param.annotation, "object"), "required": True}

--- a/api/test/unit/test_docs.py
+++ b/api/test/unit/test_docs.py
@@ -1,0 +1,118 @@
+import pytest
+
+from howler.common.swagger import generate_swagger_docs
+
+
+@pytest.fixture(scope="module")
+def docstring():
+    return """Brief description of function.
+
+        Arguments:
+            arg1: float   => Description of arg1
+            arg2        => Description of arg2
+
+        Optional Arguments:
+            arg3: boolean   => Description of arg3
+        """
+
+
+@pytest.fixture(scope="module")
+def func_with_docstring(docstring):
+    def test_func(**extra_args):
+        pass
+
+    test_func.__doc__ = docstring
+    return test_func
+
+
+@pytest.fixture(scope="module")
+def func_with_path_params():
+    def test_func(path_arg: int, **extra_args):
+        pass
+
+    return test_func
+
+
+@pytest.fixture(scope="module")
+def func_with_path_and_query_params():
+    def test_func(path_arg: int, *, query_arg: str, query_arg_optional: int | None, **extra_args):
+        pass
+
+    return test_func
+
+
+@pytest.fixture(scope="function")
+def func_with_docstring_and_path_params(func_with_path_params, docstring):
+    original_doc = func_with_path_params.__doc__
+    func_with_path_params.__doc__ = docstring
+
+    yield func_with_path_params
+
+    func_with_path_params.__doc__ = original_doc
+
+
+@pytest.fixture(scope="function")
+def func_with_docstring_and_path_and_query_params(func_with_path_and_query_params, docstring):
+    original_doc = func_with_path_and_query_params.__doc__
+    func_with_path_and_query_params.__doc__ = docstring
+
+    yield func_with_path_and_query_params
+
+    func_with_path_and_query_params.__doc__ = original_doc
+
+
+def test_spec_from_docstring(func_with_docstring):
+    decorated = generate_swagger_docs()(func_with_docstring)
+
+    assert hasattr(decorated, "specs_dict")
+    assert decorated.specs_dict["parameters"] == [
+        {"name": "arg1", "in": "query", "type": "number"},
+        {"name": "arg2", "in": "query", "type": None},
+        {"name": "arg3", "in": "query", "type": "boolean"},
+    ]
+
+
+def test_spec_from_path(func_with_path_params):
+    decorated = generate_swagger_docs()(func_with_path_params)
+
+    assert hasattr(decorated, "specs_dict")
+    assert decorated.specs_dict["parameters"] == [
+        {"name": "path_arg", "in": "path", "type": "string", "required": True}
+    ]
+
+
+def test_spec_from_path_and_query(func_with_path_and_query_params):
+    decorated = generate_swagger_docs()(func_with_path_and_query_params)
+
+    assert hasattr(decorated, "specs_dict")
+    assert decorated.specs_dict["parameters"] == [
+        {"name": "path_arg", "in": "path", "type": "string", "required": True},
+        {"name": "query_arg", "in": "query", "type": "string", "required": True},
+        {"name": "query_arg_optional", "in": "query", "type": "integer", "required": False},
+    ]
+
+
+def test_spec_from_docstring_and_path(func_with_docstring_and_path_params):
+    decorated = generate_swagger_docs()(func_with_docstring_and_path_params)
+
+    assert hasattr(decorated, "specs_dict")
+    assert decorated.specs_dict["parameters"] == [
+        {"name": "path_arg", "in": "path", "type": "string", "required": True},
+        {"name": "arg1", "in": "query", "type": "number"},
+        {"name": "arg2", "in": "query", "type": None},
+        {"name": "arg3", "in": "query", "type": "boolean"},
+    ]
+
+
+def test_spec_from_docstring_and_path_and_query(func_with_docstring_and_path_and_query_params):
+    decorated = generate_swagger_docs()(func_with_docstring_and_path_and_query_params)
+
+    assert hasattr(decorated, "specs_dict")
+    assert decorated.specs_dict["parameters"] == [
+        {"name": "path_arg", "in": "path", "type": "string", "required": True},
+        {"name": "query_arg", "in": "query", "type": "string", "required": True},
+        {"name": "query_arg_optional", "in": "query", "type": "integer", "required": False},
+        {"name": "arg1", "in": "query", "type": "number"},
+        {"name": "arg2", "in": "query", "type": None},
+        {"name": "arg3", "in": "query", "type": "boolean"},
+    ]


### PR DESCRIPTION
Update generate_swagger_docs so that it discovers query params properly and add support for discovering query params requested through parse_parameters.

parse_parameters validates/parses request args and passes it directly as a kwarg, so endpoint functions can do
```python
@api.route("/")
@parse_parameters(my_non_string_param=custom_parser, my_required_param="required", my_optional_param=None)
def my_endpoint(*, my_non_string_param: AnObject, my_required_param: str, my_optional_param: str | None):
    ...
```
and these parameters will be populated with the parsed values from request args. Since this means we can annotate the parameters directly in python, these changes update generate_swagger_docs to get these annotations from the signature if they exist.

**Changes:**
- Move the re.sub() call to parse the `=> [description]` out of the argument docs to after the step to check for an `=>` in the line, so that arguments described in the docstring are added to the swagger docs.
- Add keyword only parameters to the doc as query parameters prioritizing the type annotations if they exist over docstring information