### PR TITLE
fix(api): add exists fallback for exists query on ilm-enabled indexes

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -456,3 +456,7 @@ For legacy collections, pass the collection alias through the `aliases` argument
 ### ILM Reindex Index Discovery
 
 Reindex and cleanup must enumerate `index_list_full`, not `index_list`, so existing physical ILM rollover indices are handled even when ILM is currently disabled in configuration. Canonical rollover names are exactly `{collection}-NNNNNN`; exclude `__reindex` temporary indices from discovery and preserve source lifecycle metadata on the reindex target.
+
+### ILM Collection Existence Checks
+
+Elasticsearch single-document `exists` requests cannot target an alias that resolves to multiple ILM rollover indexes. For ILM collections, use a zero-result `ids` search against the alias and derive existence from `hits.total`; retain the same search as a logged fallback when a legacy single-document check returns `BadRequestError`.

--- a/api/howler/datastore/collection.py
+++ b/api/howler/datastore/collection.py
@@ -1136,13 +1136,35 @@ class ESCollection(Generic[ModelType]):
 
         return data
 
+    def _search_exists(self, key) -> bool:
+        """Check document existence with an alias-safe search query."""
+        result = self.with_retries(
+            self.datastore.client.search,
+            index=self.name,
+            query={"ids": {"values": [key]}},
+            size=0,
+            track_total_hits=True,
+        )
+        total = result["hits"]["total"]
+        return total["value"] > 0 if isinstance(total, dict) else total > 0
+
     def exists(self, key) -> bool:
         """Check if a document exists in the datastore.
 
         :param key: key of the document to get from the datastore
         :return: true/false depending if the document exists or not
         """
-        return cast(bool, self.with_retries(self.datastore.client.exists, index=self.name, id=key, _source=False))
+        if self.ilm_config:
+            return self._search_exists(key)
+
+        try:
+            return cast(bool, self.with_retries(self.datastore.client.exists, index=self.name, id=key, _source=False))
+        except elasticsearch.BadRequestError:
+            logger.exception(
+                "Single-document existence check failed on %s; falling back to an alias-safe search.",
+                self.name,
+            )
+            return self._search_exists(key)
 
     @overload
     def _get(self, key, retries, version: Literal[False]) -> dict[str, Any]: ...

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -152,7 +152,7 @@ suppress-none-returning = true
 [tool.poetry]
 package-mode = true
 name = "howler-api"
-version = "4.0.2"
+version = "4.0.3"
 description = "Howler - API server"
 authors = [
     "Canadian Centre for Cyber Security <howler@cyber.gc.ca>",

--- a/api/test/unit/test_ilm_collection.py
+++ b/api/test/unit/test_ilm_collection.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 
 import elasticsearch
 import pytest
+from elastic_transport import ApiResponseMeta
 
 from howler.datastore.collection import ESCollection
 from howler.odm.models.config import ILMConfig, ILMIndexConfig
@@ -48,6 +49,43 @@ def _make_collection(mock_datastore, ilm_config=None):
     mock_datastore._models = {"testcol": None}
     col = ESCollection(mock_datastore, "testcol", model_class=None, ilm_config=ilm_config)
     return col
+
+
+class TestExists:
+    """Tests for alias-safe document existence checks."""
+
+    def test_ilm_exists_uses_search_instead_of_single_document_endpoint(self, mock_datastore):
+        """ILM aliases can resolve to multiple indexes, so use an ids search."""
+        col = _make_collection(mock_datastore, ilm_config=ILMIndexConfig(warm="30d"))
+        mock_datastore.client.search.return_value = {"hits": {"total": {"value": 1, "relation": "eq"}}}
+
+        assert col.exists("document-id") is True
+
+        mock_datastore.client.exists.assert_not_called()
+        mock_datastore.client.search.assert_called_once_with(
+            index=col.name,
+            query={"ids": {"values": ["document-id"]}},
+            size=0,
+            track_total_hits=True,
+        )
+
+    def test_exists_falls_back_to_search_after_bad_request(self, mock_datastore, caplog):
+        """Unexpected multi-index alias errors recover through the alias-safe search."""
+        col = _make_collection(mock_datastore)
+        meta = ApiResponseMeta(status=400, http_version="1.1", headers={}, duration=0.0, node=None)
+        mock_datastore.client.exists.side_effect = elasticsearch.exceptions.BadRequestError("bad_request", meta, {})
+        mock_datastore.client.search.return_value = {"hits": {"total": {"value": 0, "relation": "eq"}}}
+
+        with caplog.at_level("ERROR", logger="howler.api.datastore"):
+            assert col.exists("document-id") is False
+
+        assert "falling back to an alias-safe search" in caplog.text
+        mock_datastore.client.search.assert_called_once_with(
+            index=col.name,
+            query={"ids": {"values": ["document-id"]}},
+            size=0,
+            track_total_hits=True,
+        )
 
 
 class TestCreateILMPolicy:

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -1,5 +1,9 @@
 # Howler Releases
 
+## Howler API `v4.0.3`
+
+- **ILM Collection Existence Checks** _(bugfix)_: Document existence checks now use alias-safe searches for ILM collections and recover from multi-index alias errors on legacy checks.
+
 ## Howler API `v4.0.2`
 
 - **Add to Case Destination Template** _(bugfix)_: The `add_to_case` action now uses a single Mustache `destination` template (e.g. `related/{{howler.analytic}} ({{howler.id}})`) instead of separate `path` and `title_template` arguments, matching the placement behavior used by case correlation rules.


### PR DESCRIPTION
This PR addresses an issue when combining single `exists` queries with a ILM-enabled system.

---

This pull request updates the Howler API to improve document existence checks for Elasticsearch ILM collections, ensuring correctness and reliability when aliases may resolve to multiple indexes. The main change is to use an alias-safe search for existence checks, with a fallback for legacy collections. Tests and documentation are also updated to reflect this behavior.

**ILM Collection Existence Checks:**

* Updated `ESCollection.exists` in `howler/datastore/collection.py` to use a zero-result `ids` search for ILM collections, avoiding errors when an alias resolves to multiple indexes. For legacy collections, falls back to the alias-safe search if a `BadRequestError` occurs during a single-document check.
* Added unit tests in `test_ilm_collection.py` to verify that ILM collections use the alias-safe search and that the fallback is triggered on errors. [[1]](diffhunk://#diff-7fb260535d4b12db698f5657b1aeede4e52e4a699459841109e161c8d51c1332R54-R90) [[2]](diffhunk://#diff-7fb260535d4b12db698f5657b1aeede4e52e4a699459841109e161c8d51c1332R11)
* Updated `.github/copilot-instructions.md` and `docs/RELEASES.md` to document the new existence check behavior and the bugfix. [[1]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5R459-R462) [[2]](diffhunk://#diff-94fd84d8893cd91cd0c77710b90bd0c68d4e0d2ddce48b6bf04b1cba48129b0aR3-R6)

**Versioning:**

* Bumped Howler API version to `4.0.3` in `pyproject.toml`.