### PR TITLE
fix(api): fixed reindex script when used with ilm

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -281,6 +281,7 @@ README.md, LICENSE, .gitignore, .pre-commit-config.yaml, pyrightconfig.json
 > **IMPORTANT FOR ALL FUTURE AGENTS**: When you learn something new, encounter a pitfall, or discover a non-obvious convention in this repository, **add a note to this section** before finishing your task. This keeps institutional knowledge available across conversations.
 
 - In `ui/`, `@fontsource/roboto` may fail TypeScript side-effect import resolution at the package root even when the dependency is installed; prefer importing the explicit CSS entry `@fontsource/roboto/index.css` from the app entrypoint.
+- When ILM indices coexist with a legacy `_hot` index, alias existence alone is insufficient: remove the legacy alias and ensure the latest ILM index is the only write index. Reindex recovery must restore only aliases actually present on its source index.
 
 ---
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -281,7 +281,7 @@ README.md, LICENSE, .gitignore, .pre-commit-config.yaml, pyrightconfig.json
 > **IMPORTANT FOR ALL FUTURE AGENTS**: When you learn something new, encounter a pitfall, or discover a non-obvious convention in this repository, **add a note to this section** before finishing your task. This keeps institutional knowledge available across conversations.
 
 - In `ui/`, `@fontsource/roboto` may fail TypeScript side-effect import resolution at the package root even when the dependency is installed; prefer importing the explicit CSS entry `@fontsource/roboto/index.css` from the app entrypoint.
-- When ILM indices coexist with a legacy `_hot` index, alias existence alone is insufficient: remove the legacy alias and ensure the latest ILM index is the only write index. Reindex recovery must restore only aliases actually present on its source index.
+- When ILM indices coexist with a legacy `_hot` index, alias existence alone is insufficient: remove the legacy alias and ensure the latest ILM index is the only write index. Maintenance commands that skip collection bootstrap must resolve the latest ILM index before reindexing; recovery must restore only aliases actually present on its source index.
 
 ---
 

--- a/api/howler/datastore/collection.py
+++ b/api/howler/datastore/collection.py
@@ -826,12 +826,10 @@ class ESCollection(Generic[ModelType]):
                     )
 
                     alias_actions = []
-                    aliases = index_data.get("aliases", {}) or {self.name: {"is_write_index": True}}
+                    aliases = index_data.get("aliases", {})
                     for alias, alias_data in aliases.items():
                         alias_action = {"index": index, "alias": alias}
                         alias_action.update(alias_data)
-                        if alias == self.name or alias_data.get("is_write_index", False):
-                            alias_action["is_write_index"] = True
                         alias_actions.append({"add": alias_action})
                     alias_actions.append({"remove_index": {"index": new_name}})
                     self.with_retries(self.datastore.client.indices.update_aliases, actions=alias_actions)
@@ -936,9 +934,9 @@ class ESCollection(Generic[ModelType]):
         """Recover from a failed or interrupted :meth:`reindex` run.
 
         For every index that still has a leftover ``__reindex`` index, restore the source
-        index as the writable target and delete the orphaned ``__reindex`` index. If the
-        source index is missing, raise an error instead of deleting ``__reindex`` because
-        it may be the only remaining copy of the data.
+        index's original aliases and delete the orphaned ``__reindex`` index. If the source
+        index is missing, raise an error instead of deleting ``__reindex`` because it may
+        be the only remaining copy of the data.
 
         Write blocks set during reindexing are cleared so the collection is usable again.
 
@@ -966,17 +964,13 @@ class ESCollection(Generic[ModelType]):
             reindex_aliases = new_index_data.get("aliases", {})
 
             alias_actions = []
-            for alias in sorted(set(source_aliases) | set(reindex_aliases) | {self.name}):
+            for alias in sorted(set(source_aliases) | set(reindex_aliases)):
                 source_alias_data = source_aliases.get(alias, {})
                 reindex_alias_data = reindex_aliases.get(alias, {})
 
                 add_alias_data = {"index": index, "alias": alias}
                 add_alias_data.update(source_alias_data)
-                if (
-                    alias == self.name
-                    or source_alias_data.get("is_write_index", False)
-                    or reindex_alias_data.get("is_write_index", False)
-                ):
+                if source_alias_data.get("is_write_index", False) or reindex_alias_data.get("is_write_index", False):
                     add_alias_data["is_write_index"] = True
 
                 alias_actions.append({"add": add_alias_data})
@@ -2884,7 +2878,25 @@ class ESCollection(Generic[ModelType]):
         if existing_ilm_indices:
             # ILM already bootstrapped — ensure the alias exists
             latest = sorted(existing_ilm_indices)[-1]
-            if not self.with_retries(self.datastore.client.indices.exists_alias, name=self.name):
+            if self.with_retries(self.datastore.client.indices.exists_alias, name=self.name):
+                alias_indices = self.with_retries(self.datastore.client.indices.get_alias, name=self.name)
+                alias_actions = []
+                for alias_index, alias_index_data in alias_indices.items():
+                    alias_data = alias_index_data.get("aliases", {}).get(self.name, {})
+                    if alias_index == self.index_name:
+                        alias_actions.append({"remove": {"index": alias_index, "alias": self.name}})
+                    elif alias_index != latest and alias_data.get("is_write_index", False):
+                        alias_actions.append(
+                            {"add": {"index": alias_index, "alias": self.name, "is_write_index": False}}
+                        )
+
+                latest_alias_data = alias_indices.get(latest, {}).get("aliases", {}).get(self.name, {})
+                if not latest_alias_data.get("is_write_index", False):
+                    alias_actions.append({"add": {"index": latest, "alias": self.name, "is_write_index": True}})
+
+                if alias_actions:
+                    self.with_retries(self.datastore.client.indices.update_aliases, actions=alias_actions)
+            else:
                 # Find the latest index to set as write index
                 self.with_retries(
                     self.datastore.client.indices.put_alias,

--- a/api/howler/datastore/collection.py
+++ b/api/howler/datastore/collection.py
@@ -2902,12 +2902,28 @@ class ESCollection(Generic[ModelType]):
                         alias_actions.append({"remove": {"index": alias_index, "alias": self.name}})
                     elif alias_index != latest and alias_data.get("is_write_index", False):
                         alias_actions.append(
-                            {"add": {"index": alias_index, "alias": self.name, "is_write_index": False}}
+                            {
+                                "add": {
+                                    "index": alias_index,
+                                    "alias": self.name,
+                                    **alias_data,
+                                    "is_write_index": False,
+                                }
+                            }
                         )
 
                 latest_alias_data = alias_indices.get(latest, {}).get("aliases", {}).get(self.name, {})
                 if not latest_alias_data.get("is_write_index", False):
-                    alias_actions.append({"add": {"index": latest, "alias": self.name, "is_write_index": True}})
+                    alias_actions.append(
+                        {
+                            "add": {
+                                "index": latest,
+                                "alias": self.name,
+                                **latest_alias_data,
+                                "is_write_index": True,
+                            }
+                        }
+                    )
 
                 if alias_actions:
                     self.with_retries(self.datastore.client.indices.update_aliases, actions=alias_actions)

--- a/api/howler/datastore/collection.py
+++ b/api/howler/datastore/collection.py
@@ -254,7 +254,7 @@ class ESCollection(Generic[ModelType]):
         if not self._index_list:
             self._index_list = list(self.with_retries(self.datastore.client.indices.get, index=f"{self.name}-*").keys())
 
-        return [self.index_name] + sorted(self._index_list, reverse=True)
+        return list(dict.fromkeys([self.index_name, *sorted(self._index_list, reverse=True)]))
 
     @property
     def index_list(self):
@@ -263,6 +263,19 @@ class ESCollection(Generic[ModelType]):
         :return: list of valid indexes for this collection
         """
         return [self.index_name]
+
+    def _refresh_ilm_index_name(self):
+        """Set ``index_name`` to the latest existing ILM index, when one exists."""
+        if not self.ilm_config:
+            return
+
+        ilm_indices = self.with_retries(
+            self.datastore.client.indices.get,
+            index=f"{self.name}-0*",
+            ignore_unavailable=True,
+        )
+        if ilm_indices:
+            self.index_name = sorted(ilm_indices)[-1]
 
     def scan_with_retry(
         self,
@@ -729,6 +742,7 @@ class ESCollection(Generic[ModelType]):
             operation can be recovered with :meth:`reindex_cleanup`.
         """
         logger.warning("Beginning Reindex")
+        self._refresh_ilm_index_name()
         for index in self.index_list:
             new_name = f"{index}__reindex"
             index_data = None
@@ -943,6 +957,7 @@ class ESCollection(Generic[ModelType]):
         :return: ``True`` when cleanup completed on all indexes
         """
         logger.warning("Beginning reindex cleanup")
+        self._refresh_ilm_index_name()
         for index in self.index_list:
             new_name = f"{index}__reindex"
 

--- a/api/howler/datastore/collection.py
+++ b/api/howler/datastore/collection.py
@@ -269,11 +269,14 @@ class ESCollection(Generic[ModelType]):
         if not self.ilm_config:
             return
 
-        ilm_indices = self.with_retries(
-            self.datastore.client.indices.get,
-            index=f"{self.name}-0*",
-            ignore_unavailable=True,
-        )
+        try:
+            ilm_indices = self.datastore.client.indices.get(
+                index=f"{self.name}-0*",
+                ignore_unavailable=True,
+            )
+        except elasticsearch.exceptions.NotFoundError:
+            return
+
         if ilm_indices:
             self.index_name = sorted(ilm_indices)[-1]
 
@@ -2893,12 +2896,13 @@ class ESCollection(Generic[ModelType]):
         if existing_ilm_indices:
             # ILM already bootstrapped — ensure the alias exists
             latest = sorted(existing_ilm_indices)[-1]
+            legacy_hot_index = f"{self.name}_hot"
             if self.with_retries(self.datastore.client.indices.exists_alias, name=self.name):
                 alias_indices = self.with_retries(self.datastore.client.indices.get_alias, name=self.name)
                 alias_actions = []
                 for alias_index, alias_index_data in alias_indices.items():
                     alias_data = alias_index_data.get("aliases", {}).get(self.name, {})
-                    if alias_index == self.index_name:
+                    if alias_index == legacy_hot_index:
                         alias_actions.append({"remove": {"index": alias_index, "alias": self.name}})
                     elif alias_index != latest and alias_data.get("is_write_index", False):
                         alias_actions.append(

--- a/api/howler/external/reindex_data.py
+++ b/api/howler/external/reindex_data.py
@@ -99,6 +99,7 @@ if __name__ == "__main__":
 
     for index_name in selected:
         collection: ESCollection = getattr(ds, index_name)
+        collection._refresh_ilm_index_name()
 
         if args.verbose:
             print(f"Index schema for '{index_name}':")

--- a/api/howler/odm/random_data.py
+++ b/api/howler/odm/random_data.py
@@ -867,8 +867,12 @@ def wipe_actions(ds: HowlerDatastore):
 def create_dossiers(ds: HowlerDatastore, num_dossiers: int = 5):
     "Create random dossiers"
     users = ds.user.search("*:*")["items"]
-    for _ in range(num_dossiers):
+    for index in range(num_dossiers):
         dossier = generate_useful_dossier(users)
+        if index == 0:
+            dossier.type = "personal"
+        elif index == 1:
+            dossier.type = "global"
         ds.dossier.save(dossier.dossier_id, dossier)
 
     ds.dossier.commit()

--- a/api/test/unit/test_ilm_collection.py
+++ b/api/test/unit/test_ilm_collection.py
@@ -6,6 +6,7 @@ index template, and _ensure_collection_ilm logic without requiring a running ES.
 
 from unittest.mock import MagicMock, patch
 
+import elasticsearch
 import pytest
 
 from howler.datastore.collection import ESCollection
@@ -238,6 +239,19 @@ class TestEnsureCollectionILM:
         assert col.index_name == f"{col.name}-000002"
         assert col.index_list_full == [f"{col.name}-000002", f"{col.name}-000001"]
 
+    def test_refresh_ilm_index_name_does_not_bootstrap_when_indices_are_missing(self, mock_datastore):
+        """Maintenance probes tolerate missing ILM indexes without ensuring the collection."""
+        col = _make_collection(mock_datastore, ilm_config=ILMIndexConfig(warm="30d"))
+        mock_datastore.client.indices.get.side_effect = elasticsearch.exceptions.NotFoundError(
+            "404", "index not found", {"error": {"type": "index_not_found_exception"}}
+        )
+
+        with patch.object(col, "_ensure_collection") as mock_ensure:
+            col._refresh_ilm_index_name()
+
+        assert col.index_name == f"{col.name}_hot"
+        mock_ensure.assert_not_called()
+
     def test_fresh_install_creates_initial_index(self, mock_datastore, ilm_global):
         """On a fresh install, creates {name}-000001 with alias and ILM settings."""
         ilm_index = ILMIndexConfig(warm="30d", cold="90d")
@@ -346,6 +360,32 @@ class TestEnsureCollectionILM:
         assert {"remove": {"index": hot_index_name, "alias": col.name}} in alias_actions
         assert {"add": {"index": latest_index_name, "alias": col.name, "is_write_index": True}} in alias_actions
         assert col.index_name == latest_index_name
+
+    def test_existing_ilm_indices_remove_legacy_alias_after_reentry(self, mock_datastore, ilm_global):
+        """Re-entering ensure does not remove the alias from the active ILM index."""
+        ilm_index = ILMIndexConfig(warm="30d")
+        col = _make_collection(mock_datastore, ilm_config=ilm_index)
+        legacy_hot_index = f"{col.name}_hot"
+        latest_index_name = f"{col.name}-000001"
+        col.index_name = latest_index_name
+
+        mock_datastore.client.indices.get.return_value = {latest_index_name: {}}
+        mock_datastore.client.indices.exists_alias.return_value = True
+        mock_datastore.client.indices.get_alias.return_value = {
+            legacy_hot_index: {"aliases": {col.name: {}}},
+            latest_index_name: {"aliases": {col.name: {"is_write_index": True}}},
+        }
+
+        with (
+            patch.object(col, "_create_ilm_policy"),
+            patch.object(col, "_create_index_template"),
+            patch.object(col, "_check_fields"),
+        ):
+            col._ensure_collection_ilm()
+
+        alias_actions = mock_datastore.client.indices.update_aliases.call_args.kwargs["actions"]
+        assert {"remove": {"index": legacy_hot_index, "alias": col.name}} in alias_actions
+        assert {"remove": {"index": latest_index_name, "alias": col.name}} not in alias_actions
 
     def test_existing_ilm_indices_preserve_alias_metadata_when_updating_write_index(self, mock_datastore, ilm_global):
         """Write-index corrections retain alias filters and routing settings."""

--- a/api/test/unit/test_ilm_collection.py
+++ b/api/test/unit/test_ilm_collection.py
@@ -225,6 +225,19 @@ class TestCreateIndexTemplate:
 class TestEnsureCollectionILM:
     """Tests for _ensure_collection_ilm bootstrap logic."""
 
+    def test_refresh_ilm_index_name_uses_latest_existing_index(self, mock_datastore):
+        """Maintenance commands select the active ILM index when bootstrap is skipped."""
+        col = _make_collection(mock_datastore, ilm_config=ILMIndexConfig(warm="30d"))
+        mock_datastore.client.indices.get.return_value = {
+            f"{col.name}-000001": {},
+            f"{col.name}-000002": {},
+        }
+
+        col._refresh_ilm_index_name()
+
+        assert col.index_name == f"{col.name}-000002"
+        assert col.index_list_full == [f"{col.name}-000002", f"{col.name}-000001"]
+
     def test_fresh_install_creates_initial_index(self, mock_datastore, ilm_global):
         """On a fresh install, creates {name}-000001 with alias and ILM settings."""
         ilm_index = ILMIndexConfig(warm="30d", cold="90d")
@@ -342,6 +355,7 @@ class TestEnsureCollectionILM:
 
         mock_datastore.client.indices.exists.side_effect = [True, True]
         mock_datastore.client.indices.get.side_effect = [
+            {col.index_name: {}},
             {col.index_name: {"aliases": {}}},
             {reindex_index_name: {"aliases": {}}},
         ]

--- a/api/test/unit/test_ilm_collection.py
+++ b/api/test/unit/test_ilm_collection.py
@@ -309,6 +309,47 @@ class TestEnsureCollectionILM:
         # index_name should be updated to the latest ILM index
         assert col.index_name == f"{col.name}-000002"
 
+    def test_existing_ilm_indices_replace_legacy_hot_alias(self, mock_datastore, ilm_global):
+        """An existing legacy write alias is moved to the latest ILM index."""
+        ilm_index = ILMIndexConfig(warm="30d")
+        col = _make_collection(mock_datastore, ilm_config=ilm_index)
+        hot_index_name = col.index_name
+        latest_index_name = f"{col.name}-000001"
+
+        mock_datastore.client.indices.get.return_value = {latest_index_name: {}}
+        mock_datastore.client.indices.exists_alias.return_value = True
+        mock_datastore.client.indices.get_alias.return_value = {
+            hot_index_name: {"aliases": {col.name: {"is_write_index": True}}}
+        }
+
+        with (
+            patch.object(col, "_create_ilm_policy"),
+            patch.object(col, "_create_index_template"),
+            patch.object(col, "_check_fields"),
+        ):
+            col._ensure_collection_ilm()
+
+        alias_actions = mock_datastore.client.indices.update_aliases.call_args.kwargs["actions"]
+        assert {"remove": {"index": hot_index_name, "alias": col.name}} in alias_actions
+        assert {"add": {"index": latest_index_name, "alias": col.name, "is_write_index": True}} in alias_actions
+        assert col.index_name == latest_index_name
+
+    def test_reindex_cleanup_does_not_restore_missing_collection_alias(self, mock_datastore):
+        """Cleanup must not make an alias writable when the source did not own it."""
+        col = _make_collection(mock_datastore, ilm_config=ILMIndexConfig(warm="30d"))
+        col.index_name = f"{col.name}-000001"
+        reindex_index_name = f"{col.index_name}__reindex"
+
+        mock_datastore.client.indices.exists.side_effect = [True, True]
+        mock_datastore.client.indices.get.side_effect = [
+            {col.index_name: {"aliases": {}}},
+            {reindex_index_name: {"aliases": {}}},
+        ]
+
+        assert col.reindex_cleanup() is True
+        mock_datastore.client.indices.update_aliases.assert_not_called()
+        mock_datastore.client.indices.delete.assert_called_once_with(index=reindex_index_name)
+
     def test_legacy_hot_index_migration(self, mock_datastore, ilm_global):
         """Legacy _hot index gets cloned to -000001 and alias is swapped."""
         ilm_index = ILMIndexConfig(warm="30d")

--- a/api/test/unit/test_ilm_collection.py
+++ b/api/test/unit/test_ilm_collection.py
@@ -347,6 +347,59 @@ class TestEnsureCollectionILM:
         assert {"add": {"index": latest_index_name, "alias": col.name, "is_write_index": True}} in alias_actions
         assert col.index_name == latest_index_name
 
+    def test_existing_ilm_indices_preserve_alias_metadata_when_updating_write_index(self, mock_datastore, ilm_global):
+        """Write-index corrections retain alias filters and routing settings."""
+        ilm_index = ILMIndexConfig(warm="30d")
+        col = _make_collection(mock_datastore, ilm_config=ilm_index)
+        old_index_name = f"{col.name}-000001"
+        latest_index_name = f"{col.name}-000002"
+        old_alias_data = {
+            "filter": {"term": {"tenant": "alpha"}},
+            "routing": "alpha",
+            "is_write_index": True,
+        }
+        latest_alias_data = {
+            "filter": {"term": {"tenant": "alpha"}},
+            "search_routing": "alpha",
+        }
+
+        mock_datastore.client.indices.get.return_value = {
+            old_index_name: {},
+            latest_index_name: {},
+        }
+        mock_datastore.client.indices.exists_alias.return_value = True
+        mock_datastore.client.indices.get_alias.return_value = {
+            old_index_name: {"aliases": {col.name: old_alias_data}},
+            latest_index_name: {"aliases": {col.name: latest_alias_data}},
+        }
+
+        with (
+            patch.object(col, "_create_ilm_policy"),
+            patch.object(col, "_create_index_template"),
+            patch.object(col, "_check_fields"),
+        ):
+            col._ensure_collection_ilm()
+
+        alias_actions = mock_datastore.client.indices.update_aliases.call_args.kwargs["actions"]
+        assert {
+            "add": {
+                "index": old_index_name,
+                "alias": col.name,
+                "filter": {"term": {"tenant": "alpha"}},
+                "routing": "alpha",
+                "is_write_index": False,
+            }
+        } in alias_actions
+        assert {
+            "add": {
+                "index": latest_index_name,
+                "alias": col.name,
+                "filter": {"term": {"tenant": "alpha"}},
+                "search_routing": "alpha",
+                "is_write_index": True,
+            }
+        } in alias_actions
+
     def test_reindex_cleanup_does_not_restore_missing_collection_alias(self, mock_datastore):
         """Cleanup must not make an alias writable when the source did not own it."""
         col = _make_collection(mock_datastore, ilm_config=ILMIndexConfig(warm="30d"))

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -29,7 +29,7 @@
 
 ## Howler API `v4.0.0`
 
-- **ILM Reindex Alias Recovery** _(bugfix)_: Reconciled legacy collection aliases during ILM bootstrap and prevented reindex recovery from creating conflicting write aliases.
+- **ILM Reindex Alias Recovery** _(bugfix)_: Reconciled legacy collection aliases during ILM bootstrap, selected the active ILM backing index for maintenance reindexing, and prevented recovery from creating conflicting write aliases.
 - **Correlation Worker Test Isolation** _(bugfix)_: Isolated each API test run's HTTP endpoint, correlation queue, and datastore indices so parallel runs cannot consume or delete one another's records.
 - **ODM Inheritance and Plugin Support** _(new feature)_: Added compatibility shims and improved enum/model type handling, `id_field` validation, and caching so plugins can define ODM subclasses ([#331](https://github.com/CybercentreCanada/howler/pull/331)).
 - **Action Execution Queue** _(improvement)_: Added a queue and worker for action execution to limit Elasticsearch query pressure and improve action-service reliability ([#385](https://github.com/CybercentreCanada/howler/pull/385)).

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -29,6 +29,7 @@
 
 ## Howler API `v4.0.0`
 
+- **ILM Reindex Alias Recovery** _(bugfix)_: Reconciled legacy collection aliases during ILM bootstrap and prevented reindex recovery from creating conflicting write aliases.
 - **Correlation Worker Test Isolation** _(bugfix)_: Isolated each API test run's HTTP endpoint, correlation queue, and datastore indices so parallel runs cannot consume or delete one another's records.
 - **ODM Inheritance and Plugin Support** _(new feature)_: Added compatibility shims and improved enum/model type handling, `id_field` validation, and caching so plugins can define ODM subclasses ([#331](https://github.com/CybercentreCanada/howler/pull/331)).
 - **Action Execution Queue** _(improvement)_: Added a queue and worker for action execution to limit Elasticsearch query pressure and improve action-service reliability ([#385](https://github.com/CybercentreCanada/howler/pull/385)).


### PR DESCRIPTION
This PR resolves a number of issues with the existing `reindex_data.py` helper that causes it to misbehave when combined with an active ILM policy.

---

This pull request addresses several issues with Index Lifecycle Management (ILM) handling, particularly around legacy alias migration, reindexing, and recovery. The main improvements ensure that maintenance operations always select the correct active ILM index, legacy `_hot` aliases are properly removed in favor of ILM indices, and reindex cleanup avoids creating conflicting write aliases. Additional tests and documentation updates support these changes.

**ILM Index and Alias Handling Improvements:**

* Added `_refresh_ilm_index_name` to select the latest ILM index as the active index for maintenance operations, ensuring that commands like reindex and recovery act on the correct index. (`api/howler/datastore/collection.py`, `api/howler/external/reindex_data.py`, [[1]](diffhunk://#diff-7fb260535d4b12db698f5657b1aeede4e52e4a699459841109e161c8d51c1332R228-R240) [[2]](diffhunk://#diff-1e4c8255a42b678b2962be8e4a244ce73da06e063ec1eb1249277a21972df5d4L257-R257) [[3]](diffhunk://#diff-1e4c8255a42b678b2962be8e4a244ce73da06e063ec1eb1249277a21972df5d4R267-R279) [[4]](diffhunk://#diff-1e4c8255a42b678b2962be8e4a244ce73da06e063ec1eb1249277a21972df5d4R745) [[5]](diffhunk://#diff-1e4c8255a42b678b2962be8e4a244ce73da06e063ec1eb1249277a21972df5d4L939-R960)
* Enhanced `_ensure_collection_ilm` to remove legacy aliases and ensure only the latest ILM index is set as the write index, preventing conflicts when both legacy and ILM indices exist. (`api/howler/datastore/collection.py`, [api/howler/datastore/collection.pyL2887-R2914](diffhunk://#diff-1e4c8255a42b678b2962be8e4a244ce73da06e063ec1eb1249277a21972df5d4L2887-R2914))

**Reindex and Recovery Logic Fixes:**

* Updated reindex and reindex_cleanup to use the refreshed ILM index and to avoid restoring write aliases that did not originally belong to the collection, preventing accidental promotion of conflicting aliases. (`api/howler/datastore/collection.py`, [[1]](diffhunk://#diff-1e4c8255a42b678b2962be8e4a244ce73da06e063ec1eb1249277a21972df5d4L829-L834) [[2]](diffhunk://#diff-1e4c8255a42b678b2962be8e4a244ce73da06e063ec1eb1249277a21972df5d4L969-R988) [[3]](diffhunk://#diff-7fb260535d4b12db698f5657b1aeede4e52e4a699459841109e161c8d51c1332R325-R366)

**Testing and Documentation:**

* Added unit tests to verify correct selection of the active ILM index, proper migration of legacy aliases, and safe alias handling during reindex cleanup. (`api/test/unit/test_ilm_collection.py`, [[1]](diffhunk://#diff-7fb260535d4b12db698f5657b1aeede4e52e4a699459841109e161c8d51c1332R228-R240) [[2]](diffhunk://#diff-7fb260535d4b12db698f5657b1aeede4e52e4a699459841109e161c8d51c1332R325-R366)
* Updated release notes and institutional knowledge docs to describe the new ILM alias handling and recovery behavior. (`docs/RELEASES.md`, [[1]](diffhunk://#diff-94fd84d8893cd91cd0c77710b90bd0c68d4e0d2ddce48b6bf04b1cba48129b0aR32); `.github/copilot-instructions.md`, [[2]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5R284)