### PR TITLE
fix(api): fix case correlation to execute on v1 ingestion

### DIFF
--- a/api/howler/api/v1/hit.py
+++ b/api/howler/api/v1/hit.py
@@ -2,7 +2,6 @@ import difflib
 import json
 from typing import Any, Optional, cast
 
-from api.howler.services import correlation_service
 from flask import request
 from mergedeep import Strategy, merge
 
@@ -31,7 +30,7 @@ from howler.odm.models.hit import Hit
 from howler.odm.models.howler_data import Comment, HitOperationType, HitStatusTransition
 from howler.odm.models.user import User
 from howler.security import api_login
-from howler.services import action_service, analytic_service, comms_service, hit_service
+from howler.services import action_service, analytic_service, comms_service, correlation_service, hit_service
 from howler.utils.constants import DEBUG_FORCE_REFRESH
 from howler.utils.str_utils import sanitize_lucene_query
 

--- a/api/howler/api/v1/hit.py
+++ b/api/howler/api/v1/hit.py
@@ -2,6 +2,7 @@ import difflib
 import json
 from typing import Any, Optional, cast
 
+from api.howler.services import correlation_service
 from flask import request
 from mergedeep import Strategy, merge
 
@@ -130,7 +131,9 @@ def create_hits(user: User, **kwargs):
 
             hit_service.create_hits(odms, user=user.uname, refresh="true" if DEBUG_FORCE_REFRESH else refresh)
             analytic_service.save_from_hits(odms, user, refresh=refresh)
-            action_service.enqueue_action_execution([odm.howler.id for odm in odms], trigger="create", user=user)
+            ids = [odm.howler.id for odm in odms]
+            action_service.enqueue_action_execution(ids, trigger="create", user=user)
+            correlation_service.enqueue_for_correlation(ids)
 
         response_body["warnings"] = warnings
 

--- a/api/howler/api/v1/tool.py
+++ b/api/howler/api/v1/tool.py
@@ -1,5 +1,6 @@
 from typing import Any, Optional
 
+from api.howler.services import correlation_service
 from flask import request
 
 from howler.api import bad_request, created, make_subapi_blueprint
@@ -233,6 +234,8 @@ def create_one_or_many_hits(tool_name: str, user: User, **kwargs):  # noqa: C901
         hit_service.create_hits(odms, user=user.uname, refresh="true" if DEBUG_FORCE_REFRESH else refresh)
         analytic_service.save_from_hits(odms, user, refresh=refresh)
 
-    action_service.enqueue_action_execution([entry["id"] for entry in out], trigger="create", user=user)
+    ids = [entry["id"] for entry in out]
+    action_service.enqueue_action_execution(ids, trigger="create", user=user)
+    correlation_service.enqueue_for_correlation(ids)
 
     return created(out, warnings=warnings)

--- a/api/howler/api/v1/tool.py
+++ b/api/howler/api/v1/tool.py
@@ -1,6 +1,5 @@
 from typing import Any, Optional
 
-from api.howler.services import correlation_service
 from flask import request
 
 from howler.api import bad_request, created, make_subapi_blueprint
@@ -14,7 +13,7 @@ from howler.odm.base import _Field
 from howler.odm.models.hit import Hit
 from howler.odm.models.user import User
 from howler.security import api_login
-from howler.services import action_service, analytic_service, hit_service
+from howler.services import action_service, analytic_service, correlation_service, hit_service
 from howler.utils.constants import DEBUG_FORCE_REFRESH
 from howler.utils.dict_utils import flatten
 from howler.utils.isotime import now_as_iso

--- a/api/howler/api/v2/ingest.py
+++ b/api/howler/api/v2/ingest.py
@@ -100,10 +100,7 @@ def create(index: str, user: User, **kwargs):
 
     # Enqueue newly created hit IDs for the correlation worker.
     if ids:
-        try:
-            correlation_service.get_ingestion_queue().push(*ids)
-        except Exception:
-            logger.exception("Failed to enqueue hit IDs for correlation")
+        correlation_service.enqueue_for_correlation(ids)
 
     return created(ids, warnings=warnings)
 

--- a/api/howler/api/v2/ingest.py
+++ b/api/howler/api/v2/ingest.py
@@ -1,7 +1,6 @@
 import json
 from typing import Any, Literal, cast
 
-from api.howler.services import correlation_service
 from flask import request
 from mergedeep import Strategy, merge
 
@@ -20,7 +19,7 @@ from howler.odm.models.event import Event
 from howler.odm.models.hit import Hit
 from howler.odm.models.user import User
 from howler.security import api_login
-from howler.services import event_service, hit_service
+from howler.services import correlation_service, event_service, hit_service
 from howler.utils.dict_utils import flatten
 
 MAX_COMMENT_LEN = 5000

--- a/api/howler/api/v2/ingest.py
+++ b/api/howler/api/v2/ingest.py
@@ -1,6 +1,7 @@
 import json
 from typing import Any, Literal, cast
 
+from api.howler.services import correlation_service
 from flask import request
 from mergedeep import Strategy, merge
 
@@ -11,7 +12,6 @@ from howler.common.exceptions import HowlerException, HowlerValueError
 from howler.common.loader import datastore
 from howler.common.logging import get_logger
 from howler.common.swagger import generate_swagger_docs
-from howler.config import CORRELATION_QUEUE_NAME, config
 from howler.datastore.collection import ESCollection
 from howler.datastore.exceptions import DataStoreException
 from howler.datastore.howler_store import INDEXES
@@ -19,7 +19,6 @@ from howler.datastore.operations import OdmHelper, OdmUpdateOperation
 from howler.odm.models.event import Event
 from howler.odm.models.hit import Hit
 from howler.odm.models.user import User
-from howler.remote.datatypes.queues.named import NamedQueue
 from howler.security import api_login
 from howler.services import event_service, hit_service
 from howler.utils.dict_utils import flatten
@@ -35,24 +34,6 @@ FIELDS = Hit.flat_fields()
 logger = get_logger(__file__)
 
 hit_helper = OdmHelper(Hit)
-
-# Persistent queue for the correlation worker to consume newly ingested hit IDs.
-_ingestion_queue: NamedQueue[str] | None = None
-
-
-def _get_ingestion_queue() -> NamedQueue[str]:
-    """Return the shared ingestion queue, creating it on first use."""
-    global _ingestion_queue
-
-    if _ingestion_queue is None:
-        _ingestion_queue = NamedQueue(
-            CORRELATION_QUEUE_NAME,
-            host=config.core.redis.persistent.host,
-            port=config.core.redis.persistent.port,
-            private=False,
-        )
-
-    return _ingestion_queue
 
 
 @generate_swagger_docs()
@@ -121,7 +102,7 @@ def create(index: str, user: User, **kwargs):
     # Enqueue newly created hit IDs for the correlation worker.
     if ids:
         try:
-            _get_ingestion_queue().push(*ids)
+            correlation_service.get_ingestion_queue().push(*ids)
         except Exception:
             logger.exception("Failed to enqueue hit IDs for correlation")
 

--- a/api/howler/services/correlation_service.py
+++ b/api/howler/services/correlation_service.py
@@ -13,7 +13,7 @@ from datetime import datetime, timedelta, timezone
 import chevron
 from opentelemetry import trace
 
-from howler.common.exceptions import InvalidDataException, NotFoundException
+from howler.common.exceptions import HowlerRuntimeError, InvalidDataException, NotFoundException
 from howler.common.loader import datastore
 from howler.common.logging import get_logger
 from howler.config import CORRELATION_QUEUE_NAME
@@ -35,6 +35,40 @@ def _normalize_utc(ts: datetime) -> datetime:
     if ts.tzinfo is None:
         return ts.replace(tzinfo=timezone.utc)
     return ts
+
+
+# Persistent queue for the correlation worker to consume newly ingested hit IDs.
+_ingestion_queue: NamedQueue[str] | None = None
+
+
+def get_ingestion_queue() -> NamedQueue[str]:
+    """Return the shared ingestion queue, creating it on first use."""
+    global _ingestion_queue
+
+    if _ingestion_queue is None:
+        _ingestion_queue = NamedQueue(
+            CORRELATION_QUEUE_NAME,
+            host=config.core.redis.persistent.host,
+            port=config.core.redis.persistent.port,
+            private=False,
+        )
+
+    return _ingestion_queue
+
+
+def enqueue_for_correlation(ids: list[str]):
+    """Enqueue record IDs for correlation processing.
+
+    Args:
+        ids: List of record IDs to enqueue for correlation.
+
+    Raises:
+        HowlerRuntimeError: If enqueueing fails.
+    """
+    try:
+        get_ingestion_queue().push(*ids)
+    except Exception as exc:
+        raise HowlerRuntimeError("Error on queuing for correlation") from exc
 
 
 def get_active_rules() -> list[tuple[str, CaseRule]]:  # noqa: C901
@@ -179,23 +213,13 @@ def process_batch(record_ids: list[str]) -> int:  # noqa: C901
     return added
 
 
-def _build_queue() -> NamedQueue[str]:
-    """Create the NamedQueue backed by persistent Redis."""
-    return NamedQueue(
-        CORRELATION_QUEUE_NAME,
-        host=config.core.redis.persistent.host,
-        port=config.core.redis.persistent.port,
-        private=False,
-    )
-
-
 def run_worker() -> None:  # pragma: no cover – long-running loop, tested via process_batch
     """Block on the ingestion queue and process batches of record IDs.
 
     Accumulates up to ``BATCH_SIZE`` IDs or flushes after ``BATCH_TIMEOUT``
     seconds, whichever comes first.
     """
-    queue = _build_queue()
+    queue = get_ingestion_queue()
     logger.info("Correlation worker started (batch_size=%d, timeout=%ds)", BATCH_SIZE, BATCH_TIMEOUT)
 
     batch: list[str] = []

--- a/api/howler/services/correlation_service.py
+++ b/api/howler/services/correlation_service.py
@@ -13,7 +13,7 @@ from datetime import datetime, timedelta, timezone
 import chevron
 from opentelemetry import trace
 
-from howler.common.exceptions import HowlerRuntimeError, InvalidDataException, NotFoundException
+from howler.common.exceptions import InvalidDataException, NotFoundException
 from howler.common.loader import datastore
 from howler.common.logging import get_logger
 from howler.config import CORRELATION_QUEUE_NAME
@@ -41,7 +41,7 @@ def _normalize_utc(ts: datetime) -> datetime:
 _ingestion_queue: NamedQueue[str] | None = None
 
 
-def get_ingestion_queue() -> NamedQueue[str]:
+def _get_ingestion_queue() -> NamedQueue[str]:
     """Return the shared ingestion queue, creating it on first use."""
     global _ingestion_queue
 
@@ -56,7 +56,7 @@ def get_ingestion_queue() -> NamedQueue[str]:
     return _ingestion_queue
 
 
-def enqueue_for_correlation(ids: list[str]):
+def enqueue_for_correlation(ids: list[str]) -> None:
     """Enqueue record IDs for correlation processing.
 
     Args:
@@ -66,9 +66,9 @@ def enqueue_for_correlation(ids: list[str]):
         HowlerRuntimeError: If enqueueing fails.
     """
     try:
-        get_ingestion_queue().push(*ids)
-    except Exception as exc:
-        raise HowlerRuntimeError("Error on queuing for correlation") from exc
+        _get_ingestion_queue().push(*ids)
+    except Exception:
+        logger.exception("Error on queuing for correlation")
 
 
 def get_active_rules() -> list[tuple[str, CaseRule]]:  # noqa: C901
@@ -219,7 +219,7 @@ def run_worker() -> None:  # pragma: no cover – long-running loop, tested via 
     Accumulates up to ``BATCH_SIZE`` IDs or flushes after ``BATCH_TIMEOUT``
     seconds, whichever comes first.
     """
-    queue = get_ingestion_queue()
+    queue = _get_ingestion_queue()
     logger.info("Correlation worker started (batch_size=%d, timeout=%ds)", BATCH_SIZE, BATCH_TIMEOUT)
 
     batch: list[str] = []

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -152,7 +152,7 @@ suppress-none-returning = true
 [tool.poetry]
 package-mode = true
 name = "howler-api"
-version = "4.0.0"
+version = "4.0.1"
 description = "Howler - API server"
 authors = [
     "Canadian Centre for Cyber Security <howler@cyber.gc.ca>",

--- a/api/test/integration/api/test_correlation.py
+++ b/api/test/integration/api/test_correlation.py
@@ -347,3 +347,78 @@ class TestCorrelationWorker:
         assert not missing_hit_ids, (
             f"Worker did not add hits {missing_hit_ids} to case {case_id} within {self.MAX_WAIT}s"
         )
+
+    def test_worker_processes_v1_hit_ingestion(self, test_case, datastore: HowlerDatastore):
+        """Hits created via v1 /hit are queued and processed by the correlation worker."""
+        case_id, session, host = test_case
+        analytic = f"v1-hit-worker-{uuid.uuid4().hex}"
+
+        self._add_rule(session, host, case_id, f"howler.analytic:{analytic}", "worker-v1-hit")
+        datastore.case.commit()
+
+        ingest_resp = get_api_data(
+            session,
+            f"{host}/api/v1/hit/",
+            method="POST",
+            data=json.dumps([{"howler": {"analytic": analytic, "score": "0.8"}}]),
+        )
+        hit_ids = [entry["howler"]["id"] for entry in ingest_resp["valid"]]
+
+        seen_hit_ids = self._wait_for_case_items(datastore, case_id, hit_ids)
+        missing_hit_ids = set(hit_ids) - set(seen_hit_ids)
+        assert not missing_hit_ids, (
+            f"Worker did not add v1 ingested hits {missing_hit_ids} to case {case_id} within {self.MAX_WAIT}s"
+        )
+
+    def test_worker_processes_v1_tool_ingestion(self, test_case, datastore: HowlerDatastore):
+        """Hits created via v1 tool mapping are queued and processed by the worker."""
+        case_id, session, host = test_case
+        analytic = f"v1-tool-worker-{uuid.uuid4().hex}"
+
+        self._add_rule(session, host, case_id, f"howler.analytic:{analytic}", "worker-v1-tool")
+        datastore.case.commit()
+
+        ingest_resp = get_api_data(
+            session,
+            f"{host}/api/v1/tools/test/hits",
+            method="POST",
+            data=json.dumps(
+                {
+                    "map": {
+                        "analytic": ["howler.analytic"],
+                        "file.sha256": ["file.hash.sha256", "howler.hash"],
+                        "file.name": ["file.name"],
+                        "src_ip": ["source.ip", "related.ip"],
+                        "dest_ip": ["destination.ip", "related.ip"],
+                        "time.created": ["event.start"],
+                        "time.completed": ["event.end"],
+                        "raw": ["howler.data"],
+                        "zone": ["cloud.availability_zone"],
+                    },
+                    "hits": [
+                        {
+                            "analytic": analytic,
+                            "file": {
+                                "name": "worker-tool-hit.bin",
+                                "sha256": "ca978112ca1bbdcafac231b39a23dc4da786eff8147c4e72b9807785afee48bb",
+                            },
+                            "src_ip": "10.10.10.10",
+                            "dest_ip": "10.10.10.11",
+                            "time": {
+                                "created": "2026-01-01T00:00:00Z",
+                                "completed": "2026-01-01T00:01:00Z",
+                            },
+                            "zone": "test-zone",
+                            "raw": {"analytic": analytic},
+                        }
+                    ],
+                }
+            ),
+        )
+        hit_ids = [entry["id"] for entry in ingest_resp]
+
+        seen_hit_ids = self._wait_for_case_items(datastore, case_id, hit_ids)
+        missing_hit_ids = set(hit_ids) - set(seen_hit_ids)
+        assert not missing_hit_ids, (
+            f"Worker did not add v1 tool ingested hits {missing_hit_ids} to case {case_id} within {self.MAX_WAIT}s"
+        )

--- a/api/test/unit/endpoints/test_ingest_endpoint.py
+++ b/api/test/unit/endpoints/test_ingest_endpoint.py
@@ -64,7 +64,7 @@ def _sample_event() -> dict:
 class TestCreateEndpoint:
     """Tests for the POST create endpoint."""
 
-    @patch("howler.api.v2.ingest._get_ingestion_queue")
+    @patch("howler.api.v2.ingest.correlation_service.get_ingestion_queue")
     @patch("howler.api.v2.ingest.event_service")
     @patch("howler.api.v2.ingest.hit_service")
     @patch("howler.security.auth_service")
@@ -94,7 +94,7 @@ class TestCreateEndpoint:
             mock_hit_svc.create_hit.assert_called_once()
             mock_queue_fn.return_value.push.assert_called_once_with("hit-001")
 
-    @patch("howler.api.v2.ingest._get_ingestion_queue")
+    @patch("howler.api.v2.ingest.correlation_service.get_ingestion_queue")
     @patch("howler.api.v2.ingest.event_service")
     @patch("howler.api.v2.ingest.hit_service")
     @patch("howler.security.auth_service")
@@ -179,7 +179,7 @@ class TestCreateEndpoint:
 
             assert result.status_code == 400
 
-    @patch("howler.api.v2.ingest._get_ingestion_queue")
+    @patch("howler.api.v2.ingest.correlation_service.get_ingestion_queue")
     @patch("howler.api.v2.ingest.hit_service")
     @patch("howler.security.auth_service")
     def test_create_multiple_hits(self, mock_auth_service, mock_hit_svc, mock_queue_fn, request_context: Flask):
@@ -207,7 +207,7 @@ class TestCreateEndpoint:
             assert "warning1" in body["api_warning"]
             mock_queue_fn.return_value.push.assert_called_once_with("hit-001", "hit-002")
 
-    @patch("howler.api.v2.ingest._get_ingestion_queue")
+    @patch("howler.api.v2.ingest.correlation_service.get_ingestion_queue")
     @patch("howler.api.v2.ingest.hit_service")
     @patch("howler.security.auth_service")
     def test_create_conversion_failure_returns_400(
@@ -233,7 +233,7 @@ class TestCreateEndpoint:
             assert result.status_code == 400
             mock_queue_fn.return_value.push.assert_not_called()
 
-    @patch("howler.api.v2.ingest._get_ingestion_queue")
+    @patch("howler.api.v2.ingest.correlation_service.get_ingestion_queue")
     @patch("howler.api.v2.ingest.hit_service")
     @patch("howler.security.auth_service")
     def test_create_queue_failure_still_returns_201(
@@ -529,7 +529,7 @@ class TestValidateEndpoint:
 class TestIngestionQueueing:
     """Tests that the create endpoint enqueues IDs for the correlation worker."""
 
-    @patch("howler.api.v2.ingest._get_ingestion_queue")
+    @patch("howler.api.v2.ingest.correlation_service.get_ingestion_queue")
     @patch("howler.api.v2.ingest.hit_service")
     @patch("howler.security.auth_service")
     def test_enqueues_hit_ids(self, mock_auth_service, mock_hit_svc, mock_queue_fn, request_context: Flask):
@@ -553,7 +553,7 @@ class TestIngestionQueueing:
 
             mock_queue_fn.return_value.push.assert_called_once_with("hit-a", "hit-b")
 
-    @patch("howler.api.v2.ingest._get_ingestion_queue")
+    @patch("howler.api.v2.ingest.correlation_service.get_ingestion_queue")
     @patch("howler.api.v2.ingest.event_service")
     @patch("howler.security.auth_service")
     def test_enqueues_event_ids(self, mock_auth_service, mock_obs_svc, mock_queue_fn, request_context: Flask):
@@ -576,7 +576,7 @@ class TestIngestionQueueing:
 
             mock_queue_fn.return_value.push.assert_called_once_with("obs-a")
 
-    @patch("howler.api.v2.ingest._get_ingestion_queue")
+    @patch("howler.api.v2.ingest.correlation_service.get_ingestion_queue")
     @patch("howler.api.v2.ingest.hit_service")
     @patch("howler.security.auth_service")
     def test_no_enqueue_when_all_fail(self, mock_auth_service, mock_hit_svc, mock_queue_fn, request_context: Flask):

--- a/api/test/unit/endpoints/test_ingest_endpoint.py
+++ b/api/test/unit/endpoints/test_ingest_endpoint.py
@@ -64,7 +64,7 @@ def _sample_event() -> dict:
 class TestCreateEndpoint:
     """Tests for the POST create endpoint."""
 
-    @patch("howler.api.v2.ingest.correlation_service.get_ingestion_queue")
+    @patch("howler.api.v2.ingest.correlation_service._get_ingestion_queue")
     @patch("howler.api.v2.ingest.event_service")
     @patch("howler.api.v2.ingest.hit_service")
     @patch("howler.security.auth_service")
@@ -94,7 +94,7 @@ class TestCreateEndpoint:
             mock_hit_svc.create_hit.assert_called_once()
             mock_queue_fn.return_value.push.assert_called_once_with("hit-001")
 
-    @patch("howler.api.v2.ingest.correlation_service.get_ingestion_queue")
+    @patch("howler.api.v2.ingest.correlation_service._get_ingestion_queue")
     @patch("howler.api.v2.ingest.event_service")
     @patch("howler.api.v2.ingest.hit_service")
     @patch("howler.security.auth_service")
@@ -179,7 +179,7 @@ class TestCreateEndpoint:
 
             assert result.status_code == 400
 
-    @patch("howler.api.v2.ingest.correlation_service.get_ingestion_queue")
+    @patch("howler.api.v2.ingest.correlation_service._get_ingestion_queue")
     @patch("howler.api.v2.ingest.hit_service")
     @patch("howler.security.auth_service")
     def test_create_multiple_hits(self, mock_auth_service, mock_hit_svc, mock_queue_fn, request_context: Flask):
@@ -207,7 +207,7 @@ class TestCreateEndpoint:
             assert "warning1" in body["api_warning"]
             mock_queue_fn.return_value.push.assert_called_once_with("hit-001", "hit-002")
 
-    @patch("howler.api.v2.ingest.correlation_service.get_ingestion_queue")
+    @patch("howler.api.v2.ingest.correlation_service._get_ingestion_queue")
     @patch("howler.api.v2.ingest.hit_service")
     @patch("howler.security.auth_service")
     def test_create_conversion_failure_returns_400(
@@ -233,7 +233,7 @@ class TestCreateEndpoint:
             assert result.status_code == 400
             mock_queue_fn.return_value.push.assert_not_called()
 
-    @patch("howler.api.v2.ingest.correlation_service.get_ingestion_queue")
+    @patch("howler.api.v2.ingest.correlation_service._get_ingestion_queue")
     @patch("howler.api.v2.ingest.hit_service")
     @patch("howler.security.auth_service")
     def test_create_queue_failure_still_returns_201(
@@ -529,7 +529,7 @@ class TestValidateEndpoint:
 class TestIngestionQueueing:
     """Tests that the create endpoint enqueues IDs for the correlation worker."""
 
-    @patch("howler.api.v2.ingest.correlation_service.get_ingestion_queue")
+    @patch("howler.api.v2.ingest.correlation_service._get_ingestion_queue")
     @patch("howler.api.v2.ingest.hit_service")
     @patch("howler.security.auth_service")
     def test_enqueues_hit_ids(self, mock_auth_service, mock_hit_svc, mock_queue_fn, request_context: Flask):
@@ -553,7 +553,7 @@ class TestIngestionQueueing:
 
             mock_queue_fn.return_value.push.assert_called_once_with("hit-a", "hit-b")
 
-    @patch("howler.api.v2.ingest.correlation_service.get_ingestion_queue")
+    @patch("howler.api.v2.ingest.correlation_service._get_ingestion_queue")
     @patch("howler.api.v2.ingest.event_service")
     @patch("howler.security.auth_service")
     def test_enqueues_event_ids(self, mock_auth_service, mock_obs_svc, mock_queue_fn, request_context: Flask):
@@ -576,7 +576,7 @@ class TestIngestionQueueing:
 
             mock_queue_fn.return_value.push.assert_called_once_with("obs-a")
 
-    @patch("howler.api.v2.ingest.correlation_service.get_ingestion_queue")
+    @patch("howler.api.v2.ingest.correlation_service._get_ingestion_queue")
     @patch("howler.api.v2.ingest.hit_service")
     @patch("howler.security.auth_service")
     def test_no_enqueue_when_all_fail(self, mock_auth_service, mock_hit_svc, mock_queue_fn, request_context: Flask):

--- a/api/test/unit/services/test_correlation_service.py
+++ b/api/test/unit/services/test_correlation_service.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from howler.common.exceptions import HowlerRuntimeError, InvalidDataException, NotFoundException
+from howler.common.exceptions import InvalidDataException, NotFoundException
 from howler.odm.models.case import CaseRule
 from howler.services import correlation_service
 
@@ -227,16 +227,6 @@ class TestEnqueueForCorrelation:
         correlation_service.enqueue_for_correlation(["hit-1", "hit-2"])
 
         queue.push.assert_called_once_with("hit-1", "hit-2")
-
-    @patch("howler.services.correlation_service._get_ingestion_queue")
-    def test_raises_runtime_error_on_queue_failure(self, mock_get_queue):
-        """Queue failures are wrapped in a HowlerRuntimeError for callers."""
-        queue = MagicMock()
-        queue.push.side_effect = Exception("redis unavailable")
-        mock_get_queue.return_value = queue
-
-        with pytest.raises(HowlerRuntimeError):
-            correlation_service.enqueue_for_correlation(["hit-1"])
 
     @patch("howler.services.correlation_service.case_service")
     @patch("howler.services.correlation_service.datastore")

--- a/api/test/unit/services/test_correlation_service.py
+++ b/api/test/unit/services/test_correlation_service.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from howler.common.exceptions import InvalidDataException, NotFoundException
+from howler.common.exceptions import HowlerRuntimeError, InvalidDataException, NotFoundException
 from howler.odm.models.case import CaseRule
 from howler.services import correlation_service
 
@@ -185,14 +185,14 @@ class TestCorrelationWorker:
     """Tests for correlation worker batching behavior."""
 
     @patch("howler.services.correlation_service.process_batch")
-    @patch("howler.services.correlation_service._build_queue")
+    @patch("howler.services.correlation_service.get_ingestion_queue")
     @patch.object(correlation_service, "BATCH_TIMEOUT", 1)
     @patch.object(correlation_service, "BATCH_SIZE", 3)
-    def test_processes_full_batch(self, mock_build_queue, mock_process_batch):
+    def test_processes_full_batch(self, mock_get_queue, mock_process_batch):
         """A full queue batch is delivered to process_batch without waiting for a timeout."""
         queue = MagicMock()
         queue.pop.side_effect = ["hit-1", "hit-2", "hit-3", KeyboardInterrupt]
-        mock_build_queue.return_value = queue
+        mock_get_queue.return_value = queue
 
         with pytest.raises(KeyboardInterrupt):
             correlation_service.run_worker()
@@ -200,19 +200,43 @@ class TestCorrelationWorker:
         mock_process_batch.assert_called_once_with(["hit-1", "hit-2", "hit-3"])
 
     @patch("howler.services.correlation_service.process_batch")
-    @patch("howler.services.correlation_service._build_queue")
+    @patch("howler.services.correlation_service.get_ingestion_queue")
     @patch.object(correlation_service, "BATCH_TIMEOUT", 1)
     @patch.object(correlation_service, "BATCH_SIZE", 3)
-    def test_flushes_partial_batch_after_timeout(self, mock_build_queue, mock_process_batch):
+    def test_flushes_partial_batch_after_timeout(self, mock_get_queue, mock_process_batch):
         """A timeout flushes queued records when the batch is not yet full."""
         queue = MagicMock()
         queue.pop.side_effect = ["hit-1", None, KeyboardInterrupt]
-        mock_build_queue.return_value = queue
+        mock_get_queue.return_value = queue
 
         with pytest.raises(KeyboardInterrupt):
             correlation_service.run_worker()
 
         mock_process_batch.assert_called_once_with(["hit-1"])
+
+
+class TestEnqueueForCorrelation:
+    """Tests for enqueue_for_correlation queue producer behavior."""
+
+    @patch("howler.services.correlation_service.get_ingestion_queue")
+    def test_enqueues_all_ids(self, mock_get_queue):
+        """All provided IDs are pushed to the shared ingestion queue."""
+        queue = MagicMock()
+        mock_get_queue.return_value = queue
+
+        correlation_service.enqueue_for_correlation(["hit-1", "hit-2"])
+
+        queue.push.assert_called_once_with("hit-1", "hit-2")
+
+    @patch("howler.services.correlation_service.get_ingestion_queue")
+    def test_raises_runtime_error_on_queue_failure(self, mock_get_queue):
+        """Queue failures are wrapped in a HowlerRuntimeError for callers."""
+        queue = MagicMock()
+        queue.push.side_effect = Exception("redis unavailable")
+        mock_get_queue.return_value = queue
+
+        with pytest.raises(HowlerRuntimeError):
+            correlation_service.enqueue_for_correlation(["hit-1"])
 
     @patch("howler.services.correlation_service.case_service")
     @patch("howler.services.correlation_service.datastore")

--- a/api/test/unit/services/test_correlation_service.py
+++ b/api/test/unit/services/test_correlation_service.py
@@ -185,7 +185,7 @@ class TestCorrelationWorker:
     """Tests for correlation worker batching behavior."""
 
     @patch("howler.services.correlation_service.process_batch")
-    @patch("howler.services.correlation_service.get_ingestion_queue")
+    @patch("howler.services.correlation_service._get_ingestion_queue")
     @patch.object(correlation_service, "BATCH_TIMEOUT", 1)
     @patch.object(correlation_service, "BATCH_SIZE", 3)
     def test_processes_full_batch(self, mock_get_queue, mock_process_batch):
@@ -200,7 +200,7 @@ class TestCorrelationWorker:
         mock_process_batch.assert_called_once_with(["hit-1", "hit-2", "hit-3"])
 
     @patch("howler.services.correlation_service.process_batch")
-    @patch("howler.services.correlation_service.get_ingestion_queue")
+    @patch("howler.services.correlation_service._get_ingestion_queue")
     @patch.object(correlation_service, "BATCH_TIMEOUT", 1)
     @patch.object(correlation_service, "BATCH_SIZE", 3)
     def test_flushes_partial_batch_after_timeout(self, mock_get_queue, mock_process_batch):
@@ -218,7 +218,7 @@ class TestCorrelationWorker:
 class TestEnqueueForCorrelation:
     """Tests for enqueue_for_correlation queue producer behavior."""
 
-    @patch("howler.services.correlation_service.get_ingestion_queue")
+    @patch("howler.services.correlation_service._get_ingestion_queue")
     def test_enqueues_all_ids(self, mock_get_queue):
         """All provided IDs are pushed to the shared ingestion queue."""
         queue = MagicMock()
@@ -228,7 +228,7 @@ class TestEnqueueForCorrelation:
 
         queue.push.assert_called_once_with("hit-1", "hit-2")
 
-    @patch("howler.services.correlation_service.get_ingestion_queue")
+    @patch("howler.services.correlation_service._get_ingestion_queue")
     def test_raises_runtime_error_on_queue_failure(self, mock_get_queue):
         """Queue failures are wrapped in a HowlerRuntimeError for callers."""
         queue = MagicMock()

--- a/api/test/unit/services/test_ingest_correlation.py
+++ b/api/test/unit/services/test_ingest_correlation.py
@@ -360,7 +360,6 @@ class TestIngestToCorrelationContract:
         rule = _make_rule(query="*:*", destination="related")
         mock_get_rules.return_value = [("case-1", rule)]
 
-        # Simulate IDs exactly as they would be pushed by _get_ingestion_queue().push(...)
         ingested_ids = ["abc123", "def456"]
 
         mock_search_svc.search.return_value = {

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -1,5 +1,9 @@
 # Howler Releases
 
+## Howler API `v4.0.1`
+
+- **Case Correlation for v1 Ingestion** _(bugfix)_: Fixed a gap where records ingested through v1 endpoints were not queued for correlation processing, so case correlation rules did not apply to those records.
+
 ## Howler UI `v2.19.0`
 
 - **View Grid Preferences** _(new feature)_: Added list/grid display preferences to views, including configurable grid columns and widths, persisted local settings, view-composer controls, and safeguards for views whose grid configuration is inactive ([#444](https://github.com/CybercentreCanada/howler/pull/444)).


### PR DESCRIPTION
This PR addresses a gap in case correlation - it doesn't run on v1 ingestion. I've added the hooks necessary to mitigate this issue.

---

This pull request refactors and centralizes the logic for queueing ingested hit IDs for correlation processing in the Howler API. It introduces a new `enqueue_for_correlation` function in `correlation_service`, updates all API endpoints to use this unified method, and adds comprehensive tests for the new behavior. This ensures that all hits ingested through both v1 and v2 endpoints are consistently queued for correlation, improving maintainability and reliability.

**Centralization and Refactoring of Correlation Queueing:**

* Added `enqueue_for_correlation` and `get_ingestion_queue` functions to `correlation_service.py`, consolidating queue management and error handling for correlation processing. The ingestion queue is now managed exclusively through these functions. [[1]](diffhunk://#diff-aca5a0319816d481e5029ea49b6af4d800ed25065106b8be26527715cb5dc72fR40-R73) [[2]](diffhunk://#diff-aca5a0319816d481e5029ea49b6af4d800ed25065106b8be26527715cb5dc72fL182-R222)
* Removed the redundant `_get_ingestion_queue` and `_build_queue` functions from `v2/ingest.py` and updated all ingestion endpoints (`v1/hit.py`, `v1/tool.py`, `v2/ingest.py`) to use `correlation_service.enqueue_for_correlation` for queueing hit IDs. [[1]](diffhunk://#diff-ce8ea93c4c19e2d4f637a74a0c1e3720840b82d13f1c5eeb66a30966c98b6f53L39-L56) [[2]](diffhunk://#diff-ce8ea93c4c19e2d4f637a74a0c1e3720840b82d13f1c5eeb66a30966c98b6f53L124-R105) [[3]](diffhunk://#diff-c67f7d29b7497a7f1e9e3de768fd08a63c684ff518b4ba921228654e66f16111L133-R136) [[4]](diffhunk://#diff-31c99d34b517bb3a96b38f266ef680d00c1c8830375e2489f48416e4e0e1b32bL236-R239)

**Testing Improvements:**

* Added new integration tests to ensure that hits created via v1 and v1 tool endpoints are correctly queued and processed by the correlation worker.
* Updated unit tests to patch `correlation_service.get_ingestion_queue` instead of the removed `_get_ingestion_queue`, ensuring tests reflect the new queueing mechanism. [[1]](diffhunk://#diff-eb3e91f8bf0837907824cb112d2fc796a9d7e68db1b1014a9169a94fbbde3e89L67-R67) [[2]](diffhunk://#diff-eb3e91f8bf0837907824cb112d2fc796a9d7e68db1b1014a9169a94fbbde3e89L97-R97) [[3]](diffhunk://#diff-eb3e91f8bf0837907824cb112d2fc796a9d7e68db1b1014a9169a94fbbde3e89L182-R182) [[4]](diffhunk://#diff-eb3e91f8bf0837907824cb112d2fc796a9d7e68db1b1014a9169a94fbbde3e89L210-R210) [[5]](diffhunk://#diff-eb3e91f8bf0837907824cb112d2fc796a9d7e68db1b1014a9169a94fbbde3e89L236-R236) [[6]](diffhunk://#diff-eb3e91f8bf0837907824cb112d2fc796a9d7e68db1b1014a9169a94fbbde3e89L532-R532) [[7]](diffhunk://#diff-eb3e91f8bf0837907824cb112d2fc796a9d7e68db1b1014a9169a94fbbde3e89L556-R556) [[8]](diffhunk://#diff-eb3e91f8bf0837907824cb112d2fc796a9d7e68db1b1014a9169a94fbbde3e89L579-R579)
* Added unit tests for the new `enqueue_for_correlation` function, including proper error handling and queue interaction.

**Other Changes:**

* Updated the Howler API version to `4.0.1` in `pyproject.toml`.

These changes improve the reliability and consistency of hit correlation processing, simplify the codebase, and enhance test coverage.