### PR TITLE
fix(api): Howler API v4.0.2 fixes

### DIFF
--- a/api/build_scripts/run_tests.py
+++ b/api/build_scripts/run_tests.py
@@ -34,6 +34,7 @@ def main():  # noqa: C901
             "HWL_DATASTORE_INDEX_PREFIX": f"howler-test-{run_id}",
             "HWL_TEST_API_HOST": f"http://localhost:{api_port}",
             "TESTING": "true",
+            "HWL_START_BACKGROUND_SERVICES": "false",
             "HWL_CORRELATION_QUEUE_NAME": f"howler.ingestion_queue.test.{run_id}",
         }
 
@@ -45,7 +46,7 @@ def main():  # noqa: C901
         print("Running howler server (with coverage)")
         background_server = subprocess.Popen(
             prep_command("coverage run -m flask --app howler.app run --no-reload"),
-            env=test_env,
+            env={**test_env, "HWL_START_BACKGROUND_SERVICES": "true"},
         )
 
         time.sleep(5)

--- a/api/howler/actions/add_to_case.py
+++ b/api/howler/actions/add_to_case.py
@@ -13,8 +13,7 @@ OPERATION_ID = "add_to_case"
 def execute(  # noqa: C901
     query: str,
     case_id: Optional[str] = None,
-    path: str = "related",
-    title_template: str = "{{howler.analytic}} ({{howler.id}})",
+    destination: str = "related/{{howler.analytic}} ({{howler.id}})",
     **kwargs,
 ):
     """Add matching alerts to a given case.
@@ -22,10 +21,9 @@ def execute(  # noqa: C901
     Args:
         query (str): The query on which to apply this automation.
         case_id (str): The ID of the case to add the alerts to.
-        path (str): The path within the case at which to place the alerts. Defaults to "related".
-        title_template (str): A Mustache-compatible template string used to generate each item's
-            name. The hit's fields are available as template variables.
-            Defaults to "{{howler.analytic}} ({{howler.id}})".
+        destination (str): A Mustache-compatible template string for the case path at which each
+            alert will be placed, in the form "path/to/parent/name". The hit's fields are
+            available as template variables. Defaults to "related/{{howler.analytic}} ({{howler.id}})".
     """
     if not case_id:
         return [
@@ -67,15 +65,15 @@ def execute(  # noqa: C901
     added = []
 
     for hit in hits:
-        title = chevron.render(title_template, hit.as_primitives())
-        item_path = f"{path.rstrip('/')}/{title}" if path else title
+        rendered_destination = chevron.render(destination, hit.as_primitives())
         try:
-            path, name = item_path.rsplit("/", maxsplit=1)
+            item_path, name = rendered_destination.rsplit("/", maxsplit=1)
         except ValueError:
-            name = item_path
+            item_path = None
+            name = rendered_destination
 
         try:
-            parent = case_service.get_parent_from_path(case, path, create_if_missing=True)
+            parent = case_service.get_parent_from_path(case, item_path, create_if_missing=True)
 
             case_service.append_case_item(
                 case,
@@ -131,8 +129,7 @@ def specification():
             {
                 "args": {
                     "case_id": [],
-                    "path": [],
-                    "title_template": [],
+                    "destination": [],
                 },
                 "options": {},
             }

--- a/api/howler/api/v2/ingest.py
+++ b/api/howler/api/v2/ingest.py
@@ -39,7 +39,7 @@ hit_helper = OdmHelper(Hit)
 @ingest_api.route("/<index>", methods=["POST"])
 @api_login(required_priv=["W"])
 @parse_parameters(refresh=parse_refresh)
-def create(index: str, user: User, **kwargs):
+def create(index: str, user: User, refresh: Literal["true", "false", "wait_for"] | None = None, **kwargs):
     """Create new records in a given index.
 
     Variables:
@@ -75,11 +75,9 @@ def create(index: str, user: User, **kwargs):
     if not isinstance(records, list):
         return bad_request(err="JSON Payload must be a list of records.")
     ignore_extra_values = request.args.get("ignore_extra_values", False, type=lambda v: v.lower() == "true")
-    refresh = cast(Literal["true", "false", "wait_for"] | None, kwargs.get("refresh"))
 
-    ids: list[str] = []
+    odms: list = []
     warnings = []
-    refresh_kwargs: dict[str, Literal["true", "false", "wait_for"] | None] = {"refresh": refresh}
     for i, record in enumerate(records):
         try:
             odm: Hit | Event
@@ -87,18 +85,22 @@ def create(index: str, user: User, **kwargs):
                 odm, _warnings = event_service.convert_event(
                     record, unique=True, ignore_extra_values=ignore_extra_values
                 )
-                event_service.create_event(odm.howler.id, odm, user.uname, skip_exists=True, **refresh_kwargs)
             else:
                 odm, _warnings = hit_service.convert_hit(record, unique=True, ignore_extra_values=ignore_extra_values)
-                hit_service.create_hit(odm.howler.id, odm, user.uname, skip_exists=True, refresh=refresh)
 
-            ids.append(odm.howler.id)
+            odms.append(odm)
             warnings.extend(_warnings)
         except HowlerException as e:
             logger.exception("Ingestion failed.")
             return bad_request(err=f"Ingestion failure on record at index {i}: {e}")
 
+    if index == "event":
+        event_service.create_events(odms, user.uname, overwrite=False, refresh=refresh)
+    else:
+        hit_service.create_hits(odms, user.uname, overwrite=False, refresh=refresh)
+
     # Enqueue newly created hit IDs for the correlation worker.
+    ids = [odm.howler.id for odm in odms]
     if ids:
         correlation_service.enqueue_for_correlation(ids)
 

--- a/api/howler/api/v2/ingest.py
+++ b/api/howler/api/v2/ingest.py
@@ -39,7 +39,7 @@ hit_helper = OdmHelper(Hit)
 @ingest_api.route("/<index>", methods=["POST"])
 @api_login(required_priv=["W"])
 @parse_parameters(refresh=parse_refresh)
-def create(index: str, user: User, refresh: Literal["true", "false", "wait_for"] | None = None, **kwargs):
+def create(index: str, user: User, *, refresh: Literal["true", "false", "wait_for"] | None = None, **kwargs):
     """Create new records in a given index.
 
     Variables:

--- a/api/howler/app.py
+++ b/api/howler/app.py
@@ -75,13 +75,14 @@ def _should_start_background_services() -> bool:
     """Return whether this process should start long-lived background services.
 
     Flask's development reloader imports this module in a parent process and
-    again in its serving child. The functional test server disables reloading,
-    so its single process must start the workers explicitly.
+    again in its serving child. The functional test wrapper sets
+    ``HWL_START_BACKGROUND_SERVICES`` only for its no-reload Flask server,
+    preventing pytest imports from starting competing workers.
     """
     return (
         not DEBUG
         or os.environ.get("WERKZEUG_RUN_MAIN") == "true"
-        or os.environ.get("TESTING", "").lower() == "true"
+        or os.environ.get("HWL_START_BACKGROUND_SERVICES", "").lower() == "true"
         or Path(sys.argv[0]).name.lower().startswith("gunicorn")
     )
 

--- a/api/howler/app.py
+++ b/api/howler/app.py
@@ -71,6 +71,11 @@ from howler.telemetry import setup_telemetry
 logger = get_logger(__file__)
 
 
+def _should_start_background_services() -> bool:
+    """Return whether this process should start long-lived background services."""
+    return not DEBUG or os.environ.get("WERKZEUG_RUN_MAIN") == "true"
+
+
 app = Flask(
     "howler-api",
     static_url_path="/api/static",
@@ -177,14 +182,15 @@ if HWL_USE_WEBSOCKET_API or DEBUG:
     logger.debug("Enabled Websocket API")
     app.register_blueprint(socket_api)
 
-    # Start the Redis pubsub watcher so this pod receives events from all pods
-    import howler.services.comms_service as comms_service
+    if _should_start_background_services():
+        # Start the Redis pubsub watcher so this pod receives events from all pods
+        import howler.services.comms_service as comms_service
 
-    comms_service.start_watcher()
+        comms_service.start_watcher()
 else:
     logger.info("Disabled Websocket API")
 
-if HWL_USE_JOB_SYSTEM or DEBUG:
+if HWL_USE_JOB_SYSTEM and _should_start_background_services():
     setup_jobs()
 
 

--- a/api/howler/app.py
+++ b/api/howler/app.py
@@ -72,10 +72,16 @@ logger = get_logger(__file__)
 
 
 def _should_start_background_services() -> bool:
-    """Return whether this process should start long-lived background services."""
+    """Return whether this process should start long-lived background services.
+
+    Flask's development reloader imports this module in a parent process and
+    again in its serving child. The functional test server disables reloading,
+    so its single process must start the workers explicitly.
+    """
     return (
         not DEBUG
         or os.environ.get("WERKZEUG_RUN_MAIN") == "true"
+        or os.environ.get("TESTING", "").lower() == "true"
         or Path(sys.argv[0]).name.lower().startswith("gunicorn")
     )
 

--- a/api/howler/app.py
+++ b/api/howler/app.py
@@ -73,7 +73,11 @@ logger = get_logger(__file__)
 
 def _should_start_background_services() -> bool:
     """Return whether this process should start long-lived background services."""
-    return not DEBUG or os.environ.get("WERKZEUG_RUN_MAIN") == "true"
+    return (
+        not DEBUG
+        or os.environ.get("WERKZEUG_RUN_MAIN") == "true"
+        or Path(sys.argv[0]).name.lower().startswith("gunicorn")
+    )
 
 
 app = Flask(

--- a/api/howler/config.py
+++ b/api/howler/config.py
@@ -21,7 +21,7 @@ MAX_CLASSIFICATION: str = CLASSIFICATION.UNRESTRICTED
 HWL_UNSECURED_UI = os.environ.get("HWL_UNSECURED_UI", "false").lower() == "true"
 HWL_USE_REST_API = os.environ.get("HWL_USE_REST_API", "true").lower() == "true"
 HWL_USE_WEBSOCKET_API = os.environ.get("HWL_USE_WEBSOCKET_API", "false").lower() == "true"
-HWL_USE_JOB_SYSTEM = os.environ.get("HWL_USE_JOB_SYSTEM", "false").lower() == "true"
+HWL_USE_JOB_SYSTEM = os.environ.get("HWL_USE_JOB_SYSTEM", "false").lower() == "true" or DEBUG
 HWL_ENABLE_COVERAGE = os.environ.get("HWL_ENABLE_COVERAGE", "false").lower() == "true"
 HWL_PLUGIN_DIRECTORY = os.environ.get("HWL_PLUGIN_DIRECTORY", "/etc/howler/plugins")
 CORRELATION_QUEUE_NAME = os.environ.get("HWL_CORRELATION_QUEUE_NAME", "howler.ingestion_queue")

--- a/api/howler/datastore/bulk.py
+++ b/api/howler/datastore/bulk.py
@@ -5,6 +5,7 @@ from typing import List, Optional
 
 from howler import odm
 from howler.config import config
+from howler.datastore.utils import expand_field_patterns, prune_to_paths
 
 _OPERATION_GROUP = tuple[str] | tuple[str, str]
 
@@ -86,7 +87,19 @@ class ElasticBulkPlan(object):
             )
         )
 
-    def add_update_operation(self, doc_id, doc, index=None):
+    def add_update_operation(self, doc_id, doc, index=None, fields: Optional[List[str]] = None):
+        """Queue a partial-merge (ES ``update``) operation.
+
+        Args:
+            fields: When provided, restricts the update body to just these dotted field
+                paths (any valid key from :meth:`ESCollection.fields`/`Model.flat_fields`),
+                dropping everything else so unrelated concurrent edits to the stored
+                document aren't clobbered. Entries may contain ``*`` wildcards, expanded
+                against the model's known field paths (e.g. ``"items.*"`` selects every
+                subfield of the ``items`` list without touching ``title``, ``summary``,
+                etc.). A path with no wildcard is kept wholesale, including any nested
+                subfields, e.g. ``"items"`` alone also keeps every subfield of ``items``.
+        """
         if self.model and isinstance(doc, self.model):
             saved_doc = doc.as_primitives(hidden_fields=True)
         elif self.model:
@@ -96,6 +109,9 @@ class ElasticBulkPlan(object):
                 saved_doc = {"__non_doc_raw__": doc}
             else:
                 saved_doc = deepcopy(doc)
+
+        if fields is not None:
+            saved_doc = prune_to_paths(saved_doc, allowed=expand_field_patterns(self.model, fields))
 
         if index:
             self.operations.append(

--- a/api/howler/datastore/bulk.py
+++ b/api/howler/datastore/bulk.py
@@ -1,3 +1,11 @@
+"""Build newline-delimited JSON payloads for Elasticsearch bulk requests.
+
+``ElasticBulkPlan`` accumulates Elasticsearch bulk operations and renders them
+as NDJSON suitable for the ``_bulk`` endpoint. Documents can be serialized
+through an ODM model, and update operations can be limited to selected fields
+to avoid overwriting unrelated stored data.
+"""
+
 import json
 import warnings
 from copy import deepcopy
@@ -14,6 +22,20 @@ DEFAULT_BATCH_SIZE = config.datastore.request_batch_size
 
 
 class ElasticBulkPlan(object):
+    """Accumulate and render Elasticsearch bulk API operations.
+
+    Unless an operation supplies an explicit ``index``, insert, index, and
+    upsert operations target the first configured index. Delete and update
+    operations target every configured index, which supports collections that
+    span multiple physical indices.
+
+    Args:
+        indexes: Elasticsearch indices available to the plan. The first index
+            is the default target for single-index operations.
+        model: Optional ODM model used to serialize document values before
+            they are added to the request.
+    """
+
     def __init__(self, indexes: List[str], model: Optional[type[odm.Model]] = None):
         self.indexes = indexes
         self.model = model
@@ -21,9 +43,22 @@ class ElasticBulkPlan(object):
 
     @property
     def empty(self):
+        """Whether the plan has no queued operations.
+
+        Returns:
+            ``True`` when no bulk operation has been added; otherwise,
+            ``False``.
+        """
         return len(self.operations) == 0
 
     def add_delete_operation(self, doc_id, index=None):
+        """Queue a document delete operation.
+
+        Args:
+            doc_id: Identifier of the document to delete.
+            index: Explicit index to target. When omitted, queues one delete
+                operation for each configured index.
+        """
         if index:
             self.operations.append((json.dumps({"delete": {"_index": index, "_id": doc_id}}),))
         else:
@@ -31,6 +66,18 @@ class ElasticBulkPlan(object):
                 self.operations.append((json.dumps({"delete": {"_index": cur_index, "_id": doc_id}}),))
 
     def add_insert_operation(self, doc_id: str, doc, index=None):
+        """Queue a create-only document insert operation.
+
+        The Elasticsearch ``create`` action fails if a document with ``doc_id``
+        already exists. The document's ``id`` field is set to ``doc_id`` in the
+        serialized request body.
+
+        Args:
+            doc_id: Identifier to assign to the new document.
+            doc: Document data or an instance of the configured ODM model.
+            index: Explicit index to target. When omitted, uses the first
+                configured index.
+        """
         if self.model and isinstance(doc, self.model):
             saved_doc = doc.as_primitives(hidden_fields=True)
         elif self.model:
@@ -50,6 +97,18 @@ class ElasticBulkPlan(object):
         )
 
     def add_index_operation(self, doc_id, doc, index=None):
+        """Queue a document index operation.
+
+        The Elasticsearch ``index`` action creates the document or replaces an
+        existing document with the same identifier. The serialized request body
+        always includes ``id`` set to ``doc_id``.
+
+        Args:
+            doc_id: Identifier of the document to create or replace.
+            doc: Document data or an instance of the configured ODM model.
+            index: Explicit index to target. When omitted, uses the first
+                configured index.
+        """
         if self.model and isinstance(doc, self.model):
             saved_doc = doc.as_primitives(hidden_fields=True)
         elif self.model:
@@ -69,6 +128,17 @@ class ElasticBulkPlan(object):
         )
 
     def add_upsert_operation(self, doc_id, doc, index=None):
+        """Queue an update operation that creates the document when absent.
+
+        The operation uses Elasticsearch's ``doc_as_upsert`` option. Its
+        serialized document includes ``id`` set to ``doc_id``.
+
+        Args:
+            doc_id: Identifier of the document to update or create.
+            doc: Document data or an instance of the configured ODM model.
+            index: Explicit index to target. When omitted, uses the first
+                configured index.
+        """
         if self.model and isinstance(doc, self.model):
             saved_doc = doc.as_primitives(hidden_fields=True)
         elif self.model:
@@ -88,9 +158,14 @@ class ElasticBulkPlan(object):
         )
 
     def add_update_operation(self, doc_id, doc, index=None, fields: Optional[List[str]] = None):
-        """Queue a partial-merge (ES ``update``) operation.
+        """Queue a partial-merge Elasticsearch ``update`` operation.
 
         Args:
+            doc_id: Identifier of the document to update.
+            doc: Document data or an instance of the configured ODM model.
+            index: Explicit index to target. When omitted, queues one update
+                operation for each configured index.
+
             fields: When provided, restricts the update body to just these dotted field
                 paths (any valid key from :meth:`ESCollection.fields`/`Model.flat_fields`),
                 dropping everything else so unrelated concurrent edits to the stored
@@ -130,18 +205,39 @@ class ElasticBulkPlan(object):
                 )
 
     def get_plan_data(self):
-        """Construct the bulk request from the current operations"""
+        """Render all queued operations as an Elasticsearch bulk request.
+
+        Returns:
+            Newline-delimited JSON with a final trailing newline, ready to send
+            to Elasticsearch's ``_bulk`` endpoint.
+        """
         return self._get_plan_for_operations()
 
     def get_plan_batches(self, batch_size: int | None = DEFAULT_BATCH_SIZE):
-        """Yield plan data in batches"""
+        """Yield queued operations as separate Elasticsearch bulk payloads.
+
+        Args:
+            batch_size: Maximum number of queued operations in each payload.
+                Pass ``None`` to produce one payload containing all operations.
+
+        Yields:
+            Newline-delimited JSON payloads, each with a trailing newline.
+        """
         if batch_size is None:
             batch_size = len(self.operations)
         for ptr in range(0, len(self.operations), batch_size):
             yield self._get_plan_for_operations(self.operations[ptr : ptr + batch_size])
 
     def _flatten_operations(self, batch: List[_OPERATION_GROUP] | None = None) -> List[str]:
-        """Flatten the (operation, data) tuples for a batch or the full list of operations if no batch provided"""
+        """Flatten queued action/body groups into their NDJSON lines.
+
+        Args:
+            batch: Operation groups to flatten. Uses every queued operation
+                when omitted or empty.
+
+        Returns:
+            JSON action and document lines in bulk API order.
+        """
         if not batch:
             batch = self.operations
 
@@ -152,7 +248,19 @@ class ElasticBulkPlan(object):
         return flattened
 
     def _get_plan_for_operations(self, batch: List[_OPERATION_GROUP] | None = None) -> str:
-        """Get the bulk plan string for a batch or the full list of operations if no batch provided"""
+        """Render operation groups as a newline-delimited JSON payload.
+
+        Args:
+            batch: Operation groups to render. Uses every queued operation when
+                omitted or empty.
+
+        Returns:
+            The rendered payload with a final trailing newline.
+
+        Warns:
+            UserWarning: If the encoded payload exceeds the configured maximum
+                Elasticsearch request size.
+        """
         plan = "\n".join(self._flatten_operations(batch)) + "\n"
 
         if ELASTIC_MAX_REQUEST_SIZE and len(plan.encode("utf-8")) > ELASTIC_MAX_REQUEST_SIZE:

--- a/api/howler/datastore/bulk.py
+++ b/api/howler/datastore/bulk.py
@@ -100,8 +100,8 @@ class ElasticBulkPlan(object):
         """Queue a document index operation.
 
         The Elasticsearch ``index`` action creates the document or replaces an
-        existing document with the same identifier. The serialized request body
-        always includes ``id`` set to ``doc_id``.
+        existing document with the same identifier. The document's id field is
+        set to doc_id in the serialized request body.
 
         Args:
             doc_id: Identifier of the document to create or replace.

--- a/api/howler/datastore/collection.py
+++ b/api/howler/datastore/collection.py
@@ -566,7 +566,14 @@ class ESCollection(Generic[ModelType]):
         for operation_batch in operations.get_plan_batches():
             response = self.with_retries(self.datastore.client.bulk, operations=operation_batch, refresh=refresh)
             responses.append(response)
-        return not any(response["errors"] for response in responses)
+
+        has_errors = False
+        for response in responses:
+            if response["errors"]:
+                has_errors = True
+                logger.error("Errors on bulk plan: %s", response["errors"])
+
+        return not has_errors
 
     def get_bulk_plan(self):
         """

--- a/api/howler/datastore/collection.py
+++ b/api/howler/datastore/collection.py
@@ -40,6 +40,7 @@ from howler.datastore.support.schemas import (
     default_mapping,
 )
 from howler.datastore.types import AggSearchResult, SearchResult
+from howler.datastore.utils import expand_field_patterns
 from howler.odm.base import (
     BANNED_FIELDS,
     IP,
@@ -1628,23 +1629,8 @@ class ESCollection(Generic[ModelType]):
         if not self.model_class or "*" not in fl:
             return fl
 
-        all_fields = list(self.model_class.flat_fields().keys())
-        expanded: list[str] = []
-        for pattern in fl.split(","):
-            pattern = pattern.strip()
-            if not pattern:
-                # Skip empty entries (e.g. from trailing commas).
-                continue
-            if "*" not in pattern or pattern == "*":
-                # Exact names and the bare '*' (meaning "all fields") are kept as-is.
-                expanded.append(pattern)
-            else:
-                # Convert the glob-style wildcard to a full regex pattern.
-                # Replace '*' with '.*' and escape all other regex special characters.
-                regex = re.compile("^" + re.escape(pattern).replace(r"\*", ".*") + "$")
-                matched = [f for f in all_fields if regex.match(f)]
-                expanded.extend(matched if matched else [pattern])
-        return ",".join(expanded)
+        patterns = [p.strip() for p in fl.split(",") if p.strip()]
+        return ",".join(expand_field_patterns(self.model_class, patterns, preserve_all=True))
 
     def _format_output(self, result, fields=None, as_obj=True):
         # Getting search document data

--- a/api/howler/datastore/collection.py
+++ b/api/howler/datastore/collection.py
@@ -1630,7 +1630,7 @@ class ESCollection(Generic[ModelType]):
             return fl
 
         patterns = [p.strip() for p in fl.split(",") if p.strip()]
-        return ",".join(expand_field_patterns(self.model_class, patterns, preserve_all=True))
+        return ",".join(sorted(expand_field_patterns(self.model_class, patterns, preserve_all=True)))
 
     def _format_output(self, result, fields=None, as_obj=True):
         # Getting search document data

--- a/api/howler/datastore/utils.py
+++ b/api/howler/datastore/utils.py
@@ -1,0 +1,59 @@
+"""Shared helpers for building field-scoped Elasticsearch operations from ODM models."""
+
+import re
+from typing import Iterable, Optional
+
+from howler import odm
+
+
+def expand_field_patterns(
+    model: Optional[type[odm.Model]], patterns: Iterable[str], preserve_all: bool = False
+) -> set[str]:
+    """Expand `*`-wildcard field patterns against a model's known dotted field paths.
+
+    Entries without a `*` are kept as-is (even if the model doesn't recognize them, so
+    synthetic keys like `__non_doc_raw__` still work). Without a model, patterns can't be
+    expanded and are kept literally.
+    """
+    if model is None:
+        return set(patterns)
+
+    known_paths = list(model.flat_fields().keys())
+    expanded: set[str] = set()
+    for pattern in patterns:
+        if "*" not in pattern:
+            expanded.add(pattern)
+            continue
+
+        if pattern == "*" and preserve_all:
+            expanded.add(pattern)
+            continue
+
+        regex = re.compile("^" + re.escape(pattern).replace(r"\*", ".*") + "$")
+        matches = [path for path in known_paths if regex.match(path)]
+        expanded.update(matches or [pattern])
+    return expanded
+
+
+def prune_to_paths(value, allowed: set[str], prefix: str = ""):
+    """Recursively keep only the parts of `value` selected by dotted paths in `allowed`.
+
+    A key is kept wholesale (subtree included as-is) if its own path is in `allowed`;
+    otherwise it's kept and recursed into if some allowed path starts with it, so
+    e.g. `allowed={"items.type"}` prunes each entry of a list field named `items` down
+    to just its `type` subfield.
+    """
+    if isinstance(value, dict):
+        result = {}
+        for key, sub_value in value.items():
+            cur_path = f"{prefix}.{key}" if prefix else key
+            if cur_path in allowed:
+                result[key] = sub_value
+            elif any(path.startswith(f"{cur_path}.") for path in allowed):
+                result[key] = prune_to_paths(sub_value, allowed, cur_path)
+        return result
+
+    if isinstance(value, list):
+        return [prune_to_paths(entry, allowed, prefix) for entry in value]
+
+    return value

--- a/api/howler/datastore/utils.py
+++ b/api/howler/datastore/utils.py
@@ -31,7 +31,7 @@ def expand_field_patterns(
 
         regex = re.compile("^" + re.escape(pattern).replace(r"\*", ".*") + "$")
         matches = [path for path in known_paths if regex.match(path)]
-        expanded.update(matches or [pattern])
+        expanded.update(matches)
     return expanded
 
 

--- a/api/howler/remote/datatypes/__init__.py
+++ b/api/howler/remote/datatypes/__init__.py
@@ -139,7 +139,7 @@ def get_client(
     host: str | redis.Redis | redis.StrictRedis | redis.RedisCluster | None,
     port: int | None,
     private: bool = False,
-):
+) -> redis.Redis | redis.StrictRedis | redis.RedisCluster:
     """
     Get Redis instance.
 

--- a/api/howler/remote/datatypes/queues/named.py
+++ b/api/howler/remote/datatypes/queues/named.py
@@ -1,6 +1,8 @@
 import json
 import time
-from typing import Any, Generic, Optional, TypeVar
+from typing import Generic, Optional, TypeVar
+
+import redis
 
 from howler.common.exceptions import HowlerTypeError
 from howler.remote.datatypes import get_client, retry_call
@@ -10,7 +12,7 @@ T = TypeVar("T")
 
 class NamedQueue(Generic[T]):
     def __init__(self, name: str, host=None, port=None, private: bool = False, ttl: int = 0):
-        self.c: Any = get_client(host, port, private)
+        self.c: redis.Redis | redis.StrictRedis | redis.RedisCluster = get_client(host, port, private)
         self.name: str = name
         self.ttl: int = ttl
         self.last_expire_time: float = 0
@@ -66,8 +68,7 @@ class NamedQueue(Generic[T]):
             return json.loads(response)
 
     def push(self, *messages: T):
-        for message in messages:
-            retry_call(self.c.rpush, self.name, json.dumps(message))
+        retry_call(self.c.rpush, self.name, *[json.dumps(message) for message in messages])
         self._conditional_expire()
 
     def unpop(self, *messages: T):

--- a/api/howler/services/case_service.py
+++ b/api/howler/services/case_service.py
@@ -9,7 +9,13 @@ from typing import Any, Literal, overload
 
 from prometheus_client import Counter
 
-from howler.common.exceptions import HowlerTypeError, HowlerValueError, InvalidDataException, NotFoundException
+from howler.common.exceptions import (
+    HowlerTypeError,
+    HowlerValueError,
+    InvalidDataException,
+    NotFoundException,
+    ResourceExists,
+)
 from howler.common.loader import APP_NAME, datastore
 from howler.common.logging import get_logger
 from howler.config import CLASSIFICATION
@@ -49,7 +55,7 @@ def create_case(
     items = case_data.pop("items", [])
 
     case = Case(case_data)
-    case.log = [CaseLog({"timestamp": "NOW", "explanation": "Case created", "user": user or "system"})]
+    case.log = [CaseLog({"timestamp": "NOW", "explanation": "Case created", "user": user.uname if user else "system"})]
     case.save(refresh="wait_for")
     CREATED_CASES.inc()
 
@@ -476,16 +482,37 @@ def append_case_item(  # noqa: C901
     if item.parent is not None:
         _ensure_parent_exists(case, item.parent)
 
-    check_conflicts(case, item)
+    conflict = check_conflicts(case, item)
 
     match item.type:
         case CaseItemTypes.HIT:
+            if conflict:
+                item.name = f"{item.name} ({item.value})" if item.name else item.value
+
+                if check_conflicts(case, item):
+                    raise ResourceExists("An item with the same name already exists in this location.")
+
             return append_hit(case, item, refresh)
         case CaseItemTypes.EVENT:
+            if conflict:
+                item.name = f"{item.name} ({item.value})" if item.name else item.value
+
+                if check_conflicts(case, item):
+                    raise ResourceExists("An item with the same name already exists in this location.")
+
             return append_event(case, item, refresh)
         case CaseItemTypes.CASE:
+            if conflict:
+                item.name = f"{item.name} ({item.value})" if item.name else item.value
+
+                if check_conflicts(case, item):
+                    raise ResourceExists("An item with the same name already exists in this location.")
+
             return append_case(case, item, refresh)
         case CaseItemTypes.REFERENCE | CaseItemTypes.MARKDOWN | CaseItemTypes.FOLDER:
+            if conflict:
+                raise ResourceExists("An item with the same name already exists in this location.")
+
             case.items.append(item)
 
             if not case.save(refresh):  # pragma: no cover
@@ -498,7 +525,7 @@ def append_case_item(  # noqa: C901
             raise InvalidDataException(f"Unsupported item type: {item.type}")
 
 
-def check_conflicts(case: Case, item: CaseItem) -> None:
+def check_conflicts(case: Case, item: CaseItem) -> bool:
     """Validate that two items are not created with the same name and parent.
 
     Args:
@@ -510,15 +537,12 @@ def check_conflicts(case: Case, item: CaseItem) -> None:
     """
     # Unnamed items (name=None) are identified by their value, not their name; skip name-based
     # conflict detection for them so that multiple unnamed hits can coexist in the same parent.
+    name = item.name
     if item.name is None:
-        return
+        name = item.value
 
     # Check for duplicate folder under same parent
-    if any(ci.name == item.name and ci.parent == item.parent for ci in case.items):
-        raise InvalidDataException(
-            f"An item with name '{item.name}' already exists in "
-            + (f"parent {item.parent}." if item.parent else "root.")
-        )
+    return any(ci.name == name and ci.parent == item.parent for ci in case.items)
 
 
 def _ensure_parent_exists(case: Case, parent_id: str) -> None:

--- a/api/howler/services/case_service.py
+++ b/api/howler/services/case_service.py
@@ -489,24 +489,15 @@ def append_case_item(  # noqa: C901
             if conflict:
                 item.name = f"{item.name} ({item.value})" if item.name else item.value
 
-                if check_conflicts(case, item):
-                    raise ResourceExists("An item with the same name already exists in this location.")
-
             return append_hit(case, item, refresh)
         case CaseItemTypes.EVENT:
             if conflict:
                 item.name = f"{item.name} ({item.value})" if item.name else item.value
 
-                if check_conflicts(case, item):
-                    raise ResourceExists("An item with the same name already exists in this location.")
-
             return append_event(case, item, refresh)
         case CaseItemTypes.CASE:
             if conflict:
                 item.name = f"{item.name} ({item.value})" if item.name else item.value
-
-                if check_conflicts(case, item):
-                    raise ResourceExists("An item with the same name already exists in this location.")
 
             return append_case(case, item, refresh)
         case CaseItemTypes.REFERENCE | CaseItemTypes.MARKDOWN | CaseItemTypes.FOLDER:

--- a/api/howler/services/case_service.py
+++ b/api/howler/services/case_service.py
@@ -476,7 +476,7 @@ def append_case_item(  # noqa: C901
     if item.parent is not None:
         _ensure_parent_exists(case, item.parent)
 
-    _check_conflicts(case, item)
+    check_conflicts(case, item)
 
     match item.type:
         case CaseItemTypes.HIT:
@@ -498,7 +498,7 @@ def append_case_item(  # noqa: C901
             raise InvalidDataException(f"Unsupported item type: {item.type}")
 
 
-def _check_conflicts(case: Case, item: CaseItem) -> None:
+def check_conflicts(case: Case, item: CaseItem) -> None:
     """Validate that two items are not created with the same name and parent.
 
     Args:

--- a/api/howler/services/case_service.py
+++ b/api/howler/services/case_service.py
@@ -535,6 +535,11 @@ def check_conflicts(case: Case, item: CaseItem) -> bool:
     Raises:
         InvalidDataException: If there is a conflict between the existing case items and the new item
     """
+    if item.type in {CaseItemTypes.HIT, CaseItemTypes.EVENT} and any(
+        existing.type == item.type and existing.value == item.value for existing in case.items
+    ):
+        raise InvalidDataException(f"Item {item.value} already exists in case {case.case_id}")
+
     # Unnamed items (name=None) are identified by their value, not their name; skip name-based
     # conflict detection for them so that multiple unnamed hits can coexist in the same parent.
     name = item.name

--- a/api/howler/services/case_service.py
+++ b/api/howler/services/case_service.py
@@ -331,6 +331,7 @@ def get_parent_from_path(
     path: str | None,
     create_if_missing: bool = False,
     refresh: Literal["true", "false", "wait_for"] | None = None,
+    persist: bool = True,
 ) -> CaseItem | None:
     """Given a path, return the lowest parent of the path in the case.
 
@@ -340,6 +341,9 @@ def get_parent_from_path(
         case: The case to search for.
         path: The path to return the lowest parent for.
         create_if_missing: Whether to create the path if it's missing or return None.
+        persist: Whether to save the case immediately when a folder is created. Callers that
+            are accumulating multiple in-memory changes before a single bulk save should pass
+            False.
 
     Raises:
         InvalidDataException: If the path is invalid.
@@ -380,9 +384,11 @@ def get_parent_from_path(
             folder_item = CaseItem({"type": CaseItemTypes.FOLDER, "name": part, "parent": current_parent, "value": ""})
             case.items.append(folder_item)
             current_parent = folder_item.id
-            case.save(refresh)
         else:
             current_parent = folder.id
+
+    if persist:
+        case.save(refresh)
 
     # Find the final parent folder
     if current_parent is None:  # pragma: no cover
@@ -676,13 +682,14 @@ def remove_case_items(  # noqa: C901
 
     case.items = [item for item in case.items if item.id not in ids_to_remove]
 
-    if not case.save(refresh=refresh):  # pragma: no cover
-        raise DataStoreException("Failed to save case after item removal")
-
     for backing_obj in backing_objs:
         remove_backreference(backing_obj, case.case_id)
+        backing_obj.save()
 
-    _sync_case_metadata(case)
+    recompute_case_metadata(case)
+
+    if not case.save(refresh=refresh):  # pragma: no cover
+        raise DataStoreException("Failed to save case after item removal")
 
     comms_service.emit("cases", {"case": case.as_primitives()})
 
@@ -726,16 +733,14 @@ def append_hit(case: Case, item: CaseItem, refresh: Literal["true", "false", "wa
 
     case.items.append(item)
 
+    add_backreference(hit, case.case_id)
+    hit.save()
+
+    recompute_case_metadata(case)
     if not case.save(refresh=refresh):  # pragma: no cover
         raise DataStoreException(f"Failed to save {case.case_id} with new item {item.value}")
 
-    _add_backreference(hit, case.case_id)
-
-    _sync_case_metadata(case)
-
-    updated_case = ds.case.get(case.case_id)
-    if updated_case:
-        comms_service.emit("cases", {"case": updated_case.as_primitives()})
+    comms_service.emit("cases", {"case": case.as_primitives()})
 
     return case
 
@@ -767,15 +772,16 @@ def append_event(case: Case, item: CaseItem, refresh: Literal["true", "false", "
 
     case.items.append(item)
 
+    add_backreference(event, case.case_id)
+    event.save()
+
+    recompute_case_metadata(case)
     if not case.save(refresh=refresh):  # pragma: no cover
         raise DataStoreException(f"Failed to save {case.case_id} with new item {item.value}")
 
-    _add_backreference(event, case.case_id)
-    updated_case = _sync_case_metadata(case)
-    if updated_case:
-        comms_service.emit("cases", {"case": updated_case.as_primitives()})
+    comms_service.emit("cases", {"case": case.as_primitives()})
 
-    return updated_case or case
+    return case
 
 
 def append_case(case: Case, item: CaseItem, refresh: Literal["true", "false", "wait_for"] | None = None) -> Case:
@@ -831,19 +837,15 @@ def _collect_indicators_from_related(related: Related | None) -> set[str]:
     return indicators
 
 
-def _sync_case_metadata(  # noqa: C901
-    case: Case | None,
-    refresh: Literal["true", "false", "wait_for"] | None = None,
-) -> Case | None:  # noqa: C901
-    """Re-compute and persist threat/target/indicator lists from all case items.
+def recompute_case_metadata(case: Case) -> None:  # noqa: C901
+    """Re-compute (in memory only) threat/target/indicator lists from all case items.
 
     Iterates over hit and event items in the case and re-derives the
     ``targets``, ``threats``, and ``indicators`` lists from the backing
-    objects' ECS ``related.*`` fields and, for hits, the outline fields.
+    objects' ECS ``related.*`` fields and, for hits, the outline fields. Does
+    not persist the case; callers are responsible for saving it.
     """
     ds = datastore()
-    if case is None:
-        return None
 
     targets: set[str] = set()
     threats: set[str] = set()
@@ -876,25 +878,21 @@ def _sync_case_metadata(  # noqa: C901
     case.targets = sorted(targets)
     case.threats = sorted(threats)
     case.indicators = sorted(indicators)
-    case.save(refresh=refresh)
-
-    return case
 
 
-def _add_backreference(
-    backing_obj: Hit | Event | None,
-    case_id: str,
-    refresh: Literal["true", "false", "wait_for"] | None = None,
-):
-    """Add a back-reference from a hit or event to a case.
+def add_backreference(backing_obj: Hit | Event | None, case_id: str) -> bool:
+    """Add a back-reference from a hit or event to a case, in memory only.
 
-    Records the case ID in the backing object's ``howler.related_ids`` set so
-    that the relationship can be traversed from the hit/event side. If the
-    back-reference already exists, the call is a no-op.
+    Records the case ID in the backing object's ``howler.related`` list so
+    that the relationship can be traversed from the hit/event side. Does not
+    persist the change; callers are responsible for saving the object.
 
     Args:
         backing_obj: The Hit or Event object to add the back-reference to.
         case_id: Unique identifier of the case to reference.
+
+    Returns:
+        True if a new back-reference was added, False if it already existed.
 
     Raises:
         InvalidDataException: If backing_obj is None or case_id is empty/falsy.
@@ -906,22 +904,21 @@ def _add_backreference(
         raise InvalidDataException("Missing back reference case_id")
 
     if any(case_id == related_id for related_id in backing_obj.howler.related):
-        return
+        return False
 
     backing_obj.howler.related.append(case_id)
-    backing_obj.save(refresh=refresh)
+    return True
 
 
 def remove_backreference(
     backing_obj: Hit | Event | None,
     case_id: str,
-    refresh: Literal["true", "false", "wait_for"] | None = None,
 ):
-    """Remove a back-reference from a hit or event to a case.
+    """Remove a back-reference from a hit or event to a case, in memory only.
 
-    Removes the case ID from the backing object's ``howler.related`` list
-    and persists the change. If the case ID is not present in the list,
-    the call is a no-op.
+    Removes the case ID from the backing object's ``howler.related`` list.
+    Does not persist the change; callers are responsible for saving the
+    object. If the case ID is not present in the list, the call is a no-op.
 
     Args:
         backing_obj: The Hit or Event object to remove the back-reference from.
@@ -938,7 +935,6 @@ def remove_backreference(
 
     if case_id in backing_obj.howler.related:
         backing_obj.howler.related.remove(case_id)
-        backing_obj.save(refresh=refresh)
 
 
 def rename_case_item(

--- a/api/howler/services/correlation_service.py
+++ b/api/howler/services/correlation_service.py
@@ -9,7 +9,7 @@ The public API consists of three functions:
 """
 
 from datetime import datetime, timedelta, timezone
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 import chevron
 from opentelemetry import trace
@@ -27,7 +27,7 @@ from howler.services import case_service, comms_service, search_service
 from howler.utils.str_utils import sanitize_lucene_query
 
 if TYPE_CHECKING:
-    from howler.datastore.collection import ESCollection
+    pass
 
 
 logger = get_logger(__file__)
@@ -64,7 +64,9 @@ def _get_ingestion_queue() -> NamedQueue[str]:
 
 
 def _resolve_backing_object(
-    item_type: str, record_id: str, backing_cache: dict[tuple[str, str], Hit | Event | None]
+    item_type: Literal["hit", "event"],
+    record_id: str,
+    backing_cache: dict[tuple[Literal["hit", "event"], str], Hit | Event | None],
 ) -> Hit | Event:
     """Fetch (and cache) the hit/event backing a correlation match, across the whole batch.
 
@@ -93,8 +95,8 @@ def _add_record_to_case(
     case_id: str,
     record: dict,
     rule: CaseRule,
-    backing_cache: dict[tuple[str, str], Hit | Event | None],
-) -> tuple[str, str] | None:
+    backing_cache: dict[tuple[Literal["hit", "event"], str], Hit | Event | None],
+) -> tuple[Literal["hit", "event"], str] | None:
     """Append a single matching record to a case, in memory only (no datastore writes).
 
     Mirrors the validation/dispatch behaviour of ``case_service.append_case_item`` for hit
@@ -255,8 +257,8 @@ def process_batch(record_ids: list[str]) -> int:  # noqa: C901
     # memory; they're only written to the datastore after every rule has been evaluated.
     case_cache: dict[str, Case | None] = {}
     case_original_item_counts: dict[str, int] = {}
-    backing_cache: dict[tuple[str, str], Hit | Event | None] = {}
-    dirty_backing_keys: set[tuple[str, str]] = set()
+    backing_cache: dict[tuple[Literal["hit", "event"], str], Hit | Event | None] = {}
+    dirty_backing_keys: set[tuple[Literal["hit", "event"], str]] = set()
 
     for case_id, rule in rules:
         indexes: list[str] = list(rule.indexes) if rule.indexes else [RuleIndexTypes.HIT]
@@ -289,14 +291,7 @@ def process_batch(record_ids: list[str]) -> int:  # noqa: C901
                 dirty_backing_keys.add(result)
                 added += 1
 
-    backing_collections: dict[str, "ESCollection"] = {
-        "hit": ds.hit,
-        "case": ds.event,
-    }
-    backing_bulk_plans = {
-        item_type: backing_collections[item_type].get_bulk_plan()
-        for item_type in {key[0] for key in dirty_backing_keys}
-    }
+    backing_bulk_plans = {item_type: ds[item_type].get_bulk_plan() for item_type, _ in dirty_backing_keys}
 
     for item_type, record_id in dirty_backing_keys:
         backing_obj = backing_cache[(item_type, record_id)]
@@ -304,7 +299,7 @@ def process_batch(record_ids: list[str]) -> int:  # noqa: C901
             backing_bulk_plans[item_type].add_update_operation(record_id, backing_obj, fields=["howler.related"])
 
     for item_type, bulk_plan in backing_bulk_plans.items():
-        if not backing_collections[item_type].bulk(bulk_plan):
+        if not ds[item_type].bulk(bulk_plan):
             raise HowlerRuntimeError("Bulk backing record update reported errors while flushing correlation batch")
 
     modified_cases = [

--- a/api/howler/services/correlation_service.py
+++ b/api/howler/services/correlation_service.py
@@ -9,7 +9,7 @@ The public API consists of three functions:
 """
 
 from datetime import datetime, timedelta, timezone
-from typing import Any
+from typing import TYPE_CHECKING
 
 import chevron
 from opentelemetry import trace
@@ -25,6 +25,10 @@ from howler.odm.models.hit import Hit
 from howler.remote.datatypes.queues.named import NamedQueue
 from howler.services import case_service, comms_service, search_service
 from howler.utils.str_utils import sanitize_lucene_query
+
+if TYPE_CHECKING:
+    from howler.datastore.collection import ESCollection
+
 
 logger = get_logger(__file__)
 tracer = trace.get_tracer(__name__)
@@ -285,11 +289,11 @@ def process_batch(record_ids: list[str]) -> int:  # noqa: C901
                 dirty_backing_keys.add(result)
                 added += 1
 
-    backing_collections: dict[str, Any] = {
-        str(RuleIndexTypes.HIT): ds.hit,
-        str(RuleIndexTypes.EVENT): ds.event,
+    backing_collections: dict[str, "ESCollection"] = {
+        "hit": ds.hit,
+        "case": ds.event,
     }
-    backing_bulk_plans: dict[str, Any] = {
+    backing_bulk_plans = {
         item_type: backing_collections[item_type].get_bulk_plan()
         for item_type in {key[0] for key in dirty_backing_keys}
     }

--- a/api/howler/services/correlation_service.py
+++ b/api/howler/services/correlation_service.py
@@ -13,14 +13,16 @@ from datetime import datetime, timedelta, timezone
 import chevron
 from opentelemetry import trace
 
-from howler.common.exceptions import InvalidDataException, NotFoundException
+from howler.common.exceptions import HowlerRuntimeError, InvalidDataException, NotFoundException
 from howler.common.loader import datastore
 from howler.common.logging import get_logger
 from howler.config import CORRELATION_QUEUE_NAME
-from howler.odm.models.case import CaseRule, RuleIndexTypes
+from howler.odm.models.case import Case, CaseItem, CaseRule, RuleIndexTypes
 from howler.odm.models.config import config
+from howler.odm.models.event import Event
+from howler.odm.models.hit import Hit
 from howler.remote.datatypes.queues.named import NamedQueue
-from howler.services import case_service, search_service
+from howler.services import case_service, comms_service, search_service
 from howler.utils.str_utils import sanitize_lucene_query
 
 logger = get_logger(__file__)
@@ -54,6 +56,83 @@ def _get_ingestion_queue() -> NamedQueue[str]:
         )
 
     return _ingestion_queue
+
+
+def _resolve_backing_object(
+    item_type: str, record_id: str, backing_cache: dict[tuple[str, str], Hit | Event | None]
+) -> Hit | Event:
+    """Fetch (and cache) the hit/event backing a correlation match, across the whole batch.
+
+    Raises:
+        NotFoundException: If the backing hit/event does not exist.
+    """
+    key = (item_type, record_id)
+    if key not in backing_cache:
+        ds = datastore()
+        if item_type == RuleIndexTypes.EVENT:
+            backing_cache[key] = ds.event.get(key=record_id)
+        else:
+            backing_cache[key] = ds.hit.get(record_id)
+
+    backing_obj = backing_cache[key]
+    if backing_obj is None:
+        raise NotFoundException(f"{item_type.capitalize()} {record_id} not found, cannot be added to case")
+
+    return backing_obj
+
+
+def _add_record_to_case(
+    case: Case,
+    case_id: str,
+    record: dict,
+    rule: CaseRule,
+    backing_cache: dict[tuple[str, str], Hit | Event | None],
+    dirty_backing_keys: set[tuple[str, str]],
+) -> bool:
+    """Append a single matching record to a case, in memory only (no datastore writes).
+
+    Mirrors the validation/dispatch behaviour of ``case_service.append_case_item`` for hit
+    and event items, but mutates ``case.items`` directly instead of saving the case (and its
+    backing hit/event) on every call.
+
+    Returns:
+        True if the record was added to the case.
+    """
+    record_id = record["howler"]["id"]
+    item_type = record.get("__index", "hit")
+
+    rendered_path = chevron.render(rule.destination, record)
+    try:
+        path, name = rendered_path.rsplit("/", maxsplit=1)
+    except ValueError:
+        path = None
+        name = rendered_path
+
+    try:
+        parent = case_service.get_parent_from_path(case, path, create_if_missing=True, persist=False)
+
+        item = CaseItem({"type": item_type, "value": record_id, "parent": parent.id if parent else None, "name": name})
+        if item.name is None:
+            item.name = item.value
+
+        case_service._check_conflicts(case, item)
+
+        backing_obj = _resolve_backing_object(item_type, record_id, backing_cache)
+        item.classification = backing_obj.classification
+        case.items.append(item)
+
+        if case_service.add_backreference(backing_obj, case_id):
+            dirty_backing_keys.add((item_type, record_id))
+
+        return True
+    except InvalidDataException:
+        logger.debug("Record %s already exists in case %s, skipping", record_id, case_id)
+    except NotFoundException:
+        logger.warning("Case %s or record %s not found during correlation", case_id, record_id)
+    except Exception:  # pragma: no cover
+        logger.exception("Failed to add record %s to case %s", record_id, case_id)
+
+    return False
 
 
 def enqueue_for_correlation(ids: list[str]) -> None:
@@ -138,8 +217,10 @@ def process_batch(record_ids: list[str]) -> int:  # noqa: C901
 
     For each rule, a single Elasticsearch query is run against the indexes
     specified by the rule (hit, event, or both) to find which of the
-    given records match. Matching records are appended to the owning case at
-    the rule's (Mustache-rendered) destination path.
+    given records match. Matching records are accumulated in memory against
+    their owning case (at the rule's Mustache-rendered destination path), and
+    every touched case is written to the datastore once, in a single bulk
+    transaction, rather than saving on every match.
 
     Args:
         record_ids: List of record IDs (hit or event) to evaluate.
@@ -152,10 +233,6 @@ def process_batch(record_ids: list[str]) -> int:  # noqa: C901
 
     ds = datastore()
 
-    # Ensure recently written data is searchable before querying.
-    ds.case.commit()
-    ds.hit.commit()
-
     rules = get_active_rules()
     if not rules:
         return 0
@@ -163,11 +240,27 @@ def process_batch(record_ids: list[str]) -> int:  # noqa: C901
     id_filter = f"howler.id:({' OR '.join(sanitize_lucene_query(h) for h in record_ids)})"
     added = 0
 
+    # Cases and their backing hit/event objects are fetched once per batch and mutated in
+    # memory; they're only written to the datastore after every rule has been evaluated.
+    case_cache: dict[str, Case | None] = {}
+    case_original_item_counts: dict[str, int] = {}
+    backing_cache: dict[tuple[str, str], Hit | Event | None] = {}
+    dirty_backing_keys: set[tuple[str, str]] = set()
+
     for case_id, rule in rules:
         indexes: list[str] = list(rule.indexes) if rule.indexes else [RuleIndexTypes.HIT]
-        case = ds.case.get(case_id)
+
+        if case_id not in case_cache:
+            case = ds.case.get(case_id)
+            if case is None:
+                logger.warning("Case %s not found during correlation", case_id)
+            else:
+                case_original_item_counts[case_id] = len(case.items)
+
+            case_cache[case_id] = case
+
+        case = case_cache[case_id]
         if case is None:
-            logger.warning("Case %s not found during correlation", case_id)
             continue
 
         try:
@@ -182,33 +275,31 @@ def process_batch(record_ids: list[str]) -> int:  # noqa: C901
             continue
 
         for record in results["items"]:
-            record_id = record["howler"]["id"]
-            item_type = record.get("__index", "hit")
-
-            rendered_path = chevron.render(rule.destination, record)
-            try:
-                path, name = rendered_path.rsplit("/", maxsplit=1)
-            except ValueError:
-                path = None
-                name = rendered_path
-
-            parent = case_service.get_parent_from_path(case, path, create_if_missing=True)
-
-            try:
-                case_service.append_case_item(
-                    case,
-                    item_type=item_type,
-                    item_value=record_id,
-                    item_name=name,
-                    item_parent=parent.id if parent else None,
-                )
+            if _add_record_to_case(case, case_id, record, rule, backing_cache, dirty_backing_keys):
                 added += 1
-            except InvalidDataException:
-                logger.debug("Record %s already exists in case %s, skipping", record_id, case_id)
-            except NotFoundException:
-                logger.warning("Case %s or record %s not found during correlation", case_id, record_id)
-            except Exception:  # pragma: no cover
-                logger.exception("Failed to add record %s to case %s", record_id, case_id)
+
+    for key in dirty_backing_keys:
+        backing_obj = backing_cache[key]
+        if backing_obj is not None:
+            backing_obj.save()
+
+    modified_cases = [
+        case for cid, case in case_cache.items() if case and len(case.items) != case_original_item_counts[cid]
+    ]
+
+    bulk_plan = ds.case.get_bulk_plan()
+    if modified_cases:
+        for case in modified_cases:
+            case_service.recompute_case_metadata(case)
+            # Partial update: only touch fields derived from items, so concurrent user edits
+            # to the case (title, summary, rules, ...) aren't clobbered by a stale in-memory copy.
+            bulk_plan.add_update_operation(case.case_id, case, fields=["items", "targets", "threats", "indicators"])
+
+    if not bulk_plan.empty and not ds.case.bulk(bulk_plan):
+        raise HowlerRuntimeError("Bulk case update reported errors while flushing correlation batch")
+
+    for case in modified_cases:
+        comms_service.emit("cases", {"case": case.as_primitives()})
 
     return added
 

--- a/api/howler/services/correlation_service.py
+++ b/api/howler/services/correlation_service.py
@@ -109,15 +109,16 @@ def _add_record_to_case(
         name = rendered_path
 
     try:
+        backing_obj = _resolve_backing_object(item_type, record_id, backing_cache)
+
         parent = case_service.get_parent_from_path(case, path, create_if_missing=True, persist=False)
 
         item = CaseItem({"type": item_type, "value": record_id, "parent": parent.id if parent else None, "name": name})
         if item.name is None:
             item.name = item.value
 
-        case_service._check_conflicts(case, item)
+        case_service.check_conflicts(case, item)
 
-        backing_obj = _resolve_backing_object(item_type, record_id, backing_cache)
         item.classification = backing_obj.classification
         case.items.append(item)
 

--- a/api/howler/services/correlation_service.py
+++ b/api/howler/services/correlation_service.py
@@ -9,7 +9,7 @@ The public API consists of three functions:
 """
 
 from datetime import datetime, timedelta, timezone
-from typing import TYPE_CHECKING, Literal
+from typing import Literal
 
 import chevron
 from opentelemetry import trace
@@ -25,10 +25,6 @@ from howler.odm.models.hit import Hit
 from howler.remote.datatypes.queues.named import NamedQueue
 from howler.services import case_service, comms_service, search_service
 from howler.utils.str_utils import sanitize_lucene_query
-
-if TYPE_CHECKING:
-    pass
-
 
 logger = get_logger(__file__)
 tracer = trace.get_tracer(__name__)

--- a/api/howler/services/correlation_service.py
+++ b/api/howler/services/correlation_service.py
@@ -9,6 +9,7 @@ The public API consists of three functions:
 """
 
 from datetime import datetime, timedelta, timezone
+from typing import Any
 
 import chevron
 from opentelemetry import trace
@@ -71,8 +72,10 @@ def _resolve_backing_object(
         ds = datastore()
         if item_type == RuleIndexTypes.EVENT:
             backing_cache[key] = ds.event.get(key=record_id)
-        else:
+        elif item_type == RuleIndexTypes.HIT:
             backing_cache[key] = ds.hit.get(record_id)
+        else:
+            raise InvalidDataException(f"Invalid index type {item_type} provided. Must be one of hit,event")
 
     backing_obj = backing_cache[key]
     if backing_obj is None:
@@ -87,8 +90,7 @@ def _add_record_to_case(
     record: dict,
     rule: CaseRule,
     backing_cache: dict[tuple[str, str], Hit | Event | None],
-    dirty_backing_keys: set[tuple[str, str]],
-) -> bool:
+) -> tuple[str, str] | None:
     """Append a single matching record to a case, in memory only (no datastore writes).
 
     Mirrors the validation/dispatch behaviour of ``case_service.append_case_item`` for hit
@@ -121,23 +123,23 @@ def _add_record_to_case(
             item.name = f"{item.name} ({item.value})" if item.name else item.value
 
             if case_service.check_conflicts(case, item):
-                return False
+                return None
 
         item.classification = backing_obj.classification
         case.items.append(item)
 
         if case_service.add_backreference(backing_obj, case_id):
-            dirty_backing_keys.add((item_type, record_id))
+            return (item_type, record_id)
 
-        return True
+        return None
     except InvalidDataException:
-        logger.info("Record %s already exists in case %s, skipping", record_id, case_id)
+        logger.info("Record %s already exists in case %s or is invalid, skipping", record_id, case_id)
     except NotFoundException:
         logger.warning("Case %s or record %s not found during correlation", case_id, record_id)
     except Exception:  # pragma: no cover
         logger.exception("Failed to add record %s to case %s", record_id, case_id)
 
-    return False
+    return None
 
 
 def enqueue_for_correlation(ids: list[str]) -> None:
@@ -279,13 +281,27 @@ def process_batch(record_ids: list[str]) -> int:  # noqa: C901
             continue
 
         for record in results["items"]:
-            if _add_record_to_case(case, case_id, record, rule, backing_cache, dirty_backing_keys):
+            if result := _add_record_to_case(case, case_id, record, rule, backing_cache):
+                dirty_backing_keys.add(result)
                 added += 1
 
-    for key in dirty_backing_keys:
-        backing_obj = backing_cache[key]
+    backing_collections: dict[str, Any] = {
+        str(RuleIndexTypes.HIT): ds.hit,
+        str(RuleIndexTypes.EVENT): ds.event,
+    }
+    backing_bulk_plans: dict[str, Any] = {
+        item_type: backing_collections[item_type].get_bulk_plan()
+        for item_type in {key[0] for key in dirty_backing_keys}
+    }
+
+    for item_type, record_id in dirty_backing_keys:
+        backing_obj = backing_cache[(item_type, record_id)]
         if backing_obj is not None:
-            backing_obj.save()
+            backing_bulk_plans[item_type].add_update_operation(record_id, backing_obj, fields=["howler.related"])
+
+    for item_type, bulk_plan in backing_bulk_plans.items():
+        if not backing_collections[item_type].bulk(bulk_plan):
+            raise HowlerRuntimeError("Bulk backing record update reported errors while flushing correlation batch")
 
     modified_cases = [
         case for cid, case in case_cache.items() if case and len(case.items) != case_original_item_counts[cid]

--- a/api/howler/services/correlation_service.py
+++ b/api/howler/services/correlation_service.py
@@ -117,7 +117,11 @@ def _add_record_to_case(
         if item.name is None:
             item.name = item.value
 
-        case_service.check_conflicts(case, item)
+        if case_service.check_conflicts(case, item):
+            item.name = f"{item.name} ({item.value})" if item.name else item.value
+
+            if case_service.check_conflicts(case, item):
+                return False
 
         item.classification = backing_obj.classification
         case.items.append(item)
@@ -127,7 +131,7 @@ def _add_record_to_case(
 
         return True
     except InvalidDataException:
-        logger.debug("Record %s already exists in case %s, skipping", record_id, case_id)
+        logger.info("Record %s already exists in case %s, skipping", record_id, case_id)
     except NotFoundException:
         logger.warning("Case %s or record %s not found during correlation", case_id, record_id)
     except Exception:  # pragma: no cover
@@ -253,15 +257,14 @@ def process_batch(record_ids: list[str]) -> int:  # noqa: C901
 
         if case_id not in case_cache:
             case = ds.case.get(case_id)
-            if case is None:
-                logger.warning("Case %s not found during correlation", case_id)
-            else:
+            if case:
                 case_original_item_counts[case_id] = len(case.items)
 
             case_cache[case_id] = case
 
         case = case_cache[case_id]
         if case is None:
+            logger.warning("Case %s not found during correlation", case_id)
             continue
 
         try:
@@ -287,8 +290,9 @@ def process_batch(record_ids: list[str]) -> int:  # noqa: C901
     modified_cases = [
         case for cid, case in case_cache.items() if case and len(case.items) != case_original_item_counts[cid]
     ]
-
     bulk_plan = ds.case.get_bulk_plan()
+
+    logger.info("Modified cases: %s", len(modified_cases))
     if modified_cases:
         for case in modified_cases:
             case_service.recompute_case_metadata(case)
@@ -296,8 +300,15 @@ def process_batch(record_ids: list[str]) -> int:  # noqa: C901
             # to the case (title, summary, rules, ...) aren't clobbered by a stale in-memory copy.
             bulk_plan.add_update_operation(case.case_id, case, fields=["items", "targets", "threats", "indicators"])
 
-    if not bulk_plan.empty and not ds.case.bulk(bulk_plan):
-        raise HowlerRuntimeError("Bulk case update reported errors while flushing correlation batch")
+    if bulk_plan.empty:
+        logger.info(
+            "Bulk plan for batch %s is empty.", f"({', '.join(record_ids[:5])}{', ...' if len(record_ids) > 5 else ''})"
+        )
+    else:
+        logger.info("Exexcuting bulk plan (%s operations)", len(bulk_plan.operations))
+
+        if not ds.case.bulk(bulk_plan, refresh="wait_for"):
+            raise HowlerRuntimeError("Bulk case update reported errors while flushing correlation batch")
 
     for case in modified_cases:
         comms_service.emit("cases", {"case": case.as_primitives()})
@@ -318,19 +329,27 @@ def run_worker() -> None:  # pragma: no cover – long-running loop, tested via 
 
     while True:
         try:
-            item: str | None = queue.pop(blocking=True, timeout=BATCH_TIMEOUT)
+            item: str | None = queue.pop(timeout=BATCH_TIMEOUT)
 
             if item is not None:
                 batch.append(item)
 
+            if len(batch) > 0:
+                logger.info("Batch size: %s", len(batch))
+
             if len(batch) >= BATCH_SIZE or (item is None and batch):
-                logger.debug("Processing correlation batch of %d hit(s)", len(batch))
+                finalized_batch = [*batch]
+                batch = []
+
+                logger.debug("Processing correlation batch of %d hit(s)", len(finalized_batch))
                 try:
-                    added = process_batch(batch)
-                    logger.info("Correlation batch complete: %d case item(s) added for %d record(s)", added, len(batch))
+                    added = process_batch(finalized_batch)
+                    logger.info(
+                        "Correlation batch complete: %d case item(s) added for %d record(s)",
+                        added,
+                        len(finalized_batch),
+                    )
                 except Exception:
-                    logger.exception("Error processing correlation batch")
-                finally:
-                    batch = []
+                    logger.exception("Error processing correlation batch %s", ", ".join(finalized_batch))
         except Exception:
             logger.exception("Unexpected error in correlation worker loop")

--- a/api/howler/services/event_service.py
+++ b/api/howler/services/event_service.py
@@ -167,6 +167,9 @@ def create_events(
             event.howler.log = [EventLog({"timestamp": "NOW", "explanation": "Created event", "user": user})]
 
         CREATED_EVENTS.inc()
-        bulk_plan.add_insert_operation(event.howler.id, event)
+        if overwrite:
+            bulk_plan.add_index_operation(event.howler.id, event)
+        else:
+            bulk_plan.add_insert_operation(event.howler.id, event)
 
     return storage.event.bulk(bulk_plan, refresh=refresh)

--- a/api/howler/services/event_service.py
+++ b/api/howler/services/event_service.py
@@ -151,17 +151,17 @@ def create_event(
 def create_events(
     events: list[Event], user: Optional[str] = None, overwrite: bool = False, refresh: str | None = None
 ) -> bool:
-    """Bulk create multiple hits in the database.
+    """Bulk create multiple events in the database.
 
     Similar to create_event for batch.
-    Will raise and abort the entire batch if any hit already exists and overwrite=False.
+    Will raise and abort the entire batch if any event already exists and overwrite=False.
     """
     storage = datastore()
     bulk_plan = storage.event.get_bulk_plan()
 
     for event in events:
-        if not overwrite and storage.hit.exists(event.howler.id):
-            raise ResourceExists("Hit %s already exists in datastore" % event.howler.id)
+        if not overwrite and storage.event.exists(event.howler.id):
+            raise ResourceExists("Event %s already exists in datastore" % event.howler.id)
 
         if user:
             event.howler.log = [EventLog({"timestamp": "NOW", "explanation": "Created event", "user": user})]
@@ -169,4 +169,4 @@ def create_events(
         CREATED_EVENTS.inc()
         bulk_plan.add_insert_operation(event.howler.id, event)
 
-    return storage.hit.bulk(bulk_plan, refresh=refresh)
+    return storage.event.bulk(bulk_plan, refresh=refresh)

--- a/api/howler/services/event_service.py
+++ b/api/howler/services/event_service.py
@@ -145,3 +145,28 @@ def create_event(
 
     CREATED_EVENTS.inc()
     return datastore().event.save(id, event, refresh=refresh)
+
+
+@tracer.start_as_current_span(f"{__name__}.create_events")
+def create_events(
+    events: list[Event], user: Optional[str] = None, overwrite: bool = False, refresh: str | None = None
+) -> bool:
+    """Bulk create multiple hits in the database.
+
+    Similar to create_event for batch.
+    Will raise and abort the entire batch if any hit already exists and overwrite=False.
+    """
+    storage = datastore()
+    bulk_plan = storage.event.get_bulk_plan()
+
+    for event in events:
+        if not overwrite and storage.hit.exists(event.howler.id):
+            raise ResourceExists("Hit %s already exists in datastore" % event.howler.id)
+
+        if user:
+            event.howler.log = [EventLog({"timestamp": "NOW", "explanation": "Created event", "user": user})]
+
+        CREATED_EVENTS.inc()
+        bulk_plan.add_insert_operation(event.howler.id, event)
+
+    return storage.hit.bulk(bulk_plan, refresh=refresh)

--- a/api/howler/services/hit_service.py
+++ b/api/howler/services/hit_service.py
@@ -462,7 +462,10 @@ def create_hits(
             hit.howler.log = [Log({"timestamp": "NOW", "explanation": "Created hit", "user": user})]
 
         CREATED_HITS.labels(hit.howler.analytic).inc()
-        bulk_plan.add_insert_operation(hit.howler.id, hit)
+        if overwrite:
+            bulk_plan.add_index_operation(hit.howler.id, hit)
+        else:
+            bulk_plan.add_insert_operation(hit.howler.id, hit)
 
     return storage.hit.bulk(bulk_plan, refresh=refresh)
 

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -152,7 +152,7 @@ suppress-none-returning = true
 [tool.poetry]
 package-mode = true
 name = "howler-api"
-version = "4.0.1"
+version = "4.0.2"
 description = "Howler - API server"
 authors = [
     "Canadian Centre for Cyber Security <howler@cyber.gc.ca>",

--- a/api/test/integration/actions/test_add_to_case.py
+++ b/api/test/integration/actions/test_add_to_case.py
@@ -17,10 +17,10 @@ def _make_case(title: str) -> dict:
     }
 
 
-def _execute(session, host, query: str, case_id: str, path: str = "related", title_template: str | None = None):
-    data: dict = {"case_id": case_id, "path": path}
-    if title_template is not None:
-        data["title_template"] = title_template
+def _execute(session, host, query: str, case_id: str, destination: str | None = None):
+    data: dict = {"case_id": case_id}
+    if destination is not None:
+        data["destination"] = destination
 
     req = {
         "request_id": str(uuid4()),
@@ -125,7 +125,7 @@ def test_add_to_case_happy_path(datastore: HowlerDatastore, login_session, test_
 
 
 def test_add_to_case_custom_path_and_template(datastore: HowlerDatastore, login_session, test_case: Case):
-    """Items are placed at the specified path using the title template."""
+    """Items are placed at the specified destination path using the rendered template."""
     session, host = login_session
 
     # Take only the first hit to keep things deterministic
@@ -137,8 +137,7 @@ def test_add_to_case_custom_path_and_template(datastore: HowlerDatastore, login_
         host,
         query=query,
         case_id=test_case.case_id,
-        path="investigations/test",
-        title_template="{{howler.id}}",
+        destination="investigations/test/{{howler.id}}",
     )
 
     reports = list(resp.values())
@@ -177,7 +176,7 @@ def test_add_to_case_missing_case_id(datastore: HowlerDatastore, login_session):
         "operations": [
             {
                 "operation_id": "add_to_case",
-                "data_json": json.dumps({"path": "related"}),
+                "data_json": json.dumps({}),
             }
         ],
     }

--- a/api/test/integration/api/test_correlation.py
+++ b/api/test/integration/api/test_correlation.py
@@ -62,10 +62,10 @@ def test_case(datastore: HowlerDatastore, login_session):
         session,
         f"{host}/api/v2/case",
         method="POST",
+        params={"refresh": "wait_for"},
         data=json.dumps(_make_case()),
     )
     case_id = resp["case_id"]
-    datastore.case.commit()
 
     yield case_id, session, host
 
@@ -88,20 +88,19 @@ class TestCorrelationPipeline:
             session,
             f"{host}/api/v2/case/{case_id}/rules",
             method="POST",
+            params={"refresh": "wait_for"},
             data=json.dumps(rule_data),
         )
-        datastore.case.commit()
 
         # Ingest a hit that matches the rule
         ingest_resp = get_api_data(
             session,
             f"{host}/api/v2/ingest/hit",
             method="POST",
+            params={"refresh": "wait_for"},
             data=json.dumps([_make_hit(analytic="My Detection", kind="alert")]),
         )
         hit_id = ingest_resp[0]
-        datastore.hit.commit()
-        time.sleep(1)
 
         # Run the correlation directly.  The background worker may have
         # already processed the hit from the ingestion queue, so we
@@ -135,6 +134,7 @@ class TestCorrelationPipeline:
             session,
             f"{host}/api/v2/case/{case_id}/rules",
             method="POST",
+            params={"refresh": "wait_for"},
             data=json.dumps(rule_data),
         )
         datastore.case.commit()
@@ -146,8 +146,6 @@ class TestCorrelationPipeline:
             data=json.dumps([_make_hit(analytic="Deeply Nested Detection", kind="alert")]),
         )
         hit_id = ingest_resp[0]
-        datastore.hit.commit()
-        time.sleep(1)
 
         correlation_service.process_batch([hit_id])
 
@@ -183,6 +181,7 @@ class TestCorrelationPipeline:
             session,
             f"{host}/api/v2/case/{case_id}/rules",
             method="POST",
+            params={"refresh": "wait_for"},
             data=json.dumps(rule_data),
         )
         datastore.case.commit()
@@ -192,6 +191,7 @@ class TestCorrelationPipeline:
             session,
             f"{host}/api/v2/ingest/hit",
             method="POST",
+            params={"refresh": "wait_for"},
             data=json.dumps([_make_hit(analytic="Other", kind="alert")]),
         )
         hit_id = ingest_resp[0]
@@ -218,6 +218,7 @@ class TestCorrelationPipeline:
             session,
             f"{host}/api/v2/case/{case_id}/rules",
             method="POST",
+            params={"refresh": "wait_for"},
             data=json.dumps(rule_data),
         )
         rule_id = resp["rules"][-1]["rule_id"]
@@ -228,6 +229,7 @@ class TestCorrelationPipeline:
             session,
             f"{host}/api/v2/case/{case_id}/rules/{rule_id}",
             method="PUT",
+            params={"refresh": "wait_for"},
             data=json.dumps({"enabled": False}),
         )
         datastore.case.commit()
@@ -259,19 +261,18 @@ class TestCorrelationPipeline:
             session,
             f"{host}/api/v2/case/{case_id}/rules",
             method="POST",
+            params={"refresh": "wait_for"},
             data=json.dumps(rule_data),
         )
-        datastore.case.commit()
 
         ingest_resp = get_api_data(
             session,
             f"{host}/api/v2/ingest/hit",
             method="POST",
+            params={"refresh": "wait_for"},
             data=json.dumps([_make_hit(kind="alert")]),
         )
         hit_id = ingest_resp[0]
-        datastore.hit.commit()
-        time.sleep(1)
 
         # The background worker may have already processed the hit from
         # the ingestion queue, so we cannot rely on exact return values.
@@ -282,7 +283,6 @@ class TestCorrelationPipeline:
         assert first + second <= 1
 
         # The hit must appear exactly once in the case.
-        datastore.case.commit()
         case = datastore.case.get(case_id)
         hit_count = sum(1 for item in case.items if item.type == "hit" and item.value == hit_id)
         assert hit_count == 1
@@ -294,10 +294,9 @@ class TestCorrelationWorker:
     MAX_WAIT = 15
     POLL_INTERVAL = 0.25
 
-    @pytest.fixture()
-    def worker_event_provider(self) -> str:
+    def _worker_event_provider(self, test_name: str) -> str:
         """Create an event provider that cannot match another test's broad rule."""
-        return f"correlationworker{uuid.uuid4().hex}"
+        return f"correlation_{test_name}"
 
     def _wait_for_case_items(self, datastore: HowlerDatastore, case_id: str, hit_ids: list[str]) -> list[str]:
         """Wait for expected hits and return those that were added to the case."""
@@ -322,20 +321,27 @@ class TestCorrelationWorker:
             session,
             f"{host}/api/v2/case/{case_id}/rules",
             method="POST",
+            params={"refresh": "wait_for"},
             data=json.dumps({"query": query, "destination": destination}),
         )
 
-    def test_worker_adds_matching_hit(self, test_case, datastore: HowlerDatastore, worker_event_provider: str):
+    def test_worker_adds_matching_hit(self, test_case, datastore: HowlerDatastore):
         """The worker adds a newly ingested hit that matches an active rule."""
         case_id, session, host = test_case
-        self._add_rule(session, host, case_id, f"event.provider:{worker_event_provider}", "worker")
-        datastore.case.commit()
+        self._add_rule(
+            session,
+            host,
+            case_id,
+            f"event.provider:{self._worker_event_provider('test_worker_adds_matching_hit')}",
+            "worker",
+        )
 
         ingest_resp = get_api_data(
             session,
             f"{host}/api/v2/ingest/hit",
             method="POST",
-            data=json.dumps([_make_hit(provider=worker_event_provider)]),
+            params={"refresh": "wait_for"},
+            data=json.dumps([_make_hit(provider=self._worker_event_provider("test_worker_adds_matching_hit"))]),
         )
 
         seen_hit_ids = self._wait_for_case_items(datastore, case_id, ingest_resp)
@@ -344,17 +350,30 @@ class TestCorrelationWorker:
             f"Worker did not add hits {missing_hit_ids} to case {case_id} within {self.MAX_WAIT}s"
         )
 
-    def test_worker_renders_destination_path(self, test_case, datastore: HowlerDatastore, worker_event_provider: str):
+    def test_worker_renders_destination_path(self, test_case, datastore: HowlerDatastore):
         """The worker renders the matching hit's destination path."""
         case_id, session, host = test_case
-        self._add_rule(session, host, case_id, f"event.provider:{worker_event_provider}", "worker/{{howler.analytic}}")
-        datastore.case.commit()
+        self._add_rule(
+            session,
+            host,
+            case_id,
+            f"event.provider:{self._worker_event_provider('test_worker_renders_destination_path')}",
+            "worker/{{howler.analytic}}",
+        )
 
         ingest_resp = get_api_data(
             session,
             f"{host}/api/v2/ingest/hit",
             method="POST",
-            data=json.dumps([_make_hit(analytic="Worker Detection", provider=worker_event_provider)]),
+            params={"refresh": "wait_for"},
+            data=json.dumps(
+                [
+                    _make_hit(
+                        analytic="Worker Detection",
+                        provider=self._worker_event_provider("test_worker_renders_destination_path"),
+                    )
+                ]
+            ),
         )
 
         seen_hit_ids = self._wait_for_case_items(datastore, case_id, ingest_resp)
@@ -369,32 +388,42 @@ class TestCorrelationWorker:
         assert matching_item.name == "Worker Detection"
         assert matching_item.parent == worker_folder.id
 
-    def test_worker_handles_multiple_hits(self, test_case, datastore: HowlerDatastore, worker_event_provider: str):
+    def test_worker_handles_multiple_hits(self, test_case, datastore: HowlerDatastore):
         """Multiple hits ingested in sequence are each processed by the worker."""
         case_id, session, host = test_case
         self._add_rule(
             session,
             host,
             case_id,
-            f"event.provider:{worker_event_provider}",
+            f"event.provider:{self._worker_event_provider('test_worker_handles_multiple_hits')}",
             "worker-multi/{{howler.analytic}}",
         )
-        datastore.case.commit()
 
-        hit_ids = []
-        for index in range(3):
-            ingest_resp = get_api_data(
+        hit_ids: list[str] = []
+        for _ in range(3):
+            hits = []
+            for index in range(3):
+                hits.append(
+                    _make_hit(
+                        analytic=f"Multi-{index}",
+                        provider=self._worker_event_provider("test_worker_handles_multiple_hits"),
+                    )
+                )
+
+            added = get_api_data(
                 session,
                 f"{host}/api/v2/ingest/hit",
                 method="POST",
-                data=json.dumps([_make_hit(analytic=f"Multi-{index}", provider=worker_event_provider)]),
+                params={"refresh": "wait_for"},
+                data=json.dumps(hits),
             )
-            hit_ids.append(ingest_resp[0])
 
+            hit_ids = [*hit_ids, *added]
         seen_hit_ids = self._wait_for_case_items(datastore, case_id, hit_ids)
         missing_hit_ids = set(hit_ids) - set(seen_hit_ids)
         assert not missing_hit_ids, (
-            f"Worker did not add hits {missing_hit_ids} to case {case_id} within {self.MAX_WAIT}s"
+            f"Worker did not add {len(missing_hit_ids)} hits ({missing_hit_ids}) "
+            f"to case {case_id} within {self.MAX_WAIT}s"
         )
 
     def test_worker_processes_v1_hit_ingestion(self, test_case, datastore: HowlerDatastore):
@@ -403,12 +432,12 @@ class TestCorrelationWorker:
         analytic = f"v1-hit-worker-{uuid.uuid4().hex}"
 
         self._add_rule(session, host, case_id, f"howler.analytic:{analytic}", "worker-v1-hit")
-        datastore.case.commit()
 
         ingest_resp = get_api_data(
             session,
             f"{host}/api/v1/hit/",
             method="POST",
+            params={"refresh": "wait_for"},
             data=json.dumps([{"howler": {"analytic": analytic, "score": "0.8"}}]),
         )
         hit_ids = [entry["howler"]["id"] for entry in ingest_resp["valid"]]
@@ -425,12 +454,12 @@ class TestCorrelationWorker:
         analytic = f"v1-tool-worker-{uuid.uuid4().hex}"
 
         self._add_rule(session, host, case_id, f"howler.analytic:{analytic}", "worker-v1-tool")
-        datastore.case.commit()
 
         ingest_resp = get_api_data(
             session,
             f"{host}/api/v1/tools/test/hits",
             method="POST",
+            params={"refresh": "wait_for"},
             data=json.dumps(
                 {
                     "map": {

--- a/api/test/integration/api/test_correlation.py
+++ b/api/test/integration/api/test_correlation.py
@@ -122,6 +122,55 @@ class TestCorrelationPipeline:
         assert matching_item.name == "My Detection"
         assert matching_item.parent == alerts_folder.id
 
+    def test_deeply_nested_destination_persists_all_folders(self, test_case, datastore: HowlerDatastore):
+        """A deeply nested rule destination has every intermediate folder persisted to the case."""
+        case_id, session, host = test_case
+
+        parts = ["a", "b", "c", "d", "e", "f", "g", "h"]
+        rule_data = {
+            "query": "event.kind:alert",
+            "destination": "/".join(parts) + "/{{howler.analytic}}",
+        }
+        get_api_data(
+            session,
+            f"{host}/api/v2/case/{case_id}/rules",
+            method="POST",
+            data=json.dumps(rule_data),
+        )
+        datastore.case.commit()
+
+        ingest_resp = get_api_data(
+            session,
+            f"{host}/api/v2/ingest/hit",
+            method="POST",
+            data=json.dumps([_make_hit(analytic="Deeply Nested Detection", kind="alert")]),
+        )
+        hit_id = ingest_resp[0]
+        datastore.hit.commit()
+        time.sleep(1)
+
+        correlation_service.process_batch([hit_id])
+
+        # Re-fetch the case from the datastore to confirm the whole folder chain, not just
+        # the in-memory objects mutated by process_batch, was actually persisted.
+        datastore.case.commit()
+        case = datastore.case.get(case_id)
+        assert case is not None
+
+        folders = [item for item in case.items if item.type == "folder"]
+        assert len(folders) == len(parts)
+
+        matching_item = next(item for item in case.items if item.value == hit_id)
+        assert matching_item.name == "Deeply Nested Detection"
+
+        names_leaf_to_root = []
+        current = next((item for item in case.items if item.id == matching_item.parent), None)
+        while current is not None:
+            names_leaf_to_root.append(current.name)
+            current = next((item for item in case.items if item.id == current.parent), None)
+
+        assert names_leaf_to_root == list(reversed(parts))
+
     def test_non_matching_hit_not_added(self, test_case, datastore: HowlerDatastore):
         """A hit that does not match the rule's query is not added."""
         case_id, session, host = test_case

--- a/api/test/integration/api/test_correlation.py
+++ b/api/test/integration/api/test_correlation.py
@@ -143,6 +143,7 @@ class TestCorrelationPipeline:
             session,
             f"{host}/api/v2/ingest/hit",
             method="POST",
+            params={"refresh": "wait_for"},
             data=json.dumps([_make_hit(analytic="Deeply Nested Detection", kind="alert")]),
         )
         hit_id = ingest_resp[0]
@@ -239,6 +240,7 @@ class TestCorrelationPipeline:
             session,
             f"{host}/api/v2/ingest/hit",
             method="POST",
+            params={"refresh": "wait_for"},
             data=json.dumps([_make_hit(kind="alert")]),
         )
         hit_id = ingest_resp[0]

--- a/api/test/integration/api/test_correlation.py
+++ b/api/test/integration/api/test_correlation.py
@@ -502,3 +502,76 @@ class TestCorrelationWorker:
         assert not missing_hit_ids, (
             f"Worker did not add v1 tool ingested hits {missing_hit_ids} to case {case_id} within {self.MAX_WAIT}s"
         )
+
+
+class TestCorrelationConflicts:
+    """Integration coverage for correlation item conflict handling."""
+
+    def _ingest_hits(self, session, host: str, hits: list[dict]) -> list[str]:
+        return get_api_data(
+            session,
+            f"{host}/api/v2/ingest/hit",
+            method="POST",
+            params={"refresh": "wait_for"},
+            data=json.dumps(hits),
+        )
+
+    def _add_case_item(self, session, host: str, case_id: str, value: str, name: str) -> None:
+        get_api_data(
+            session,
+            f"{host}/api/v2/case/{case_id}/items",
+            method="POST",
+            params={"refresh": "wait_for"},
+            data=json.dumps({"type": "hit", "value": value, "name": name}),
+        )
+
+    def _add_rule(self, session, host: str, case_id: str, destination: str) -> None:
+        get_api_data(
+            session,
+            f"{host}/api/v2/case/{case_id}/rules",
+            method="POST",
+            params={"refresh": "wait_for"},
+            data=json.dumps({"query": "*:*", "destination": destination}),
+        )
+
+    def test_matching_name_is_renamed_with_record_id(self, test_case, datastore: HowlerDatastore):
+        """A real duplicate name is disambiguated with the correlated hit ID."""
+        case_id, session, host = test_case
+        hit_ids = self._ingest_hits(
+            session,
+            host,
+            [_make_hit(analytic="Existing"), _make_hit(analytic="Target")],
+        )
+        self._add_case_item(session, host, case_id, hit_ids[0], "related")
+
+        self._add_rule(session, host, case_id, "related")
+        correlation_service.process_batch([hit_ids[1]])
+
+        datastore.case.commit()
+        case = datastore.case.get(case_id)
+        assert case is not None
+        target_item = next(item for item in case.items if item.value == hit_ids[1])
+        assert target_item.name == f"related ({hit_ids[1]})"
+
+    def test_duplicate_name_after_renaming_is_skipped(self, test_case, datastore: HowlerDatastore):
+        """A real conflict with both candidate names causes correlation to skip the hit."""
+        case_id, session, host = test_case
+        hit_ids = self._ingest_hits(
+            session,
+            host,
+            [
+                _make_hit(analytic="Existing"),
+                _make_hit(analytic="Existing Name"),
+                _make_hit(analytic="Target"),
+            ],
+        )
+        self._add_case_item(session, host, case_id, hit_ids[0], "related")
+        self._add_case_item(session, host, case_id, hit_ids[1], f"related ({hit_ids[2]})")
+
+        self._add_rule(session, host, case_id, "related")
+        correlation_service.process_batch([hit_ids[2]])
+
+        datastore.case.commit()
+        case = datastore.case.get(case_id)
+        assert case is not None
+        assert not any(item.value == hit_ids[2] for item in case.items)

--- a/api/test/unit/actions/test_add_to_case.py
+++ b/api/test/unit/actions/test_add_to_case.py
@@ -159,7 +159,7 @@ def test_execute_custom_path():
     execute(
         "howler.analytic:TestingCustomPath",
         case_id=_case.case_id,
-        path="investigations/test",
+        destination="investigations/test/{{howler.analytic}} ({{howler.id}})",
     )
 
     updated = ds.case.get(_case.case_id)
@@ -193,7 +193,7 @@ def test_execute_custom_title_template():
     execute(
         "howler.analytic:TestingTitleTemplate",
         case_id=_case.case_id,
-        title_template="Alert: {{howler.analytic}}",
+        destination="related/Alert: {{howler.analytic}}",
     )
 
     updated = ds.case.get(_case.case_id)
@@ -304,17 +304,16 @@ def test_specification():
     assert isinstance(step, dict)
     args = step["args"]
     assert "case_id" in args
-    assert "path" in args
-    assert "title_template" in args
+    assert "destination" in args
 
 
 # ---------------------------------------------------------------------------
-# path="" with no slash in rendered title → name = item_path (ValueError path)
+# destination with no '/' in the rendered value → name = rendered_destination (ValueError path)
 # ---------------------------------------------------------------------------
 
 
 def test_execute_empty_path_and_simple_title():
-    """When path is empty and the rendered title has no '/', name equals the full item_path."""
+    """When the rendered destination has no '/', name equals the full rendered destination."""
     lookups = loader.get_lookups()
     users = datastore().user.search("uname:*")["items"]
 
@@ -332,8 +331,7 @@ def test_execute_empty_path_and_simple_title():
     result = execute(
         "howler.analytic:TestingEmptyPath",
         case_id=_case.case_id,
-        path="",
-        title_template="SimpleTitle",
+        destination="SimpleTitle",
     )
 
     assert any(r["outcome"] == "success" for r in result)

--- a/api/test/unit/config.yml
+++ b/api/test/unit/config.yml
@@ -37,8 +37,8 @@ system:
   type: development
   correlation:
     enabled: true
-    batch_size: 1
-    batch_timeout: 1
+    batch_size: 5
+    batch_timeout: 2
 
 ui:
   audit: false

--- a/api/test/unit/endpoints/test_ingest_endpoint.py
+++ b/api/test/unit/endpoints/test_ingest_endpoint.py
@@ -91,7 +91,7 @@ class TestCreateEndpoint:
             assert result.status_code == 201
             body = result.get_json()
             assert body["api_response"] == ["hit-001"]
-            mock_hit_svc.create_hit.assert_called_once()
+            mock_hit_svc.create_hits.assert_called_once_with([mock_hit], user.uname, overwrite=False, refresh=None)
             mock_queue_fn.return_value.push.assert_called_once_with("hit-001")
 
     @patch("howler.api.v2.ingest.correlation_service._get_ingestion_queue")
@@ -106,7 +106,7 @@ class TestCreateEndpoint:
         _mock_auth(mock_auth_service, user)
 
         mock_obs = MagicMock()
-        mock_obs.howler.id = "obs-001"
+        mock_obs.howler.id = "event-001"
         mock_obs_svc.convert_event.return_value = (mock_obs, [])
 
         with request_context.test_request_context(
@@ -120,8 +120,8 @@ class TestCreateEndpoint:
 
             assert result.status_code == 201
             body = result.get_json()
-            assert body["api_response"] == ["obs-001"]
-            mock_obs_svc.create_event.assert_called_once()
+            assert body["api_response"] == ["event-001"]
+            mock_obs_svc.create_events.assert_called_once_with([mock_obs], user.uname, overwrite=False, refresh=None)
             mock_hit_svc.convert_hit.assert_not_called()
 
     @patch("howler.api.v2.ingest.hit_service")
@@ -562,7 +562,7 @@ class TestIngestionQueueing:
         _mock_auth(mock_auth_service, user)
 
         obs = MagicMock()
-        obs.howler.id = "obs-a"
+        obs.howler.id = "event-a"
         mock_obs_svc.convert_event.return_value = (obs, [])
 
         with request_context.test_request_context(
@@ -574,7 +574,7 @@ class TestIngestionQueueing:
 
             create(index="event")
 
-            mock_queue_fn.return_value.push.assert_called_once_with("obs-a")
+            mock_queue_fn.return_value.push.assert_called_once_with("event-a")
 
     @patch("howler.api.v2.ingest.correlation_service._get_ingestion_queue")
     @patch("howler.api.v2.ingest.hit_service")

--- a/api/test/unit/services/test_case_service.py
+++ b/api/test/unit/services/test_case_service.py
@@ -627,11 +627,11 @@ class TestAppendCaseItemRouting:
 class TestAppendHit:
     """Tests for case_service.append_hit."""
 
-    @patch("howler.services.case_service._sync_case_metadata")
-    @patch("howler.services.case_service._add_backreference")
+    @patch("howler.services.case_service.recompute_case_metadata")
+    @patch("howler.services.case_service.add_backreference")
     @patch("howler.services.case_service.datastore")
     def test_append_hit_adds_item(self, mock_ds_fn, mock_backref, mock_sync):
-        """append_hit appends the item to the case and delegates save to _sync_case_metadata."""
+        """append_hit appends the item to the case and delegates metadata sync to recompute_case_metadata."""
         mock_ds = MagicMock()
         mock_ds_fn.return_value = mock_ds
 
@@ -650,9 +650,10 @@ class TestAppendHit:
         assert len(mock_case.items) == 1
         mock_backref.assert_called_once_with(mock_hit, "case-001")
         mock_sync.assert_called_once_with(mock_case)
+        mock_hit.save.assert_called_once()
 
-    @patch("howler.services.case_service._sync_case_metadata")
-    @patch("howler.services.case_service._add_backreference")
+    @patch("howler.services.case_service.recompute_case_metadata")
+    @patch("howler.services.case_service.add_backreference")
     @patch("howler.services.case_service.datastore")
     def test_append_hit_preserves_name_and_parent(self, mock_ds_fn, mock_backref, mock_sync):
         """append_hit preserves the item's name and parent fields without modification."""
@@ -728,8 +729,8 @@ class TestAppendHit:
 class TestAppendEvent:
     """Tests for case_service.append_event."""
 
-    @patch("howler.services.case_service._sync_case_metadata")
-    @patch("howler.services.case_service._add_backreference")
+    @patch("howler.services.case_service.recompute_case_metadata")
+    @patch("howler.services.case_service.add_backreference")
     @patch("howler.services.case_service.datastore")
     def test_append_event_adds_item(self, mock_ds_fn, mock_backref, mock_sync):
         """append_event appends the item to the case and saves."""
@@ -754,6 +755,7 @@ class TestAppendEvent:
         assert len(mock_case.items) == 1
         mock_backref.assert_called_once_with(mock_obs, "case-001")
         mock_sync.assert_called_once_with(mock_case)
+        mock_obs.save.assert_called_once()
 
     @patch("howler.services.case_service.datastore")
     def test_append_event_missing_case_raises(self, mock_ds_fn):
@@ -1047,7 +1049,7 @@ class TestRemoveCaseItem:
         with pytest.raises(NotFoundException):
             case_service.remove_case_items("case-001", ["00000000-0000-0000-0000-000000000000"])
 
-    @patch("howler.services.case_service._sync_case_metadata")
+    @patch("howler.services.case_service.recompute_case_metadata")
     @patch("howler.services.case_service.datastore")
     def test_remove_hit_item_clears_backreference(self, mock_ds_fn, mock_sync):
         """remove_case_item removes the item from the case and removes the hit back-reference."""
@@ -1071,7 +1073,7 @@ class TestRemoveCaseItem:
         assert hit_item not in mock_case.items
         mock_sync.assert_called_once_with(mock_case)
 
-    @patch("howler.services.case_service._sync_case_metadata")
+    @patch("howler.services.case_service.recompute_case_metadata")
     @patch("howler.services.case_service.datastore")
     def test_remove_event_item_clears_backreference(self, mock_ds_fn, mock_sync):
         """remove_case_item removes an event item from the case."""
@@ -1293,26 +1295,16 @@ class TestCollectIndicatorsFromRelated:
 
 
 # ---------------------------------------------------------------------------
-# _sync_case_metadata()
+# recompute_case_metadata()
 # ---------------------------------------------------------------------------
 
 
 class TestSyncCaseMetadata:
-    """Tests for case_service._sync_case_metadata."""
-
-    @patch("howler.services.case_service.datastore")
-    def test_sync_case_metadata_noop_on_missing_case(self, mock_ds_fn):
-        """_sync_case_metadata does nothing when the case does not exist."""
-        mock_ds = MagicMock()
-        mock_ds_fn.return_value = mock_ds
-
-        case_service._sync_case_metadata(None)
-
-        mock_ds.case.save.assert_not_called()
+    """Tests for case_service.recompute_case_metadata."""
 
     @patch("howler.services.case_service.datastore")
     def test_sync_case_metadata_updates_from_hit_outline(self, mock_ds_fn):
-        """_sync_case_metadata populates threats/targets/indicators from hit outline data."""
+        """recompute_case_metadata populates threats/targets/indicators from hit outline data, in memory only."""
         mock_ds = MagicMock()
         mock_ds_fn.return_value = mock_ds
 
@@ -1320,7 +1312,6 @@ class TestSyncCaseMetadata:
 
         mock_case = MagicMock()
         mock_case.items = [hit_item]
-        mock_case.save.return_value = True
 
         mock_outline = MagicMock()
         mock_outline.threat = "evil.example.com"
@@ -1332,33 +1323,32 @@ class TestSyncCaseMetadata:
         mock_hit.howler.outline = mock_outline
         mock_ds.hit.get.return_value = mock_hit
 
-        case_service._sync_case_metadata(mock_case)
+        case_service.recompute_case_metadata(mock_case)
 
-        mock_case.save.assert_called_once()
+        mock_case.save.assert_not_called()
         assert mock_case.threats == ["evil.example.com"]
         assert mock_case.targets == ["workstation-01"]
         assert mock_case.indicators == ["hash-abc"]
 
     @patch("howler.services.case_service.datastore")
     def test_sync_case_metadata_clears_when_no_items(self, mock_ds_fn):
-        """_sync_case_metadata resets threats/targets/indicators to empty lists when no items exist."""
+        """recompute_case_metadata resets threats/targets/indicators to empty lists when no items exist."""
         mock_ds = MagicMock()
         mock_ds_fn.return_value = mock_ds
 
         mock_case = MagicMock()
         mock_case.items = []
-        mock_case.save.return_value = True
 
-        case_service._sync_case_metadata(mock_case)
+        case_service.recompute_case_metadata(mock_case)
 
-        mock_case.save.assert_called_once()
+        mock_case.save.assert_not_called()
         assert mock_case.targets == []
         assert mock_case.threats == []
         assert mock_case.indicators == []
 
     @patch("howler.services.case_service.datastore")
     def test_sync_case_metadata_collects_from_events(self, mock_ds_fn):
-        """_sync_case_metadata collects indicators from event items via their related data."""
+        """recompute_case_metadata collects indicators from event items via their related data."""
         mock_ds = MagicMock()
         mock_ds_fn.return_value = mock_ds
 
@@ -1366,22 +1356,21 @@ class TestSyncCaseMetadata:
 
         mock_case = MagicMock()
         mock_case.items = [obs_item]
-        mock_case.save.return_value = True
 
         mock_related = Related({"ip": ["10.0.0.1"], "hosts": ["host-x"]})
         mock_obs = MagicMock()
         mock_obs.related = mock_related
         mock_ds.event.get.return_value = mock_obs
 
-        case_service._sync_case_metadata(mock_case)
+        case_service.recompute_case_metadata(mock_case)
 
-        mock_case.save.assert_called_once()
+        mock_case.save.assert_not_called()
         assert "10.0.0.1" in mock_case.indicators
         assert "host-x" in mock_case.indicators
 
     @patch("howler.services.case_service.datastore")
     def test_sync_case_metadata_skips_missing_event(self, mock_ds_fn):
-        """_sync_case_metadata skips event items whose backing object is None."""
+        """recompute_case_metadata skips event items whose backing object is None."""
         mock_ds = MagicMock()
         mock_ds_fn.return_value = mock_ds
 
@@ -1389,55 +1378,56 @@ class TestSyncCaseMetadata:
 
         mock_case = MagicMock()
         mock_case.items = [obs_item]
-        mock_case.save.return_value = True
 
         mock_ds.event.get.return_value = None
 
-        case_service._sync_case_metadata(mock_case)
+        case_service.recompute_case_metadata(mock_case)
 
-        mock_case.save.assert_called_once()
+        mock_case.save.assert_not_called()
         assert mock_case.indicators == []
 
 
 # ---------------------------------------------------------------------------
-# _add_backreference()
+# add_backreference()
 # ---------------------------------------------------------------------------
 
 
 class TestAddBackreference:
-    """Tests for case_service._add_backreference."""
+    """Tests for case_service.add_backreference."""
 
     def test_add_backreference_raises_on_none_object(self):
-        """_add_backreference raises InvalidDataException when backing_obj is None."""
+        """add_backreference raises InvalidDataException when backing_obj is None."""
         with pytest.raises(InvalidDataException):
-            case_service._add_backreference(None, "case-id")
+            case_service.add_backreference(None, "case-id")
 
     def test_add_backreference_raises_on_empty_case_id(self):
-        """_add_backreference raises InvalidDataException when case_id is empty."""
+        """add_backreference raises InvalidDataException when case_id is empty."""
         mock_obj = MagicMock()
 
         with pytest.raises(InvalidDataException):
-            case_service._add_backreference(mock_obj, "")
+            case_service.add_backreference(mock_obj, "")
 
-    def test_add_backreference_appends_and_saves(self):
-        """_add_backreference appends the case_id to related and saves the object."""
+    def test_add_backreference_appends_without_saving(self):
+        """add_backreference appends the case_id to related, in memory only."""
         mock_obj = MagicMock()
         mock_obj.howler.related = []
         mock_obj.howler.id = "obj-001"
 
-        case_service._add_backreference(mock_obj, "case-abc")
+        added = case_service.add_backreference(mock_obj, "case-abc")
 
+        assert added is True
         assert "case-abc" in mock_obj.howler.related
-        mock_obj.save.assert_called_once()
+        mock_obj.save.assert_not_called()
 
     def test_add_backreference_is_idempotent(self):
-        """_add_backreference does not add a duplicate if the case_id is already present."""
+        """add_backreference does not add a duplicate if the case_id is already present."""
         mock_obj = MagicMock()
         mock_obj.howler.related = ["case-abc"]
         mock_obj.howler.id = "obj-001"
 
-        case_service._add_backreference(mock_obj, "case-abc")
+        added = case_service.add_backreference(mock_obj, "case-abc")
 
+        assert added is False
         assert mock_obj.howler.related.count("case-abc") == 1
         mock_obj.save.assert_not_called()
 
@@ -1465,8 +1455,8 @@ class TestRemoveBackreference:
         assert "other-case" in mock_obj.howler.related
         mock_obj.save.assert_not_called()
 
-    def test_remove_backreference_removes_and_saves(self):
-        """remove_backreference removes the case_id from related and saves."""
+    def test_remove_backreference_removes_without_saving(self):
+        """remove_backreference removes the case_id from related, in memory only."""
         mock_obj = MagicMock()
         mock_obj.howler.related = ["case-abc", "other-case"]
         mock_obj.howler.id = "obj-001"
@@ -1475,7 +1465,7 @@ class TestRemoveBackreference:
 
         assert "case-abc" not in mock_obj.howler.related
         assert "other-case" in mock_obj.howler.related
-        mock_obj.save.assert_called_once()
+        mock_obj.save.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -1522,7 +1512,7 @@ class TestCaseEventEmission:
         assert "case" in args[0][1]
         assert args[0][1]["case"]["title"] == "New"
 
-    @patch("howler.services.case_service._sync_case_metadata")
+    @patch("howler.services.case_service.recompute_case_metadata")
     @patch("howler.services.case_service.comms_service")
     @patch("howler.services.case_service.datastore")
     def test_append_hit_emits_event(self, mock_ds_fn, mock_events, mock_sync):
@@ -1547,30 +1537,6 @@ class TestCaseEventEmission:
         args = mock_events.emit.call_args
         assert args[0][0] == "cases"
         assert "case" in args[0][1]
-
-    @patch("howler.services.case_service._sync_case_metadata")
-    @patch("howler.services.case_service.comms_service")
-    @patch("howler.services.case_service.datastore")
-    def test_append_hit_skips_emit_when_refetch_returns_none(self, mock_ds_fn, mock_events, mock_sync):
-        """append_hit does not emit when the re-fetch returns None."""
-        mock_ds = MagicMock()
-        mock_ds_fn.return_value = mock_ds
-
-        mock_case = Case({"case_id": "case-001", "title": "T", "summary": "S", "overview": "O", "escalation": "normal"})
-        mock_hit = MagicMock()
-        mock_hit.classification = CLASSIFICATION.UNRESTRICTED
-        mock_hit.howler.related = []
-        mock_hit.howler.id = "hit-001"
-
-        # First get returns the case, second get (refetch) returns None
-        mock_ds.case.get.side_effect = [None]
-        mock_ds.hit.get.return_value = mock_hit
-        mock_ds.case.save.return_value = True
-
-        item = CaseItem({"type": "hit", "value": "hit-001", "name": "test"})
-        case_service.append_hit(mock_case, item)
-
-        mock_events.emit.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -2096,8 +2062,8 @@ def _make_log_change(key: str, prev: str, new: str, timestamp: str) -> CaseLog:
 class TestCaseItemClassificationPropagation:
     """Tests that append_hit / append_event copy the record's classification onto the item."""
 
-    @patch("howler.services.case_service._sync_case_metadata")
-    @patch("howler.services.case_service._add_backreference")
+    @patch("howler.services.case_service.recompute_case_metadata")
+    @patch("howler.services.case_service.add_backreference")
     @patch("howler.services.case_service.datastore")
     def test_append_hit_copies_classification(self, mock_ds_fn, _mock_backref, _mock_sync):
         """append_hit sets item.classification from the fetched hit."""
@@ -2119,8 +2085,8 @@ class TestCaseItemClassificationPropagation:
 
         assert item.classification.value == CLASSIFICATION.normalize_classification("RESTRICTED")
 
-    @patch("howler.services.case_service._sync_case_metadata")
-    @patch("howler.services.case_service._add_backreference")
+    @patch("howler.services.case_service.recompute_case_metadata")
+    @patch("howler.services.case_service.add_backreference")
     @patch("howler.services.case_service.datastore")
     def test_append_hit_overwrites_any_existing_classification(self, mock_ds_fn, _mock_backref, _mock_sync):
         """append_hit overwrites any classification already set on the item with the hit's value."""
@@ -2142,8 +2108,8 @@ class TestCaseItemClassificationPropagation:
 
         assert item.classification.value == CLASSIFICATION.normalize_classification("UNRESTRICTED")
 
-    @patch("howler.services.case_service._sync_case_metadata")
-    @patch("howler.services.case_service._add_backreference")
+    @patch("howler.services.case_service.recompute_case_metadata")
+    @patch("howler.services.case_service.add_backreference")
     @patch("howler.services.case_service.datastore")
     def test_append_event_copies_classification(self, mock_ds_fn, _mock_backref, _mock_sync):
         """append_event sets item.classification from the fetched event."""
@@ -2166,8 +2132,8 @@ class TestCaseItemClassificationPropagation:
 
         assert item.classification.value == CLASSIFICATION.normalize_classification("RESTRICTED")
 
-    @patch("howler.services.case_service._sync_case_metadata")
-    @patch("howler.services.case_service._add_backreference")
+    @patch("howler.services.case_service.recompute_case_metadata")
+    @patch("howler.services.case_service.add_backreference")
     @patch("howler.services.case_service.datastore")
     def test_append_event_copies_unrestricted_classification(self, mock_ds_fn, _mock_backref, _mock_sync):
         """append_event sets item.classification even when the event is UNRESTRICTED."""
@@ -2514,7 +2480,7 @@ class TestMoveCaseItem:
 class TestRemoveCaseItemsByIds:
     """Tests for case_service.remove_case_items."""
 
-    @patch("howler.services.case_service._sync_case_metadata")
+    @patch("howler.services.case_service.recompute_case_metadata")
     @patch("howler.services.case_service.datastore")
     def test_remove_item_by_id(self, mock_ds_fn, mock_sync):
         """remove_case_items removes a single item by its UUID."""
@@ -2575,7 +2541,7 @@ class TestRemoveCaseItemsByIds:
         with pytest.raises(InvalidDataException, match="not empty"):
             case_service.remove_case_items("case-001", [folder.id], force=False)
 
-    @patch("howler.services.case_service._sync_case_metadata")
+    @patch("howler.services.case_service.recompute_case_metadata")
     @patch("howler.services.case_service.datastore")
     def test_remove_non_empty_folder_with_force(self, mock_ds_fn, mock_sync):
         """remove_case_items with force=True removes a folder and its children."""
@@ -2810,6 +2776,29 @@ class TestGetParentFromPath:
         with pytest.raises(NotFoundException):
             case_service.get_parent_from_path(None, "some/path")
 
+    @patch("howler.odm.models.case.Case.save")
+    def test_deeply_nested_path_creates_all_folders_without_persisting(self, mock_save):
+        """With persist=False, every folder in a deep path is created in memory without saving."""
+        case = Case({"case_id": "case-001", "title": "T", "summary": "S", "overview": "O", "escalation": "normal"})
+        case.items = []
+
+        parts = ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j"]
+        result = case_service.get_parent_from_path(case, "/".join(parts), create_if_missing=True, persist=False)
+
+        mock_save.assert_not_called()
+
+        folders = [item for item in case.items if item.type == "folder"]
+        assert len(folders) == len(parts)
+
+        # Walk the returned leaf folder back up to the root via parent pointers.
+        names_leaf_to_root = []
+        current = result
+        while current is not None:
+            names_leaf_to_root.append(current.name)
+            current = next((item for item in case.items if item.id == current.parent), None)
+
+        assert names_leaf_to_root == list(reversed(parts))
+
 
 # ---------------------------------------------------------------------------
 # _check_conflicts()
@@ -2887,16 +2876,16 @@ class TestMoveCaseItemNameConflict:
 
 
 # ---------------------------------------------------------------------------
-# _sync_case_metadata() — missing hit
+# recompute_case_metadata() — missing hit
 # ---------------------------------------------------------------------------
 
 
 class TestSyncCaseMetadataMissingHit:
-    """Test _sync_case_metadata skips a hit item when the backing hit is not found."""
+    """Test recompute_case_metadata skips a hit item when the backing hit is not found."""
 
     @patch("howler.services.case_service.datastore")
     def test_sync_skips_hit_not_in_datastore(self, mock_ds_fn):
-        """_sync_case_metadata continues gracefully when ds.hit.get returns None."""
+        """recompute_case_metadata continues gracefully when ds.hit.get returns None."""
         mock_ds = MagicMock()
         mock_ds_fn.return_value = mock_ds
 
@@ -2904,13 +2893,12 @@ class TestSyncCaseMetadataMissingHit:
 
         mock_case = MagicMock()
         mock_case.items = [hit_item]
-        mock_case.save.return_value = True
 
         mock_ds.hit.get.return_value = None
 
-        case_service._sync_case_metadata(mock_case)
+        case_service.recompute_case_metadata(mock_case)
 
-        mock_case.save.assert_called_once()
+        mock_case.save.assert_not_called()
         assert mock_case.targets == []
         assert mock_case.threats == []
         assert mock_case.indicators == []

--- a/api/test/unit/services/test_case_service.py
+++ b/api/test/unit/services/test_case_service.py
@@ -2801,15 +2801,15 @@ class TestGetParentFromPath:
 
 
 # ---------------------------------------------------------------------------
-# _check_conflicts()
+# check_conflicts()
 # ---------------------------------------------------------------------------
 
 
 class TestCheckConflicts:
-    """Tests for case_service._check_conflicts."""
+    """Tests for case_service.check_conflicts."""
 
     def test_item_with_none_name_skips_conflict_check(self):
-        """_check_conflicts returns immediately without checking when item.name is None."""
+        """check_conflicts returns immediately without checking when item.name is None."""
         existing = CaseItem({"type": "hit", "value": "existing", "name": "taken"})
         mock_case = MagicMock()
         mock_case.items = [existing]
@@ -2818,7 +2818,7 @@ class TestCheckConflicts:
         item.name = None
 
         # Should not raise even though there is an item named "taken" in the case
-        case_service._check_conflicts(mock_case, item)
+        case_service.check_conflicts(mock_case, item)
 
 
 # ---------------------------------------------------------------------------

--- a/api/test/unit/services/test_case_service.py
+++ b/api/test/unit/services/test_case_service.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from howler.common.exceptions import HowlerValueError, InvalidDataException, NotFoundException
+from howler.common.exceptions import HowlerValueError, InvalidDataException, NotFoundException, ResourceExists
 from howler.config import CLASSIFICATION
 from howler.odm.models.case import Case, CaseItem, CaseRule
 from howler.odm.models.ecs.related import Related
@@ -69,7 +69,7 @@ class TestCreateCase:
         result = case_service.create_case({"title": "Title", "summary": "Summary"}, user=user)
 
         assert len(result.log) == 1
-        assert result.log[0].user == str(user)
+        assert result.log[0].user == user.uname
 
     @patch("howler.services.case_service.datastore")
     def test_create_case_no_user_defaults_to_system(self, _mock_ds_fn):
@@ -705,8 +705,8 @@ class TestAppendHit:
         mock_ds.case.save.assert_not_called()
 
     @patch("howler.services.case_service.datastore")
-    def test_append_hit_duplicate_raises(self, mock_ds_fn):
-        """append_case_item raises InvalidDataException when the destination already contains same name/parent."""
+    def test_append_hit_conflicting_name_is_disambiguated(self, mock_ds_fn):
+        """append_case_item disambiguates a hit name that conflicts with a sibling."""
         mock_ds = MagicMock()
         mock_ds_fn.return_value = mock_ds
 
@@ -717,7 +717,25 @@ class TestAppendHit:
         mock_ds.hit.get.return_value = MagicMock(classification=CLASSIFICATION.UNRESTRICTED)
 
         item = CaseItem({"type": "hit", "value": "hit-002", "name": "dup"})
-        with pytest.raises(InvalidDataException):
+        case_service.append_case_item("case-001", item=item)
+
+        assert item.name == "dup (hit-002)"
+        assert mock_case.items == [existing, item]
+
+    @patch("howler.services.case_service.datastore")
+    def test_append_hit_duplicate_value_raises(self, mock_ds_fn):
+        """append_case_item rejects a hit already present in the case."""
+        mock_ds = MagicMock()
+        mock_ds_fn.return_value = mock_ds
+
+        existing = CaseItem({"type": "hit", "value": "hit-001", "name": "existing"})
+        mock_case = MagicMock()
+        mock_case.case_id = "case-001"
+        mock_case.items = [existing]
+        mock_ds.case.get.return_value = mock_case
+
+        item = CaseItem({"type": "hit", "value": "hit-001", "name": "another name"})
+        with pytest.raises(InvalidDataException, match="already exists"):
             case_service.append_case_item("case-001", item=item)
 
 
@@ -784,8 +802,8 @@ class TestAppendEvent:
             case_service.append_event(mock_case, item)
 
     @patch("howler.services.case_service.datastore")
-    def test_append_event_duplicate_raises(self, mock_ds_fn):
-        """append_case_item raises InvalidDataException for duplicate destination name/parent."""
+    def test_append_event_conflicting_name_is_disambiguated(self, mock_ds_fn):
+        """append_case_item disambiguates an event name that conflicts with a sibling."""
         mock_ds = MagicMock()
         mock_ds_fn.return_value = mock_ds
 
@@ -796,8 +814,10 @@ class TestAppendEvent:
         mock_ds.event.get.return_value = MagicMock(classification=CLASSIFICATION.UNRESTRICTED)
 
         item = CaseItem({"type": "event", "value": "obs-002", "name": "dup"})
-        with pytest.raises(InvalidDataException):
-            case_service.append_case_item("case-001", item=item)
+        case_service.append_case_item("case-001", item=item)
+
+        assert item.name == "dup (obs-002)"
+        assert mock_case.items == [existing, item]
 
 
 # ---------------------------------------------------------------------------
@@ -1004,7 +1024,7 @@ class TestAppendReference:
 
     @patch("howler.services.case_service.datastore")
     def test_append_reference_duplicate_raises(self, mock_ds_fn):
-        """append_case_item raises InvalidDataException when destination sibling name already exists."""
+        """append_case_item raises ResourceExists when a reference name conflicts with a sibling."""
         mock_ds = MagicMock()
         mock_ds_fn.return_value = mock_ds
 
@@ -1014,7 +1034,7 @@ class TestAppendReference:
         mock_ds.case.get.return_value = mock_case
 
         item = CaseItem({"type": "reference", "value": "https://another.example.com", "name": "refs"})
-        with pytest.raises(InvalidDataException):
+        with pytest.raises(ResourceExists):
             case_service.append_case_item("case-001", item=item)
 
 
@@ -2312,7 +2332,7 @@ class TestAppendFolder:
 
     @patch("howler.services.case_service.datastore")
     def test_append_folder_duplicate_same_parent_raises(self, mock_ds_fn):
-        """append_case_item raises InvalidDataException for duplicate folder name under same parent."""
+        """append_case_item raises ResourceExists for a duplicate folder name under the same parent."""
         mock_ds = MagicMock()
         mock_ds_fn.return_value = mock_ds
 
@@ -2323,7 +2343,7 @@ class TestAppendFolder:
         mock_ds.case.get.return_value = mock_case
 
         item = CaseItem({"type": "folder", "name": "My Folder"})
-        with pytest.raises(InvalidDataException, match="already exists"):
+        with pytest.raises(ResourceExists, match="already exists"):
             case_service.append_case_item("case-001", item=item)
 
 

--- a/api/test/unit/services/test_correlation_service.py
+++ b/api/test/unit/services/test_correlation_service.py
@@ -249,11 +249,6 @@ class TestEnqueueForCorrelation:
         assert result[0][0] == "case-1"
 
 
-# ---------------------------------------------------------------------------
-# process_batch
-# ---------------------------------------------------------------------------
-
-
 def _make_case(case_id: str, items: list | None = None) -> MagicMock:
     case = MagicMock()
     case.case_id = case_id

--- a/api/test/unit/services/test_correlation_service.py
+++ b/api/test/unit/services/test_correlation_service.py
@@ -288,6 +288,7 @@ def _setup_ds(
     mock_ds.case.get.side_effect = lambda cid: cases.get(cid)
     mock_ds.hit.get.side_effect = lambda hid: (hits or {}).get(hid)
     mock_ds.event.get.side_effect = event_get
+    mock_ds.__getitem__.side_effect = lambda item_type: getattr(mock_ds, item_type)
 
     # Mirror ElasticBulkPlan.empty: starts empty, flips once an operation is queued.
     bulk_plan = mock_ds.case.get_bulk_plan.return_value

--- a/api/test/unit/services/test_correlation_service.py
+++ b/api/test/unit/services/test_correlation_service.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from howler.common.exceptions import HowlerRuntimeError
 from howler.config import CLASSIFICATION
 from howler.odm.models.case import CaseItem, CaseRule
 from howler.services import correlation_service
@@ -687,3 +688,59 @@ class TestProcessBatch:
 
         assert added == 0
         mock_ds.case.bulk.assert_not_called()
+
+
+class TestCorrelationUnreachableBranches:
+    """Cover correlation states that require controlled fault injection."""
+
+    def test_missing_item_name_falls_back_to_record_id(self):
+        """An item with no rendered name uses its record ID."""
+        case = MagicMock(items=[])
+        backing_obj = _make_backing_obj()
+        item = MagicMock(type="hit", value="hit-1")
+        item.name = None
+        rule = _make_rule(destination="related")
+
+        with (
+            patch.object(correlation_service, "CaseItem", return_value=item),
+            patch.object(correlation_service, "_resolve_backing_object", return_value=backing_obj),
+            patch.object(correlation_service.case_service, "get_parent_from_path", return_value=None),
+            patch.object(correlation_service.case_service, "check_conflicts", return_value=False),
+            patch.object(correlation_service.case_service, "add_backreference", return_value=False),
+        ):
+            added = correlation_service._add_record_to_case(
+                case,
+                "case-1",
+                {"howler": {"id": "hit-1"}},
+                rule,
+                {},
+                set(),
+            )
+
+        assert added is True
+        assert item.name == "hit-1"
+        assert case.items == [item]
+
+    @patch("howler.services.correlation_service.search_service")
+    @patch("howler.services.correlation_service.get_active_rules")
+    @patch("howler.services.correlation_service.datastore")
+    def test_bulk_failure_raises_runtime_error(self, mock_ds_fn, mock_get_rules, mock_search_svc):
+        """A failed bulk case update is surfaced to the caller."""
+        case = _make_case("case-1")
+        datastore = _setup_ds(mock_ds_fn, {"case-1": case}, hits={"hit-1": _make_backing_obj()})
+        datastore.case.bulk.return_value = False
+        datastore.case.get_bulk_plan.return_value.empty = False
+        datastore.case.get_bulk_plan.return_value.operations = ["update"]
+
+        mock_get_rules.return_value = [("case-1", _make_rule(destination="related"))]
+        mock_search_svc.search.return_value = {
+            "items": [{"howler": {"id": "hit-1"}, "__index": "hit"}],
+            "total": 1,
+            "offset": 0,
+            "rows": 1,
+        }
+
+        with pytest.raises(HowlerRuntimeError, match="Bulk case update reported errors"):
+            correlation_service.process_batch(["hit-1"])
+
+        datastore.case.bulk.assert_called_once()

--- a/api/test/unit/services/test_correlation_service.py
+++ b/api/test/unit/services/test_correlation_service.py
@@ -6,8 +6,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from howler.common.exceptions import InvalidDataException, NotFoundException
-from howler.odm.models.case import CaseRule
+from howler.config import CLASSIFICATION
+from howler.odm.models.case import CaseItem, CaseRule
 from howler.services import correlation_service
 
 # ---------------------------------------------------------------------------
@@ -253,17 +253,66 @@ class TestEnqueueForCorrelation:
 # ---------------------------------------------------------------------------
 
 
+def _make_case(case_id: str, items: list | None = None) -> MagicMock:
+    case = MagicMock()
+    case.case_id = case_id
+    case.items = items if items is not None else []
+    return case
+
+
+def _make_backing_obj(classification: str = CLASSIFICATION.UNRESTRICTED) -> MagicMock:
+    """A stand-in for a Hit/Event with just enough shape for backreference/metadata sync."""
+    obj = MagicMock()
+    obj.classification = classification
+    obj.related = None
+    obj.howler.related = []
+    obj.howler.outline = None
+    return obj
+
+
+def _setup_ds(
+    mock_ds_fn: MagicMock,
+    cases: dict[str, MagicMock],
+    hits: dict[str, MagicMock] | None = None,
+    events: dict[str, MagicMock] | None = None,
+) -> MagicMock:
+    """Wire up a mocked datastore whose case/hit/event `.get()` calls resolve from dicts."""
+    mock_ds = MagicMock()
+    mock_ds_fn.return_value = mock_ds
+
+    def event_get(*args, **kwargs):
+        key = args[0] if args else kwargs.get("key")
+        return (events or {}).get(key)
+
+    mock_ds.case.get.side_effect = lambda cid: cases.get(cid)
+    mock_ds.hit.get.side_effect = lambda hid: (hits or {}).get(hid)
+    mock_ds.event.get.side_effect = event_get
+
+    # Mirror ElasticBulkPlan.empty: starts empty, flips once an operation is queued.
+    bulk_plan = mock_ds.case.get_bulk_plan.return_value
+    bulk_plan.empty = True
+
+    def _mark_not_empty(*args, **kwargs):
+        bulk_plan.empty = False
+
+    bulk_plan.add_update_operation.side_effect = _mark_not_empty
+    bulk_plan.add_index_operation.side_effect = _mark_not_empty
+
+    return mock_ds
+
+
 class TestProcessBatch:
     """Tests for correlation_service.process_batch."""
 
+    @patch("howler.services.correlation_service.comms_service")
     @patch("howler.services.correlation_service.search_service")
-    @patch("howler.services.correlation_service.case_service")
     @patch("howler.services.correlation_service.get_active_rules")
     @patch("howler.services.correlation_service.datastore")
-    def test_adds_matching_hits(self, mock_ds_fn, mock_get_rules, mock_case_svc, mock_search_svc):
-        """Matching hits are added to the case via append_case_item."""
-        mock_ds = MagicMock()
-        mock_ds_fn.return_value = mock_ds
+    def test_adds_matching_hits(self, mock_ds_fn, mock_get_rules, mock_search_svc, mock_comms):
+        """Matching hits are accumulated onto the case and flushed in a single bulk call."""
+        case = _make_case("case-1")
+        hit = _make_backing_obj()
+        mock_ds = _setup_ds(mock_ds_fn, {"case-1": case}, hits={"hit-1": hit})
 
         rule = _make_rule(query="event.kind:alert", destination="alerts")
         mock_get_rules.return_value = [("case-1", rule)]
@@ -278,20 +327,29 @@ class TestProcessBatch:
         added = correlation_service.process_batch(["hit-1"])
 
         assert added == 1
-        mock_case_svc.append_case_item.assert_called_once()
-        kwargs = mock_case_svc.append_case_item.call_args.kwargs
-        assert kwargs["item_type"] == "hit"
-        assert kwargs["item_value"] == "hit-1"
-        assert kwargs["item_name"] == "alerts"
+        assert len(case.items) == 1
+        assert case.items[0].type == "hit"
+        assert case.items[0].value == "hit-1"
+        assert case.items[0].name == "alerts"
 
+        assert "case-1" in hit.howler.related
+        hit.save.assert_called_once()
+
+        mock_ds.case.get_bulk_plan.return_value.add_update_operation.assert_called_once_with(
+            "case-1", case, fields=["items", "targets", "threats", "indicators"]
+        )
+        mock_ds.case.bulk.assert_called_once()
+        mock_comms.emit.assert_called_once_with("cases", {"case": case.as_primitives()})
+
+    @patch("howler.services.correlation_service.comms_service")
     @patch("howler.services.correlation_service.search_service")
-    @patch("howler.services.correlation_service.case_service")
     @patch("howler.services.correlation_service.get_active_rules")
     @patch("howler.services.correlation_service.datastore")
-    def test_skips_duplicates(self, mock_ds_fn, mock_get_rules, mock_case_svc, mock_search_svc):
-        """Duplicate records (InvalidDataException) are silently skipped."""
-        mock_ds = MagicMock()
-        mock_ds_fn.return_value = mock_ds
+    def test_skips_duplicates(self, mock_ds_fn, mock_get_rules, mock_search_svc, mock_comms):
+        """Records that would conflict with an existing item are silently skipped."""
+        existing = CaseItem({"type": "hit", "value": "hit-0", "name": "related"})
+        case = _make_case("case-1", items=[existing])
+        mock_ds = _setup_ds(mock_ds_fn, {"case-1": case})
 
         rule = _make_rule(query="*:*", destination="related")
         mock_get_rules.return_value = [("case-1", rule)]
@@ -302,20 +360,22 @@ class TestProcessBatch:
             "offset": 0,
             "rows": 1,
         }
-        mock_case_svc.append_case_item.side_effect = InvalidDataException("already exists")
 
         added = correlation_service.process_batch(["hit-1"])
 
         assert added == 0
+        assert case.items == [existing]
+        mock_ds.case.bulk.assert_not_called()
 
+    @patch("howler.services.correlation_service.comms_service")
     @patch("howler.services.correlation_service.search_service")
-    @patch("howler.services.correlation_service.case_service")
     @patch("howler.services.correlation_service.get_active_rules")
     @patch("howler.services.correlation_service.datastore")
-    def test_renders_destination_template(self, mock_ds_fn, mock_get_rules, mock_case_svc, mock_search_svc):
+    def test_renders_destination_template(self, mock_ds_fn, mock_get_rules, mock_search_svc, mock_comms):
         """Mustache templates in destination are rendered with record data."""
-        mock_ds = MagicMock()
-        mock_ds_fn.return_value = mock_ds
+        case = _make_case("case-1")
+        hit = _make_backing_obj()
+        _setup_ds(mock_ds_fn, {"case-1": case}, hits={"hit-1": hit})
 
         rule = _make_rule(query="*:*", destination="alerts/{{howler.analytic}}")
         mock_get_rules.return_value = [("case-1", rule)]
@@ -329,41 +389,83 @@ class TestProcessBatch:
 
         correlation_service.process_batch(["hit-1"])
 
-        mock_case_svc.append_case_item.assert_called_once()
-        kwargs = mock_case_svc.append_case_item.call_args.kwargs
-        assert kwargs["item_type"] == "hit"
-        assert kwargs["item_value"] == "hit-1"
-        assert kwargs["item_name"] == "My Detection"
+        hit_items = [i for i in case.items if i.type == "hit"]
+        assert len(hit_items) == 1
+        assert hit_items[0].name == "My Detection"
 
-    @patch("howler.services.correlation_service.case_service")
+        folder_items = [i for i in case.items if i.type == "folder"]
+        assert len(folder_items) == 1
+        assert folder_items[0].name == "alerts"
+
+    @patch("howler.services.correlation_service.comms_service")
+    @patch("howler.services.correlation_service.search_service")
     @patch("howler.services.correlation_service.get_active_rules")
     @patch("howler.services.correlation_service.datastore")
-    def test_returns_zero_when_no_records(self, mock_ds_fn, mock_get_rules, mock_case_svc):
+    def test_deeply_nested_destination_persists_all_new_folders(
+        self, mock_ds_fn, mock_get_rules, mock_search_svc, mock_comms
+    ):
+        """Every folder created along a deep destination path is included in the bulk-persisted case."""
+        case = _make_case("case-1")
+        hit = _make_backing_obj()
+        mock_ds = _setup_ds(mock_ds_fn, {"case-1": case}, hits={"hit-1": hit})
+
+        parts = ["a", "b", "c", "d", "e", "f", "g", "h"]
+        rule = _make_rule(query="*:*", destination="/".join(parts) + "/{{howler.id}}")
+        mock_get_rules.return_value = [("case-1", rule)]
+
+        mock_search_svc.search.return_value = {
+            "items": [{"howler": {"id": "hit-1"}, "__index": "hit"}],
+            "total": 1,
+            "offset": 0,
+            "rows": 1,
+        }
+
+        added = correlation_service.process_batch(["hit-1"])
+
+        assert added == 1
+
+        # The exact case object mutated in memory is what gets handed to the bulk plan, so its
+        # folders are part of the single persisted document rather than requiring separate saves.
+        mock_ds.case.get_bulk_plan.return_value.add_update_operation.assert_called_once_with(
+            "case-1", case, fields=["items", "targets", "threats", "indicators"]
+        )
+        mock_ds.case.bulk.assert_called_once()
+
+        folders = [i for i in case.items if i.type == "folder"]
+        assert len(folders) == len(parts)
+
+        names_leaf_to_root = []
+        current = next(i for i in case.items if i.type == "hit")
+        while current is not None:
+            names_leaf_to_root.append(current.name)
+            current = next((i for i in case.items if i.id == current.parent), None)
+
+        assert names_leaf_to_root[1:] == list(reversed(parts))
+
+    def test_returns_zero_when_no_records(self):
         """An empty record_ids list returns 0 without querying."""
         added = correlation_service.process_batch([])
         assert added == 0
-        mock_case_svc.append_case_item.assert_not_called()
 
-    @patch("howler.services.correlation_service.case_service")
     @patch("howler.services.correlation_service.get_active_rules")
     @patch("howler.services.correlation_service.datastore")
-    def test_returns_zero_when_no_rules(self, mock_ds_fn, mock_get_rules, mock_case_svc):
+    def test_returns_zero_when_no_rules(self, mock_ds_fn, mock_get_rules):
         """Returns 0 when there are no active rules."""
+        mock_ds_fn.return_value = MagicMock()
         mock_get_rules.return_value = []
 
         added = correlation_service.process_batch(["hit-1"])
 
         assert added == 0
-        mock_case_svc.append_case_item.assert_not_called()
 
+    @patch("howler.services.correlation_service.comms_service")
     @patch("howler.services.correlation_service.search_service")
-    @patch("howler.services.correlation_service.case_service")
     @patch("howler.services.correlation_service.get_active_rules")
     @patch("howler.services.correlation_service.datastore")
-    def test_handles_not_found_gracefully(self, mock_ds_fn, mock_get_rules, mock_case_svc, mock_search_svc):
-        """NotFoundException from append_case_item is logged, not raised."""
-        mock_ds = MagicMock()
-        mock_ds_fn.return_value = mock_ds
+    def test_handles_not_found_gracefully(self, mock_ds_fn, mock_get_rules, mock_search_svc, mock_comms):
+        """A missing backing hit/event is logged and does not raise, nor does it flush a bulk update."""
+        case = _make_case("case-1")
+        mock_ds = _setup_ds(mock_ds_fn, {"case-1": case})
 
         rule = _make_rule(query="*:*", destination="related")
         mock_get_rules.return_value = [("case-1", rule)]
@@ -374,20 +476,23 @@ class TestProcessBatch:
             "offset": 0,
             "rows": 1,
         }
-        mock_case_svc.append_case_item.side_effect = NotFoundException("gone")
 
         added = correlation_service.process_batch(["hit-1"])
 
         assert added == 0
+        assert case.items == []
+        mock_ds.case.bulk.assert_not_called()
 
+    @patch("howler.services.correlation_service.comms_service")
     @patch("howler.services.correlation_service.search_service")
-    @patch("howler.services.correlation_service.case_service")
     @patch("howler.services.correlation_service.get_active_rules")
     @patch("howler.services.correlation_service.datastore")
-    def test_continues_after_es_query_failure(self, mock_ds_fn, mock_get_rules, mock_case_svc, mock_search_svc):
+    def test_continues_after_es_query_failure(self, mock_ds_fn, mock_get_rules, mock_search_svc, mock_comms):
         """An ES query failure for one rule doesn't block subsequent rules."""
-        mock_ds = MagicMock()
-        mock_ds_fn.return_value = mock_ds
+        case1 = _make_case("case-1")
+        case2 = _make_case("case-2")
+        hit = _make_backing_obj()
+        _setup_ds(mock_ds_fn, {"case-1": case1, "case-2": case2}, hits={"hit-1": hit})
 
         rule_bad = _make_rule(query="invalid(", destination="a")
         rule_good = _make_rule(query="*:*", destination="b")
@@ -401,22 +506,23 @@ class TestProcessBatch:
         added = correlation_service.process_batch(["hit-1"])
 
         assert added == 1
-        mock_case_svc.append_case_item.assert_called_once()
-        kwargs = mock_case_svc.append_case_item.call_args.kwargs
-        assert kwargs["item_type"] == "hit"
-        assert kwargs["item_value"] == "hit-1"
+        assert case1.items == []
+        assert len(case2.items) == 1
+        assert case2.items[0].value == "hit-1"
 
+    @patch("howler.services.correlation_service.comms_service")
     @patch("howler.services.correlation_service.search_service")
-    @patch("howler.services.correlation_service.case_service")
     @patch("howler.services.correlation_service.get_active_rules")
     @patch("howler.services.correlation_service.datastore")
-    def test_multiple_records_multiple_rules(self, mock_ds_fn, mock_get_rules, mock_case_svc, mock_search_svc):
-        """Multiple records can match across multiple rules."""
-        mock_ds = MagicMock()
-        mock_ds_fn.return_value = mock_ds
+    def test_multiple_records_multiple_rules(self, mock_ds_fn, mock_get_rules, mock_search_svc, mock_comms):
+        """Multiple records can match across multiple rules and cases in a single bulk flush."""
+        case1 = _make_case("case-1")
+        case2 = _make_case("case-2")
+        hits = {"hit-1": _make_backing_obj(), "hit-2": _make_backing_obj(), "hit-3": _make_backing_obj()}
+        mock_ds = _setup_ds(mock_ds_fn, {"case-1": case1, "case-2": case2}, hits=hits)
 
-        rule_a = _make_rule(query="event.kind:alert", destination="alerts")
-        rule_b = _make_rule(query="event.kind:event", destination="events")
+        rule_a = _make_rule(query="event.kind:alert", destination="alerts/{{howler.id}}")
+        rule_b = _make_rule(query="event.kind:event", destination="events/{{howler.id}}")
         mock_get_rules.return_value = [("case-1", rule_a), ("case-2", rule_b)]
 
         mock_search_svc.search.side_effect = [
@@ -440,21 +546,22 @@ class TestProcessBatch:
         added = correlation_service.process_batch(["hit-1", "hit-2", "hit-3"])
 
         assert added == 3
+        assert len([i for i in case1.items if i.type == "hit"]) == 2
+        assert len([i for i in case2.items if i.type == "hit"]) == 1
+        assert mock_ds.case.get_bulk_plan.return_value.add_update_operation.call_count == 2
+        mock_ds.case.bulk.assert_called_once()
 
+    @patch("howler.services.correlation_service.comms_service")
     @patch("howler.services.correlation_service.search_service")
-    @patch("howler.services.correlation_service.case_service")
     @patch("howler.services.correlation_service.get_active_rules")
     @patch("howler.services.correlation_service.datastore")
-    def test_adds_matching_events(self, mock_ds_fn, mock_get_rules, mock_case_svc, mock_search_svc):
-        """Matching events are added to the case with item_type='event'.."""
-        mock_ds = MagicMock()
-        mock_ds_fn.return_value = mock_ds
+    def test_adds_matching_events(self, mock_ds_fn, mock_get_rules, mock_search_svc, mock_comms):
+        """Matching events are added to the case with item type 'event'."""
+        case = _make_case("case-1")
+        event = _make_backing_obj()
+        _setup_ds(mock_ds_fn, {"case-1": case}, events={"obs-1": event})
 
-        rule = _make_rule(
-            query="event.kind:enrichment",
-            destination="events",
-            indexes=["event"],
-        )
+        rule = _make_rule(query="event.kind:enrichment", destination="events", indexes=["event"])
         mock_get_rules.return_value = [("case-1", rule)]
 
         mock_search_svc.search.return_value = {
@@ -467,25 +574,26 @@ class TestProcessBatch:
         added = correlation_service.process_batch(["obs-1"])
 
         assert added == 1
-        mock_case_svc.append_case_item.assert_called_once()
-        kwargs = mock_case_svc.append_case_item.call_args.kwargs
-        assert kwargs["item_type"] == "event"
-        assert kwargs["item_value"] == "obs-1"
+        event_items = [i for i in case.items if i.type == "event"]
+        assert len(event_items) == 1
+        assert event_items[0].value == "obs-1"
+        assert "case-1" in event.howler.related
 
+    @patch("howler.services.correlation_service.comms_service")
     @patch("howler.services.correlation_service.search_service")
-    @patch("howler.services.correlation_service.case_service")
     @patch("howler.services.correlation_service.get_active_rules")
     @patch("howler.services.correlation_service.datastore")
-    def test_searches_both_indexes(self, mock_ds_fn, mock_get_rules, mock_case_svc, mock_search_svc):
+    def test_searches_both_indexes(self, mock_ds_fn, mock_get_rules, mock_search_svc, mock_comms):
         """A rule targeting both hit and event indexes searches across both."""
-        mock_ds = MagicMock()
-        mock_ds_fn.return_value = mock_ds
-
-        rule = _make_rule(
-            query="*:*",
-            destination="related",
-            indexes=["hit", "event"],
+        case = _make_case("case-1")
+        _setup_ds(
+            mock_ds_fn,
+            {"case-1": case},
+            hits={"hit-1": _make_backing_obj()},
+            events={"obs-1": _make_backing_obj()},
         )
+
+        rule = _make_rule(query="*:*", destination="related/{{howler.id}}", indexes=["hit", "event"])
         mock_get_rules.return_value = [("case-1", rule)]
 
         mock_search_svc.search.return_value = {
@@ -505,18 +613,17 @@ class TestProcessBatch:
         call_kwargs = mock_search_svc.search.call_args
         assert set(call_kwargs.kwargs["indexes"]) == {"hit", "event"}
 
-        calls = mock_case_svc.append_case_item.call_args_list
-        types = {c.kwargs["item_type"] for c in calls}
+        types = {i.type for i in case.items if i.type != "folder"}
         assert types == {"hit", "event"}
 
+    @patch("howler.services.correlation_service.comms_service")
     @patch("howler.services.correlation_service.search_service")
-    @patch("howler.services.correlation_service.case_service")
     @patch("howler.services.correlation_service.get_active_rules")
     @patch("howler.services.correlation_service.datastore")
-    def test_defaults_to_hit_index_when_indexes_empty(self, mock_ds_fn, mock_get_rules, mock_case_svc, mock_search_svc):
+    def test_defaults_to_hit_index_when_indexes_empty(self, mock_ds_fn, mock_get_rules, mock_search_svc, mock_comms):
         """When indexes is empty, the rule defaults to searching the hit index."""
-        mock_ds = MagicMock()
-        mock_ds_fn.return_value = mock_ds
+        case = _make_case("case-1")
+        _setup_ds(mock_ds_fn, {"case-1": case}, hits={"hit-1": _make_backing_obj()})
 
         rule = _make_rule(query="*:*", destination="related", indexes=[])
         mock_get_rules.return_value = [("case-1", rule)]
@@ -533,16 +640,21 @@ class TestProcessBatch:
         call_kwargs = mock_search_svc.search.call_args
         assert call_kwargs.kwargs["indexes"] == ["hit"]
 
+    @patch("howler.services.correlation_service.comms_service")
     @patch("howler.services.correlation_service.search_service")
-    @patch("howler.services.correlation_service.case_service")
     @patch("howler.services.correlation_service.get_active_rules")
     @patch("howler.services.correlation_service.datastore")
-    def test_item_type_derived_from_index(self, mock_ds_fn, mock_get_rules, mock_case_svc, mock_search_svc):
-        """The item_type passed to append_case_item matches the __index of the record."""
-        mock_ds = MagicMock()
-        mock_ds_fn.return_value = mock_ds
+    def test_item_type_derived_from_index(self, mock_ds_fn, mock_get_rules, mock_search_svc, mock_comms):
+        """The item type added to the case matches the __index of the record."""
+        case = _make_case("case-1")
+        _setup_ds(
+            mock_ds_fn,
+            {"case-1": case},
+            hits={"hit-1": _make_backing_obj()},
+            events={"obs-1": _make_backing_obj()},
+        )
 
-        rule = _make_rule(query="*:*", destination="items", indexes=["hit", "event"])
+        rule = _make_rule(query="*:*", destination="items/{{howler.id}}", indexes=["hit", "event"])
         mock_get_rules.return_value = [("case-1", rule)]
 
         mock_search_svc.search.return_value = {
@@ -557,23 +669,16 @@ class TestProcessBatch:
 
         correlation_service.process_batch(["hit-1", "obs-1"])
 
-        calls = mock_case_svc.append_case_item.call_args_list
-        assert len(calls) == 2
+        hit_item = next(i for i in case.items if i.value == "hit-1")
+        obs_item = next(i for i in case.items if i.value == "obs-1")
+        assert hit_item.type == "hit"
+        assert obs_item.type == "event"
 
-        hit_call = [c for c in calls if c.kwargs["item_value"] == "hit-1"][0]
-        obs_call = [c for c in calls if c.kwargs["item_value"] == "obs-1"][0]
-        assert hit_call.kwargs["item_type"] == "hit"
-        assert obs_call.kwargs["item_type"] == "event"
-
-    @patch("howler.services.correlation_service.search_service")
-    @patch("howler.services.correlation_service.case_service")
     @patch("howler.services.correlation_service.get_active_rules")
     @patch("howler.services.correlation_service.datastore")
-    def test_skips_rule_when_case_not_found(self, mock_ds_fn, mock_get_rules, mock_case_svc, mock_search_svc):
+    def test_skips_rule_when_case_not_found(self, mock_ds_fn, mock_get_rules):
         """When ds.case.get returns None for a case, the rule is skipped and no items are added."""
-        mock_ds = MagicMock()
-        mock_ds_fn.return_value = mock_ds
-        mock_ds.case.get.return_value = None
+        mock_ds = _setup_ds(mock_ds_fn, {})
 
         rule = _make_rule(query="*:*", destination="related")
         mock_get_rules.return_value = [("case-missing", rule)]
@@ -581,4 +686,4 @@ class TestProcessBatch:
         added = correlation_service.process_batch(["hit-1"])
 
         assert added == 0
-        mock_case_svc.append_case_item.assert_not_called()
+        mock_ds.case.bulk.assert_not_called()

--- a/api/test/unit/services/test_correlation_service.py
+++ b/api/test/unit/services/test_correlation_service.py
@@ -334,7 +334,10 @@ class TestProcessBatch:
         assert case.items[0].name == "alerts"
 
         assert "case-1" in hit.howler.related
-        hit.save.assert_called_once()
+        mock_ds.hit.get_bulk_plan.return_value.add_update_operation.assert_called_once_with(
+            "hit-1", hit, fields=["howler.related"]
+        )
+        mock_ds.hit.bulk.assert_called_once_with(mock_ds.hit.get_bulk_plan.return_value)
 
         mock_ds.case.get_bulk_plan.return_value.add_update_operation.assert_called_once_with(
             "case-1", case, fields=["items", "targets", "threats", "indicators"]
@@ -579,6 +582,11 @@ class TestProcessBatch:
         assert len(event_items) == 1
         assert event_items[0].value == "obs-1"
         assert "case-1" in event.howler.related
+        mock_ds = mock_ds_fn.return_value
+        mock_ds.event.get_bulk_plan.return_value.add_update_operation.assert_called_once_with(
+            "obs-1", event, fields=["howler.related"]
+        )
+        mock_ds.event.bulk.assert_called_once_with(mock_ds.event.get_bulk_plan.return_value)
 
     @patch("howler.services.correlation_service.comms_service")
     @patch("howler.services.correlation_service.search_service")
@@ -706,18 +714,13 @@ class TestCorrelationUnreachableBranches:
             patch.object(correlation_service, "_resolve_backing_object", return_value=backing_obj),
             patch.object(correlation_service.case_service, "get_parent_from_path", return_value=None),
             patch.object(correlation_service.case_service, "check_conflicts", return_value=False),
-            patch.object(correlation_service.case_service, "add_backreference", return_value=False),
+            patch.object(correlation_service.case_service, "add_backreference", return_value=True),
         ):
-            added = correlation_service._add_record_to_case(
-                case,
-                "case-1",
-                {"howler": {"id": "hit-1"}},
-                rule,
-                {},
-                set(),
-            )
+            added = correlation_service._add_record_to_case(case, "case-1", {"howler": {"id": "hit-1"}}, rule, {})
 
-        assert added is True
+        assert added is not None
+        assert added[0] == "hit"
+        assert added[1] == "hit-1"
         assert item.name == "hit-1"
         assert case.items == [item]
 

--- a/api/test/unit/services/test_event_service.py
+++ b/api/test/unit/services/test_event_service.py
@@ -305,3 +305,23 @@ def test_create_event_increments_counter(mock_exists, mock_datastore):
     after = event_service.CREATED_EVENTS._value.get()
 
     assert after == before + 1
+
+
+@patch("howler.services.event_service.datastore")
+def test_create_events_uses_event_collection(mock_datastore):
+    """Bulk event ingestion checks and writes the event collection."""
+    storage = mock_datastore.return_value
+    storage.event.exists.return_value = False
+    storage.event.bulk.return_value = True
+    bulk_plan = storage.event.get_bulk_plan.return_value
+    event = Event(SAMPLE_EVENT_DATA)
+
+    result = event_service.create_events([event], user="test_user", refresh="wait_for")
+
+    assert result is True
+    storage.event.exists.assert_called_once_with(event.howler.id)
+    bulk_plan.add_insert_operation.assert_called_once_with(event.howler.id, event)
+    storage.event.bulk.assert_called_once_with(bulk_plan, refresh="wait_for")
+    storage.hit.exists.assert_not_called()
+    storage.hit.bulk.assert_not_called()
+    assert event.howler.log[0].user == "test_user"

--- a/api/test/unit/services/test_ingest_correlation.py
+++ b/api/test/unit/services/test_ingest_correlation.py
@@ -204,8 +204,8 @@ class TestIngestedAlertsCorrelation:
     @patch("howler.services.correlation_service.get_active_rules")
     @patch("howler.services.correlation_service.datastore")
     def test_duplicate_alert_skipped(self, mock_ds_fn, mock_get_rules, mock_search_svc, mock_comms):
-        """An alert that would conflict with an already-present item is skipped."""
-        existing = CaseItem({"type": "hit", "value": "hit-existing", "name": "related"})
+        """An alert already present in the case is skipped."""
+        existing = CaseItem({"type": "hit", "value": "hit-dup", "name": "related"})
         case = _make_case("case-1", items=[existing])
         _setup_ds(mock_ds_fn, {"case-1": case}, hits={"hit-dup": _make_backing_obj()})
 

--- a/api/test/unit/services/test_ingest_correlation.py
+++ b/api/test/unit/services/test_ingest_correlation.py
@@ -8,8 +8,8 @@ ingest.py (producer) and correlation_service.process_batch (consumer).
 from typing import Any
 from unittest.mock import MagicMock, patch
 
-from howler.common.exceptions import InvalidDataException
-from howler.odm.models.case import CaseRule
+from howler.config import CLASSIFICATION
+from howler.odm.models.case import CaseItem, CaseRule
 from howler.services import correlation_service
 
 # ---------------------------------------------------------------------------
@@ -36,6 +36,54 @@ def _make_rule(
     return CaseRule(data)
 
 
+def _make_case(case_id: str, items: list | None = None) -> MagicMock:
+    case = MagicMock()
+    case.case_id = case_id
+    case.items = items if items is not None else []
+    return case
+
+
+def _make_backing_obj(classification: str = CLASSIFICATION.UNRESTRICTED) -> MagicMock:
+    """A stand-in for a Hit/Event with just enough shape for backreference/metadata sync."""
+    obj = MagicMock()
+    obj.classification = classification
+    obj.related = None
+    obj.howler.related = []
+    obj.howler.outline = None
+    return obj
+
+
+def _setup_ds(
+    mock_ds_fn: MagicMock,
+    cases: dict[str, MagicMock],
+    hits: dict[str, MagicMock] | None = None,
+    events: dict[str, MagicMock] | None = None,
+) -> MagicMock:
+    """Wire up a mocked datastore whose case/hit/event `.get()` calls resolve from dicts."""
+    mock_ds = MagicMock()
+    mock_ds_fn.return_value = mock_ds
+
+    def event_get(*args, **kwargs):
+        key = args[0] if args else kwargs.get("key")
+        return (events or {}).get(key)
+
+    mock_ds.case.get.side_effect = lambda cid: cases.get(cid)
+    mock_ds.hit.get.side_effect = lambda hid: (hits or {}).get(hid)
+    mock_ds.event.get.side_effect = event_get
+
+    # Mirror ElasticBulkPlan.empty: starts empty, flips once an operation is queued.
+    bulk_plan = mock_ds.case.get_bulk_plan.return_value
+    bulk_plan.empty = True
+
+    def _mark_not_empty(*args, **kwargs):
+        bulk_plan.empty = False
+
+    bulk_plan.add_update_operation.side_effect = _mark_not_empty
+    bulk_plan.add_index_operation.side_effect = _mark_not_empty
+
+    return mock_ds
+
+
 # ---------------------------------------------------------------------------
 # Ingested alerts are correlated
 # ---------------------------------------------------------------------------
@@ -44,14 +92,14 @@ def _make_rule(
 class TestIngestedAlertsCorrelation:
     """Verify that alerts (hits) ingested via the API reach the correlation service."""
 
+    @patch("howler.services.correlation_service.comms_service")
     @patch("howler.services.correlation_service.search_service")
-    @patch("howler.services.correlation_service.case_service")
     @patch("howler.services.correlation_service.get_active_rules")
     @patch("howler.services.correlation_service.datastore")
-    def test_single_alert_matches_rule(self, mock_ds_fn, mock_get_rules, mock_case_svc, mock_search_svc):
+    def test_single_alert_matches_rule(self, mock_ds_fn, mock_get_rules, mock_search_svc, mock_comms):
         """A single ingested alert ID that matches a rule is appended to the case."""
-        mock_ds = MagicMock()
-        mock_ds_fn.return_value = mock_ds
+        case = _make_case("case-1")
+        _setup_ds(mock_ds_fn, {"case-1": case}, hits={"ingested-hit-1": _make_backing_obj()})
 
         rule = _make_rule(query="event.kind:alert", destination="alerts/incoming")
         mock_get_rules.return_value = [("case-1", rule)]
@@ -66,22 +114,21 @@ class TestIngestedAlertsCorrelation:
         added = correlation_service.process_batch(["ingested-hit-1"])
 
         assert added == 1
-        mock_case_svc.append_case_item.assert_called_once()
-        kwargs = mock_case_svc.append_case_item.call_args.kwargs
-        assert kwargs["item_type"] == "hit"
-        assert kwargs["item_value"] == "ingested-hit-1"
-        assert kwargs["item_name"] == "incoming"
+        hit_item = next(i for i in case.items if i.type == "hit")
+        assert hit_item.value == "ingested-hit-1"
+        assert hit_item.name == "incoming"
 
+    @patch("howler.services.correlation_service.comms_service")
     @patch("howler.services.correlation_service.search_service")
-    @patch("howler.services.correlation_service.case_service")
     @patch("howler.services.correlation_service.get_active_rules")
     @patch("howler.services.correlation_service.datastore")
-    def test_batch_of_alerts_all_matched(self, mock_ds_fn, mock_get_rules, mock_case_svc, mock_search_svc):
+    def test_batch_of_alerts_all_matched(self, mock_ds_fn, mock_get_rules, mock_search_svc, mock_comms):
         """Multiple alerts in a batch all matching the same rule are each added."""
-        mock_ds = MagicMock()
-        mock_ds_fn.return_value = mock_ds
+        case = _make_case("case-1")
+        hits = {"hit-a": _make_backing_obj(), "hit-b": _make_backing_obj(), "hit-c": _make_backing_obj()}
+        _setup_ds(mock_ds_fn, {"case-1": case}, hits=hits)
 
-        rule = _make_rule(query="event.kind:alert", destination="alerts")
+        rule = _make_rule(query="event.kind:alert", destination="alerts/{{howler.id}}")
         mock_get_rules.return_value = [("case-1", rule)]
 
         mock_search_svc.search.return_value = {
@@ -98,16 +145,15 @@ class TestIngestedAlertsCorrelation:
         added = correlation_service.process_batch(["hit-a", "hit-b", "hit-c"])
 
         assert added == 3
-        assert mock_case_svc.append_case_item.call_count == 3
+        assert len([i for i in case.items if i.type == "hit"]) == 3
 
     @patch("howler.services.correlation_service.search_service")
-    @patch("howler.services.correlation_service.case_service")
     @patch("howler.services.correlation_service.get_active_rules")
     @patch("howler.services.correlation_service.datastore")
-    def test_alert_not_matching_rule_not_added(self, mock_ds_fn, mock_get_rules, mock_case_svc, mock_search_svc):
+    def test_alert_not_matching_rule_not_added(self, mock_ds_fn, mock_get_rules, mock_search_svc):
         """An alert that does not match the rule query is not added to any case."""
-        mock_ds = MagicMock()
-        mock_ds_fn.return_value = mock_ds
+        case = _make_case("case-1")
+        _setup_ds(mock_ds_fn, {"case-1": case})
 
         rule = _make_rule(query="event.kind:signal", destination="signals")
         mock_get_rules.return_value = [("case-1", rule)]
@@ -123,16 +169,17 @@ class TestIngestedAlertsCorrelation:
         added = correlation_service.process_batch(["hit-no-match"])
 
         assert added == 0
-        mock_case_svc.append_case_item.assert_not_called()
+        assert case.items == []
 
+    @patch("howler.services.correlation_service.comms_service")
     @patch("howler.services.correlation_service.search_service")
-    @patch("howler.services.correlation_service.case_service")
     @patch("howler.services.correlation_service.get_active_rules")
     @patch("howler.services.correlation_service.datastore")
-    def test_alert_matched_by_multiple_rules(self, mock_ds_fn, mock_get_rules, mock_case_svc, mock_search_svc):
+    def test_alert_matched_by_multiple_rules(self, mock_ds_fn, mock_get_rules, mock_search_svc, mock_comms):
         """A single alert matching rules from two different cases is added to both."""
-        mock_ds = MagicMock()
-        mock_ds_fn.return_value = mock_ds
+        case_a = _make_case("case-a")
+        case_b = _make_case("case-b")
+        _setup_ds(mock_ds_fn, {"case-a": case_a, "case-b": case_b}, hits={"hit-1": _make_backing_obj()})
 
         rule_a = _make_rule(query="event.kind:alert", destination="case-a-alerts")
         rule_b = _make_rule(query="*:*", destination="case-b-all")
@@ -149,16 +196,18 @@ class TestIngestedAlertsCorrelation:
         added = correlation_service.process_batch(["hit-1"])
 
         assert added == 2
-        assert mock_case_svc.append_case_item.call_count == 2
+        assert len([i for i in case_a.items if i.type == "hit"]) == 1
+        assert len([i for i in case_b.items if i.type == "hit"]) == 1
 
+    @patch("howler.services.correlation_service.comms_service")
     @patch("howler.services.correlation_service.search_service")
-    @patch("howler.services.correlation_service.case_service")
     @patch("howler.services.correlation_service.get_active_rules")
     @patch("howler.services.correlation_service.datastore")
-    def test_duplicate_alert_skipped(self, mock_ds_fn, mock_get_rules, mock_case_svc, mock_search_svc):
-        """An alert already present in a case (InvalidDataException) is skipped."""
-        mock_ds = MagicMock()
-        mock_ds_fn.return_value = mock_ds
+    def test_duplicate_alert_skipped(self, mock_ds_fn, mock_get_rules, mock_search_svc, mock_comms):
+        """An alert that would conflict with an already-present item is skipped."""
+        existing = CaseItem({"type": "hit", "value": "hit-existing", "name": "related"})
+        case = _make_case("case-1", items=[existing])
+        _setup_ds(mock_ds_fn, {"case-1": case}, hits={"hit-dup": _make_backing_obj()})
 
         rule = _make_rule(query="*:*", destination="related")
         mock_get_rules.return_value = [("case-1", rule)]
@@ -169,20 +218,20 @@ class TestIngestedAlertsCorrelation:
             "offset": 0,
             "rows": 1,
         }
-        mock_case_svc.append_case_item.side_effect = InvalidDataException("already exists")
 
         added = correlation_service.process_batch(["hit-dup"])
 
         assert added == 0
+        assert case.items == [existing]
 
+    @patch("howler.services.correlation_service.comms_service")
     @patch("howler.services.correlation_service.search_service")
-    @patch("howler.services.correlation_service.case_service")
     @patch("howler.services.correlation_service.get_active_rules")
     @patch("howler.services.correlation_service.datastore")
-    def test_alert_destination_rendered_with_hit_data(self, mock_ds_fn, mock_get_rules, mock_case_svc, mock_search_svc):
+    def test_alert_destination_rendered_with_hit_data(self, mock_ds_fn, mock_get_rules, mock_search_svc, mock_comms):
         """The destination path is rendered as a Mustache template with hit fields."""
-        mock_ds = MagicMock()
-        mock_ds_fn.return_value = mock_ds
+        case = _make_case("case-1")
+        _setup_ds(mock_ds_fn, {"case-1": case}, hits={"hit-tpl": _make_backing_obj()})
 
         rule = _make_rule(
             query="event.kind:alert",
@@ -205,11 +254,9 @@ class TestIngestedAlertsCorrelation:
 
         correlation_service.process_batch(["hit-tpl"])
 
-        mock_case_svc.append_case_item.assert_called_once()
-        kwargs = mock_case_svc.append_case_item.call_args.kwargs
-        assert kwargs["item_type"] == "hit"
-        assert kwargs["item_value"] == "hit-tpl"
-        assert kwargs["item_name"] == "alert"
+        hit_item = next(i for i in case.items if i.type == "hit")
+        assert hit_item.value == "hit-tpl"
+        assert hit_item.name == "alert"
 
 
 # ---------------------------------------------------------------------------
@@ -220,14 +267,14 @@ class TestIngestedAlertsCorrelation:
 class TestIngestedEventsCorrelation:
     """Verify that events ingested via the API reach the correlation service."""
 
+    @patch("howler.services.correlation_service.comms_service")
     @patch("howler.services.correlation_service.search_service")
-    @patch("howler.services.correlation_service.case_service")
     @patch("howler.services.correlation_service.get_active_rules")
     @patch("howler.services.correlation_service.datastore")
-    def test_event_matches_rule_with_event_index(self, mock_ds_fn, mock_get_rules, mock_case_svc, mock_search_svc):
+    def test_event_matches_rule_with_event_index(self, mock_ds_fn, mock_get_rules, mock_search_svc, mock_comms):
         """An event matching a rule targeting the event index is added."""
-        mock_ds = MagicMock()
-        mock_ds_fn.return_value = mock_ds
+        case = _make_case("case-1")
+        _setup_ds(mock_ds_fn, {"case-1": case}, events={"obs-1": _make_backing_obj()})
 
         rule = _make_rule(
             query="event.kind:enrichment",
@@ -246,19 +293,16 @@ class TestIngestedEventsCorrelation:
         added = correlation_service.process_batch(["obs-1"])
 
         assert added == 1
-        mock_case_svc.append_case_item.assert_called_once()
-        kwargs = mock_case_svc.append_case_item.call_args.kwargs
-        assert kwargs["item_type"] == "event"
-        assert kwargs["item_value"] == "obs-1"
+        event_item = next(i for i in case.items if i.type == "event")
+        assert event_item.value == "obs-1"
 
     @patch("howler.services.correlation_service.search_service")
-    @patch("howler.services.correlation_service.case_service")
     @patch("howler.services.correlation_service.get_active_rules")
     @patch("howler.services.correlation_service.datastore")
-    def test_event_not_matched_by_hit_only_rule(self, mock_ds_fn, mock_get_rules, mock_case_svc, mock_search_svc):
+    def test_event_not_matched_by_hit_only_rule(self, mock_ds_fn, mock_get_rules, mock_search_svc):
         """A rule targeting only the hit index does not match events."""
-        mock_ds = MagicMock()
-        mock_ds_fn.return_value = mock_ds
+        case = _make_case("case-1")
+        _setup_ds(mock_ds_fn, {"case-1": case})
 
         rule = _make_rule(query="*:*", destination="hits", indexes=["hit"])
         mock_get_rules.return_value = [("case-1", rule)]
@@ -275,16 +319,21 @@ class TestIngestedEventsCorrelation:
 
         assert added == 0
 
+    @patch("howler.services.correlation_service.comms_service")
     @patch("howler.services.correlation_service.search_service")
-    @patch("howler.services.correlation_service.case_service")
     @patch("howler.services.correlation_service.get_active_rules")
     @patch("howler.services.correlation_service.datastore")
-    def test_mixed_batch_alerts_and_events(self, mock_ds_fn, mock_get_rules, mock_case_svc, mock_search_svc):
+    def test_mixed_batch_alerts_and_events(self, mock_ds_fn, mock_get_rules, mock_search_svc, mock_comms):
         """A batch with both hit and event IDs can match a rule searching both indexes."""
-        mock_ds = MagicMock()
-        mock_ds_fn.return_value = mock_ds
+        case = _make_case("case-1")
+        _setup_ds(
+            mock_ds_fn,
+            {"case-1": case},
+            hits={"hit-1": _make_backing_obj()},
+            events={"obs-1": _make_backing_obj()},
+        )
 
-        rule = _make_rule(query="*:*", destination="all", indexes=["hit", "event"])
+        rule = _make_rule(query="*:*", destination="all/{{howler.id}}", indexes=["hit", "event"])
         mock_get_rules.return_value = [("case-1", rule)]
 
         mock_search_svc.search.return_value = {
@@ -301,23 +350,24 @@ class TestIngestedEventsCorrelation:
 
         assert added == 2
 
-        calls = mock_case_svc.append_case_item.call_args_list
-        types = {c.kwargs["item_type"] for c in calls}
-        values = {c.kwargs["item_value"] for c in calls}
+        types = {i.type for i in case.items if i.type != "folder"}
+        values = {i.value for i in case.items if i.type != "folder"}
         assert types == {"hit", "event"}
         assert values == {"hit-1", "obs-1"}
 
+    @patch("howler.services.correlation_service.comms_service")
     @patch("howler.services.correlation_service.search_service")
-    @patch("howler.services.correlation_service.case_service")
     @patch("howler.services.correlation_service.get_active_rules")
     @patch("howler.services.correlation_service.datastore")
-    def test_event_batch_multiple_rules(self, mock_ds_fn, mock_get_rules, mock_case_svc, mock_search_svc):
+    def test_event_batch_multiple_rules(self, mock_ds_fn, mock_get_rules, mock_search_svc, mock_comms):
         """Multiple events matched by multiple rules across different cases."""
-        mock_ds = MagicMock()
-        mock_ds_fn.return_value = mock_ds
+        case_a = _make_case("case-a")
+        case_b = _make_case("case-b")
+        events = {"obs-1": _make_backing_obj(), "obs-2": _make_backing_obj()}
+        _setup_ds(mock_ds_fn, {"case-a": case_a, "case-b": case_b}, events=events)
 
-        rule_a = _make_rule(query="*:*", destination="case-a-obs", indexes=["event"])
-        rule_b = _make_rule(query="*:*", destination="case-b-obs", indexes=["event"])
+        rule_a = _make_rule(query="*:*", destination="case-a-obs/{{howler.id}}", indexes=["event"])
+        rule_b = _make_rule(query="*:*", destination="case-b-obs/{{howler.id}}", indexes=["event"])
         mock_get_rules.return_value = [("case-a", rule_a), ("case-b", rule_b)]
 
         search_result = {
@@ -335,7 +385,8 @@ class TestIngestedEventsCorrelation:
 
         # 2 events × 2 rules = 4 appends
         assert added == 4
-        assert mock_case_svc.append_case_item.call_count == 4
+        assert len([i for i in case_a.items if i.type == "event"]) == 2
+        assert len([i for i in case_b.items if i.type == "event"]) == 2
 
 
 # ---------------------------------------------------------------------------
@@ -346,18 +397,19 @@ class TestIngestedEventsCorrelation:
 class TestIngestToCorrelationContract:
     """Verify the queue contract between the ingest endpoint and the correlation worker."""
 
+    @patch("howler.services.correlation_service.comms_service")
     @patch("howler.services.correlation_service.search_service")
-    @patch("howler.services.correlation_service.case_service")
     @patch("howler.services.correlation_service.get_active_rules")
     @patch("howler.services.correlation_service.datastore")
     def test_ids_format_matches_process_batch_expectation(
-        self, mock_ds_fn, mock_get_rules, mock_case_svc, mock_search_svc
+        self, mock_ds_fn, mock_get_rules, mock_search_svc, mock_comms
     ):
         """process_batch expects a list[str] of record IDs — the same format pushed by ingest."""
-        mock_ds = MagicMock()
-        mock_ds_fn.return_value = mock_ds
+        case = _make_case("case-1")
+        hits = {"abc123": _make_backing_obj(), "def456": _make_backing_obj()}
+        _setup_ds(mock_ds_fn, {"case-1": case}, hits=hits)
 
-        rule = _make_rule(query="*:*", destination="related")
+        rule = _make_rule(query="*:*", destination="related/{{howler.id}}")
         mock_get_rules.return_value = [("case-1", rule)]
 
         ingested_ids = ["abc123", "def456"]
@@ -380,30 +432,6 @@ class TestIngestToCorrelationContract:
         search_call = mock_search_svc.search.call_args
         filters = search_call.kwargs["filters"]
         assert any("abc123" in f and "def456" in f for f in filters)
-
-    @patch("howler.services.correlation_service.search_service")
-    @patch("howler.services.correlation_service.case_service")
-    @patch("howler.services.correlation_service.get_active_rules")
-    @patch("howler.services.correlation_service.datastore")
-    def test_commits_before_querying(self, mock_ds_fn, mock_get_rules, mock_case_svc, mock_search_svc):
-        """process_batch commits recent writes before querying to ensure freshly ingested data is searchable."""
-        mock_ds = MagicMock()
-        mock_ds_fn.return_value = mock_ds
-
-        mock_get_rules.return_value = [("case-1", _make_rule())]
-
-        mock_search_svc.search.return_value = {
-            "items": [],
-            "total": 0,
-            "offset": 0,
-            "rows": 0,
-        }
-
-        correlation_service.process_batch(["hit-1"])
-
-        # Verify commits happened before the search
-        mock_ds.case.commit.assert_called_once()
-        mock_ds.hit.commit.assert_called_once()
 
 
 # ---------------------------------------------------------------------------

--- a/api/test/unit/test_app.py
+++ b/api/test/unit/test_app.py
@@ -1,0 +1,26 @@
+import howler.app as howler_app
+
+
+def test_should_start_background_services(monkeypatch):
+    """Workers start in production, serving, Gunicorn, and functional-test processes."""
+    monkeypatch.setattr(howler_app, "DEBUG", True)
+    monkeypatch.setattr(howler_app.sys, "argv", ["flask"])
+    monkeypatch.delenv("WERKZEUG_RUN_MAIN", raising=False)
+    monkeypatch.delenv("TESTING", raising=False)
+
+    assert not howler_app._should_start_background_services()
+
+    monkeypatch.setenv("WERKZEUG_RUN_MAIN", "true")
+    assert howler_app._should_start_background_services()
+
+    monkeypatch.delenv("WERKZEUG_RUN_MAIN")
+    monkeypatch.setenv("TESTING", "true")
+    assert howler_app._should_start_background_services()
+
+    monkeypatch.delenv("TESTING")
+    monkeypatch.setattr(howler_app.sys, "argv", ["gunicorn"])
+    assert howler_app._should_start_background_services()
+
+    monkeypatch.setattr(howler_app, "DEBUG", False)
+    monkeypatch.setattr(howler_app.sys, "argv", ["flask"])
+    assert howler_app._should_start_background_services()

--- a/api/test/unit/test_app.py
+++ b/api/test/unit/test_app.py
@@ -6,17 +6,22 @@ def test_should_start_background_services(monkeypatch):
     monkeypatch.setattr(howler_app, "DEBUG", True)
     monkeypatch.setattr(howler_app.sys, "argv", ["flask"])
     monkeypatch.delenv("WERKZEUG_RUN_MAIN", raising=False)
+    monkeypatch.delenv("HWL_START_BACKGROUND_SERVICES", raising=False)
     monkeypatch.delenv("TESTING", raising=False)
 
+    assert not howler_app._should_start_background_services()
+
+    monkeypatch.setenv("TESTING", "true")
     assert not howler_app._should_start_background_services()
 
     monkeypatch.setenv("WERKZEUG_RUN_MAIN", "true")
     assert howler_app._should_start_background_services()
 
     monkeypatch.delenv("WERKZEUG_RUN_MAIN")
-    monkeypatch.setenv("TESTING", "true")
+    monkeypatch.setenv("HWL_START_BACKGROUND_SERVICES", "true")
     assert howler_app._should_start_background_services()
 
+    monkeypatch.delenv("HWL_START_BACKGROUND_SERVICES")
     monkeypatch.delenv("TESTING")
     monkeypatch.setattr(howler_app.sys, "argv", ["gunicorn"])
     assert howler_app._should_start_background_services()

--- a/api/test/unit/test_bulk.py
+++ b/api/test/unit/test_bulk.py
@@ -1,9 +1,11 @@
 import json
 import math
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from howler.datastore.bulk import ElasticBulkPlan
+from howler.datastore.collection import ESCollection
 from howler.odm.models.case import Case, CaseItem
 
 
@@ -42,6 +44,24 @@ def test_get_plan_batches(bulk_plan, operations, operation_length, batch_size):
 
     assert len(batches) == math.ceil(operation_length / (batch_size or operation_length))
     assert "".join(batches) == bulk_plan.get_plan_data()
+
+
+def test_collection_bulk_returns_false_and_logs_errors():
+    operations = MagicMock()
+    operations.get_plan_batches.return_value = ["bulk-operation"]
+    collection = MagicMock()
+    collection.with_retries.return_value = {"errors": {"delete": "document not found"}}
+
+    with patch("howler.datastore.collection.logger") as mock_logger:
+        result = ESCollection.bulk(collection, operations)
+
+    assert result is False
+    collection.with_retries.assert_called_once_with(
+        collection.datastore.client.bulk,
+        operations="bulk-operation",
+        refresh=None,
+    )
+    mock_logger.error.assert_called_once_with("Errors on bulk plan: %s", {"delete": "document not found"})
 
 
 # ---------------------------------------------------------------------------

--- a/api/test/unit/test_bulk.py
+++ b/api/test/unit/test_bulk.py
@@ -1,8 +1,10 @@
+import json
 import math
 
 import pytest
 
 from howler.datastore.bulk import ElasticBulkPlan
+from howler.odm.models.case import Case, CaseItem
 
 
 @pytest.fixture(scope="module")
@@ -40,3 +42,85 @@ def test_get_plan_batches(bulk_plan, operations, operation_length, batch_size):
 
     assert len(batches) == math.ceil(operation_length / (batch_size or operation_length))
     assert "".join(batches) == bulk_plan.get_plan_data()
+
+
+# ---------------------------------------------------------------------------
+# add_update_operation() field scoping
+# ---------------------------------------------------------------------------
+
+
+def _make_case() -> Case:
+    return Case(
+        {
+            "case_id": "case-001",
+            "title": "Original Title",
+            "summary": "Original Summary",
+            "overview": "O",
+            "escalation": "normal",
+            "items": [CaseItem({"type": "hit", "value": "hit-1", "name": "hit-1"})],
+        }
+    )
+
+
+def _get_update_body(plan: ElasticBulkPlan) -> dict:
+    """Extract the `doc` body of the single queued update operation."""
+    op = plan.operations[0]
+    assert len(op) == 2
+    header, body = op
+    assert json.loads(header) == {"update": {"_index": "case", "_id": "case-001"}}
+    return json.loads(body)["doc"]
+
+
+def test_add_update_operation_without_fields_keeps_everything():
+    """Without a `fields` filter, the full serialized document is sent."""
+    plan = ElasticBulkPlan(indexes=["case"], model=Case)
+    plan.add_update_operation("case-001", _make_case())
+
+    doc = _get_update_body(plan)
+    assert doc["title"] == "Original Title"
+    assert doc["summary"] == "Original Summary"
+    assert len(doc["items"]) == 1
+
+
+def test_add_update_operation_exact_field_keeps_whole_subtree():
+    """An exact field name (no wildcard) keeps that field's entire subtree."""
+    plan = ElasticBulkPlan(indexes=["case"], model=Case)
+    plan.add_update_operation("case-001", _make_case(), fields=["items"])
+
+    doc = _get_update_body(plan)
+    assert set(doc.keys()) == {"items"}
+    assert doc["items"][0]["value"] == "hit-1"
+    assert doc["items"][0]["name"] == "hit-1"
+
+
+def test_add_update_operation_wildcard_field_expands_against_model():
+    """A `*`-suffixed pattern expands to every subfield of that field via the model."""
+    plan = ElasticBulkPlan(indexes=["case"], model=Case)
+    plan.add_update_operation("case-001", _make_case(), fields=["items.*"])
+
+    doc = _get_update_body(plan)
+    assert set(doc.keys()) == {"items"}
+    # Every subfield of the CaseItem is present, since "items.*" expands to all of them.
+    assert doc["items"][0]["value"] == "hit-1"
+    assert doc["items"][0]["type"] == "hit"
+    assert doc["items"][0]["name"] == "hit-1"
+
+
+def test_add_update_operation_specific_subfield_prunes_siblings():
+    """A specific dotted subfield pattern keeps only that subfield in each list entry."""
+    plan = ElasticBulkPlan(indexes=["case"], model=Case)
+    plan.add_update_operation("case-001", _make_case(), fields=["items.type"])
+
+    doc = _get_update_body(plan)
+    assert set(doc.keys()) == {"items"}
+    assert doc["items"][0] == {"type": "hit"}
+
+
+def test_add_update_operation_drops_unselected_top_level_fields():
+    """Fields not selected (e.g. title/summary) are absent from the update body entirely."""
+    plan = ElasticBulkPlan(indexes=["case"], model=Case)
+    plan.add_update_operation("case-001", _make_case(), fields=["items", "targets"])
+
+    doc = _get_update_body(plan)
+    assert "title" not in doc
+    assert "summary" not in doc

--- a/api/test/unit/test_datastore_utils.py
+++ b/api/test/unit/test_datastore_utils.py
@@ -1,0 +1,78 @@
+"""Unit tests for datastore field-selection utilities."""
+
+from howler.datastore.utils import expand_field_patterns, prune_to_paths
+from howler.odm import Compound, Keyword, List, model
+from howler.odm.base import Model
+
+
+@model()
+class _Item(Model):
+    item_type = Keyword()
+    value = Keyword()
+
+
+@model()
+class _Document(Model):
+    title = Keyword()
+    category = Keyword()
+    items = List(Compound(_Item))
+
+
+def test_expand_field_patterns_expands_wildcards_and_keeps_exact_fields():
+    expanded = expand_field_patterns(_Document, ["items.*", "title", "__non_doc_raw__"])
+
+    assert expanded == {"items.item_type", "items.value", "title", "__non_doc_raw__"}
+
+
+def test_expand_field_patterns_keeps_unmatched_wildcards():
+    expanded = expand_field_patterns(_Document, ["missing.*"])
+
+    assert expanded == {"missing.*"}
+
+
+def test_expand_field_patterns_expands_bare_star_by_default():
+    expanded = expand_field_patterns(_Document, ["*"])
+
+    assert expanded == set(_Document.flat_fields())
+
+
+def test_expand_field_patterns_preserves_bare_star_when_requested():
+    expanded = expand_field_patterns(_Document, ["*"], preserve_all=True)
+
+    assert expanded == {"*"}
+
+
+def test_expand_field_patterns_without_model_keeps_patterns_literal():
+    expanded = expand_field_patterns(None, ["items.*", "__non_doc_raw__"])
+
+    assert expanded == {"items.*", "__non_doc_raw__"}
+
+
+def test_prune_to_paths_keeps_selected_subtree():
+    value = {
+        "title": "Alert",
+        "items": [{"item_type": "hit", "value": "hit-1"}],
+        "owner": {"id": "user-1", "name": "Analyst"},
+    }
+
+    pruned = prune_to_paths(value, {"items"})
+
+    assert pruned == {"items": [{"item_type": "hit", "value": "hit-1"}]}
+
+
+def test_prune_to_paths_prunes_nested_dicts_and_list_entries():
+    value = {
+        "title": "Alert",
+        "items": [
+            {"item_type": "hit", "value": "hit-1"},
+            {"item_type": "event", "value": "event-1"},
+        ],
+        "owner": {"id": "user-1", "name": "Analyst"},
+    }
+
+    pruned = prune_to_paths(value, {"items.item_type", "owner.id"})
+
+    assert pruned == {
+        "items": [{"item_type": "hit"}, {"item_type": "event"}],
+        "owner": {"id": "user-1"},
+    }

--- a/api/test/unit/test_datastore_utils.py
+++ b/api/test/unit/test_datastore_utils.py
@@ -24,10 +24,16 @@ def test_expand_field_patterns_expands_wildcards_and_keeps_exact_fields():
     assert expanded == {"items.item_type", "items.value", "title", "__non_doc_raw__"}
 
 
-def test_expand_field_patterns_keeps_unmatched_wildcards():
+def test_expand_field_patterns_omits_unmatched_wildcards():
     expanded = expand_field_patterns(_Document, ["missing.*"])
 
-    assert expanded == {"missing.*"}
+    assert expanded == set()
+
+
+def test_expand_field_patterns_omits_unmatched_patterns_when_model_is_provided():
+    expanded = expand_field_patterns(_Document, ["items.*", "missing.*"])
+
+    assert expanded == {"items.item_type", "items.value"}
 
 
 def test_expand_field_patterns_expands_bare_star_by_default():

--- a/api/test/unit/test_expand_fl.py
+++ b/api/test/unit/test_expand_fl.py
@@ -87,13 +87,6 @@ def test_expand_fl_global_wildcard():
     assert result == "*"
 
 
-def test_expand_fl_unmatched_wildcard_kept_as_is():
-    """Wildcard with no matches must be kept in the result list unchanged."""
-    coll = _make_collection()
-    result = coll._expand_fl("nonexistent.*")
-    assert result == "nonexistent.*"
-
-
 def test_expand_fl_no_model_class_returns_unchanged():
     """Without a model class, _expand_fl must return the original string."""
     mock_datastore = MagicMock()

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -1,5 +1,9 @@
 # Howler Releases
 
+## Howler API `v4.0.2`
+
+- **Add to Case Destination Template** _(bugfix)_: The `add_to_case` action now uses a single Mustache `destination` template (e.g. `related/{{howler.analytic}} ({{howler.id}})`) instead of separate `path` and `title_template` arguments, matching the placement behavior used by case correlation rules.
+
 ## Howler API `v4.0.1`
 
 - **Case Correlation for v1 Ingestion** _(bugfix)_: Fixed a gap where records ingested through v1 endpoints were not queued for correlation processing, so case correlation rules did not apply to those records.

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -3,6 +3,9 @@
 ## Howler API `v4.0.2`
 
 - **Add to Case Destination Template** _(bugfix)_: The `add_to_case` action now uses a single Mustache `destination` template (e.g. `related/{{howler.analytic}} ({{howler.id}})`) instead of separate `path` and `title_template` arguments, matching the placement behavior used by case correlation rules.
+- **Correlation Bulk Case Updates** _(bugfix)_: `process_batch` now accumulates all matched items and newly-created destination folders per case in memory across the whole batch and writes each modified case exactly once via a single bulk operation, instead of saving on every matched record.
+- **Correlation Partial Field Updates** _(bugfix)_: The bulk case write issued by correlation now only merges the `items`, `targets`, `threats`, and `indicators` fields instead of overwriting the entire case document, so correlation no longer clobbers concurrent user edits to a case's title, summary, rules, or tasks.
+- **Bulk Plan Field Scoping** _(new feature)_: `ElasticBulkPlan.add_update_operation` accepts an optional `fields` list restricting a partial update to specific dotted field paths, with `*` wildcard patterns (e.g. `"items.*"`) expanded against the model's known fields via a new shared `howler.datastore.utils` helper.
 
 ## Howler API `v4.0.1`
 

--- a/ui/src/locales/en/translation.json
+++ b/ui/src/locales/en/translation.json
@@ -372,7 +372,7 @@
   "on": "on",
   "open": "Open",
   "operations.add_label": "Add Label",
-  "operations.add_to_bundle": "Add to Bundle",
+  "operations.add_to_case": "Add to Case",
   "operations.change_field": "Change Field",
   "operations.demote": "Demote Hit",
   "operations.prioritization": "Change Prioritization",

--- a/ui/src/locales/fr/translation.json
+++ b/ui/src/locales/fr/translation.json
@@ -372,7 +372,7 @@
   "on": "sur",
   "open": "Ouvert",
   "operations.add_label": "Ajouter un label",
-  "operations.add_to_bundle": "Ajouter à une groupe des hits",
+  "operations.add_to_case": "Ajouter au cas",
   "operations.change_field": "Modifier un champs",
   "operations.demote": "Rétrograder un hit",
   "operations.prioritization": "Modifier l'ordre de priorité",


### PR DESCRIPTION
- **Add to Case Destination Template** _(bugfix)_: The `add_to_case` action now uses a single Mustache `destination` template (e.g. `related/{{howler.analytic}} ({{howler.id}})`) instead of separate `path` and `title_template` arguments, matching the placement behavior used by case correlation rules.
- **Correlation Bulk Case Updates** _(bugfix)_: `process_batch` now accumulates all matched items and newly-created destination folders per case in memory across the whole batch and writes each modified case exactly once via a single bulk operation, instead of saving on every matched record.
- **Correlation Partial Field Updates** _(bugfix)_: The bulk case write issued by correlation now only merges the `items`, `targets`, `threats`, and `indicators` fields instead of overwriting the entire case document, so correlation no longer clobbers concurrent user edits to a case's title, summary, rules, or tasks.
- **Bulk Plan Field Scoping** _(new feature)_: `ElasticBulkPlan.add_update_operation` accepts an optional `fields` list restricting a partial update to specific dotted field paths, with `*` wildcard patterns (e.g. `"items.*"`) expanded against the model's known fields via a new shared `howler.datastore.utils` helper.

---

This pull request introduces several improvements and refactorings to case management, field pattern expansion, and correlation logic in the Howler backend. The most significant changes streamline field selection and pruning, improve batch operations for case updates, and clarify persistence behavior for case and backing object modifications.

**Case management and persistence improvements:**

* Refactored case item addition and removal to separate in-memory changes from persistence: new `persist` argument to `get_parent_from_path`, and new `recompute_case_metadata` and `add_backreference` functions ensure that multiple changes can be accumulated before a single save, improving efficiency and consistency. (`api/howler/services/case_service.py`) [[1]](diffhunk://#diff-4f6ee8823fc3ed367f6afb7493f24bbf6154261797b5dba5bd612a2c5650a2d5R334) [[2]](diffhunk://#diff-4f6ee8823fc3ed367f6afb7493f24bbf6154261797b5dba5bd612a2c5650a2d5R344-R346) [[3]](diffhunk://#diff-4f6ee8823fc3ed367f6afb7493f24bbf6154261797b5dba5bd612a2c5650a2d5L383-R392) [[4]](diffhunk://#diff-4f6ee8823fc3ed367f6afb7493f24bbf6154261797b5dba5bd612a2c5650a2d5L679-R692) [[5]](diffhunk://#diff-4f6ee8823fc3ed367f6afb7493f24bbf6154261797b5dba5bd612a2c5650a2d5R736-R743) [[6]](diffhunk://#diff-4f6ee8823fc3ed367f6afb7493f24bbf6154261797b5dba5bd612a2c5650a2d5R775-R784) [[7]](diffhunk://#diff-4f6ee8823fc3ed367f6afb7493f24bbf6154261797b5dba5bd612a2c5650a2d5L834-L846) [[8]](diffhunk://#diff-4f6ee8823fc3ed367f6afb7493f24bbf6154261797b5dba5bd612a2c5650a2d5L879-R896) [[9]](diffhunk://#diff-4f6ee8823fc3ed367f6afb7493f24bbf6154261797b5dba5bd612a2c5650a2d5L909-R921) [[10]](diffhunk://#diff-4f6ee8823fc3ed367f6afb7493f24bbf6154261797b5dba5bd612a2c5650a2d5L941)

* Added batch-friendly helpers in correlation processing (`_resolve_backing_object`, `_add_record_to_case`) to efficiently add multiple hits/events to a case in memory before persisting, minimizing unnecessary writes. (`api/howler/services/correlation_service.py`)

**Field pattern expansion and pruning:**

* Introduced `expand_field_patterns` and `prune_to_paths` utilities for consistent expansion of wildcard field patterns and selective pruning of update payloads, now used in both bulk update operations and field list expansion. (`api/howler/datastore/utils.py`, `api/howler/datastore/collection.py`, `api/howler/datastore/bulk.py`) [[1]](diffhunk://#diff-7056d848d078dbd67f536e2c6e51ac7c524fc7c0ce2a4338209ed89b7245284cR1-R59) [[2]](diffhunk://#diff-1e4c8255a42b678b2962be8e4a244ce73da06e063ec1eb1249277a21972df5d4L1631-R1633) [[3]](diffhunk://#diff-9e5152d797376a1ae35fd498a51b1276ff7db964eb38dce5d517b1640a0dd8e1R113-R115)

* Enhanced `add_update_operation` in bulk operations to support partial updates: only specified fields (with wildcards) are sent, reducing risk of clobbering concurrent edits. (`api/howler/datastore/bulk.py`)

**API and argument changes:**

* Changed `add_to_case` action to use a single `destination` template for path and name, replacing `path` and `title_template` arguments for clarity and flexibility. (`api/howler/actions/add_to_case.py`) [[1]](diffhunk://#diff-fa17c2b4e709b24ab552b28ede0a518ffafd3210fb9fb6b959c7e62fb598e536L16-R26) [[2]](diffhunk://#diff-fa17c2b4e709b24ab552b28ede0a518ffafd3210fb9fb6b959c7e62fb598e536L70-R76) [[3]](diffhunk://#diff-fa17c2b4e709b24ab552b28ede0a518ffafd3210fb9fb6b959c7e62fb598e536L134-R132)

These changes collectively improve the reliability, maintainability, and efficiency of case and record management in the Howler backend.