### PR TITLE
fix(api): fixing errors when getting alerts or updating alerts in an ilm index

### DIFF
--- a/api/howler/api/v1/action.py
+++ b/api/howler/api/v1/action.py
@@ -143,7 +143,7 @@ def update_action(id: str, user: User, **kwargs) -> Response:
 
     ds = datastore()
 
-    existing_action = ds.action.get(id, as_obj=False)
+    existing_action, server_version = ds.action.get(id, as_obj=False, version=True)
 
     if not existing_action:
         return not_found(err="The specified automation does not exist")
@@ -166,7 +166,7 @@ def update_action(id: str, user: User, **kwargs) -> Response:
         action_obj = Action(updated_action)
         action_obj.action_id = id
 
-        ds.action.save(action_obj.action_id, action_obj, refresh=refresh)
+        ds.action.save(action_obj.action_id, action_obj, version=server_version, refresh=refresh)
     except HowlerException as e:
         return bad_request(err=str(e))
 

--- a/api/howler/api/v2/ingest.py
+++ b/api/howler/api/v2/ingest.py
@@ -265,7 +265,7 @@ def overwrite(index: str, id: str, **kwargs):
 
     ds = datastore()
 
-    record = ds[index].get(id, as_obj=False, version=False)
+    record, server_version = ds[index].get(id, as_obj=False, version=True)
     if not record:
         return not_found(err="Record %s does not exist" % id)
 
@@ -292,7 +292,7 @@ def overwrite(index: str, id: str, **kwargs):
         ds[index].save(
             id,
             odm(new_record) if odm else new_record,
-            version=kwargs.get("server_version"),
+            version=server_version,
             refresh=refresh,
         )
 

--- a/api/howler/datastore/collection.py
+++ b/api/howler/datastore/collection.py
@@ -16,6 +16,7 @@ from typing import Any, Callable, Dict, Generic, Literal, Optional, TypeVar, Uni
 import elasticsearch
 from datemath import dm
 from datemath.helpers import DateMathException
+from elastic_transport import ApiResponseMeta
 from opentelemetry import trace
 
 from howler import odm
@@ -1166,6 +1167,17 @@ class ESCollection(Generic[ModelType]):
             )
             return self._search_exists(key)
 
+    def _raise_document_not_found(self, key: str, result: Any) -> typing.NoReturn:
+        """Raise the same error shape as an Elasticsearch document lookup for an empty search."""
+        meta = ApiResponseMeta(
+            status=404,
+            http_version="1.1",
+            headers=cast(Any, {}),
+            duration=0.0,
+            node=cast(Any, None),
+        )
+        raise elasticsearch.exceptions.NotFoundError(f"Document with id {key} not found", meta, result)
+
     @overload
     def _get(self, key, retries, version: Literal[False]) -> dict[str, Any]: ...
 
@@ -1176,7 +1188,7 @@ class ESCollection(Generic[ModelType]):
         """Versioned get-save for atomic update has two paths:
             1. Document doesn't exist at all. Create token will be returned for version.
                This way only the first query to try and create the document will succeed.
-            2. Document exists in hot. A version string with the info needed to do a versioned save is returned.
+            2. Document exists. A version string with the info needed to do a versioned save is returned.
 
         The create token is needed to differentiate between "I'm saving a new
         document non-atomic (version=None)" and "I'm saving a new document
@@ -1195,11 +1207,29 @@ class ESCollection(Generic[ModelType]):
         done = False
         while not done:
             try:
-                doc = self.with_retries(self.datastore.client.get, index=self.name, id=key)
+                if self.ilm_config:
+                    result = self.with_retries(
+                        self.datastore.client.search,
+                        index=self.name,
+                        query={"ids": {"values": [key]}},
+                        size=1,
+                        seq_no_primary_term=True,
+                    )
+                    hits = result["hits"]["hits"]
+                    if not hits:
+                        self._raise_document_not_found(key, result)
+                    doc = hits[0]
+                else:
+                    doc = self.with_retries(self.datastore.client.get, index=self.name, id=key)
+
                 if version:
+                    if self.ilm_config:
+                        version_token = f"{doc['_index']}---{doc['_seq_no']}---{doc['_primary_term']}"
+                    else:
+                        version_token = f"{doc['_seq_no']}---{doc['_primary_term']}"
                     return (
                         normalize_output(doc["_source"]),
-                        f"{doc['_seq_no']}---{doc['_primary_term']}",
+                        version_token,
                     )
                 return normalize_output(doc["_source"])
             except elasticsearch.exceptions.NotFoundError:
@@ -1217,6 +1247,15 @@ class ESCollection(Generic[ModelType]):
             return None, CREATE_TOKEN
 
         return None
+
+    def _get_version_write_target(self, version: str) -> tuple[str, str, str]:
+        """Return the concrete write target and optimistic-concurrency values from a version token."""
+        version_parts = version.split("---")
+        if len(version_parts) == 3:
+            return version_parts[0], version_parts[1], version_parts[2]
+
+        seq_no, primary_term = version_parts
+        return self.name, seq_no, primary_term
 
     @overload
     def get(self, key, as_obj: Literal[True], version: Literal[True]) -> tuple[ModelType | None, str]: ...
@@ -1347,13 +1386,17 @@ class ESCollection(Generic[ModelType]):
 
         saved_data["id"] = key
         operation = "index"
+        index = self.name
         seq_no = None
         primary_term = None
+
+        if version is None and self.ilm_config:
+            _, version = self.get_if_exists(key, as_obj=False, version=True)
 
         if version == CREATE_TOKEN:
             operation = "create"
         elif version:
-            seq_no, primary_term = version.split("---")
+            index, seq_no, primary_term = self._get_version_write_target(version)
 
         if refresh == "true":
             logger.warning(
@@ -1363,7 +1406,7 @@ class ESCollection(Generic[ModelType]):
         try:
             self.with_retries(
                 self.datastore.client.index,
-                index=self.name,
+                index=index,
                 id=key,
                 document=json.dumps(saved_data),
                 op_type=operation,
@@ -1563,15 +1606,16 @@ class ESCollection(Generic[ModelType]):
         """
         operations = self._validate_operations(operations)
         script = self._create_scripts_from_operations(operations)
+        index = self.name
         seq_no = None
         primary_term = None
         if version:
-            seq_no, primary_term = version.split("---")
+            index, seq_no, primary_term = self._get_version_write_target(version)
 
         try:
             res = self.with_retries(
                 self.datastore.client.update,
-                index=self.name,
+                index=index,
                 id=key,
                 script=script,
                 if_seq_no=seq_no,
@@ -1581,7 +1625,11 @@ class ESCollection(Generic[ModelType]):
             )
             return (
                 res["result"] == "updated",
-                f"{res['_seq_no']}---{res['_primary_term']}",
+                (
+                    f"{res['_index']}---{res['_seq_no']}---{res['_primary_term']}"
+                    if self.ilm_config
+                    else f"{res['_seq_no']}---{res['_primary_term']}"
+                ),
             )
         except elasticsearch.NotFoundError as e:
             logger.warning("Update - elasticsearch.NotFoundError: %s %s", e.message, e.info)

--- a/api/howler/datastore/collection.py
+++ b/api/howler/datastore/collection.py
@@ -1252,10 +1252,14 @@ class ESCollection(Generic[ModelType]):
         """Return the concrete write target and optimistic-concurrency values from a version token."""
         version_parts = version.split("---")
         if len(version_parts) == 3:
-            return version_parts[0], version_parts[1], version_parts[2]
+            index, seq_no, primary_term = version_parts
+            return index, seq_no, primary_term
 
-        seq_no, primary_term = version_parts
-        return self.name, seq_no, primary_term
+        if len(version_parts) == 2:
+            seq_no, primary_term = version_parts
+            return self.name, seq_no, primary_term
+
+        raise DataStoreException(f"Invalid version token for {self.name}: {version!r}")
 
     @overload
     def get(self, key, as_obj: Literal[True], version: Literal[True]) -> tuple[ModelType | None, str]: ...

--- a/api/howler/odm/mixins.py
+++ b/api/howler/odm/mixins.py
@@ -9,7 +9,7 @@ Elasticsearch datastore without boilerplate.
 from __future__ import annotations
 
 from operator import attrgetter
-from typing import Generic, Literal, TypeVar, overload
+from typing import Generic, Literal, Self, TypeVar, overload
 
 from howler.common.exceptions import HowlerRuntimeError
 from howler.common.loader import datastore
@@ -28,10 +28,10 @@ class _ObjectsDescriptor(Generic[ModelType]):
     """
 
     @overload
-    def __get__(self, obj: None, objtype: type[ModelType]) -> ESCollection[ModelType]: ...
+    def __get__(self: Self, obj: None, objtype: type[ModelType]) -> ESCollection[ModelType]: ...
 
     @overload
-    def __get__(self, obj: ModelType, objtype: type[ModelType]) -> ESCollection[ModelType]: ...
+    def __get__(self: Self, obj: ModelType, objtype: type[ModelType]) -> ESCollection[ModelType]: ...
 
     def __get__(self, obj: ModelType | None, objtype: type[ModelType] | None = None) -> ESCollection[ModelType]:
         """Return the ESCollection for the owner class.
@@ -82,7 +82,11 @@ class DatastoreMixin(Generic[ModelType]):
         """
         return datastore()
 
-    def save(self, refresh: Literal["true", "false", "wait_for"] | None = None) -> bool:
+    def save(
+        self: Self,
+        refresh: Literal["true", "false", "wait_for"] | None = None,
+        version: str | None = None,
+    ) -> bool:
         """Persist the current model instance to the datastore.
 
         Determines the target index from the lowercase class name, extracts the
@@ -96,5 +100,6 @@ class DatastoreMixin(Generic[ModelType]):
         index_name = self.__class__.__name__.lower()
         id_field = self.__class__._Model__id_field  # type: ignore[attr-defined]
         current_id = attrgetter(id_field)(self)
+        collection = self.ds[index_name]
 
-        return self.ds[index_name].save(current_id, self, refresh=refresh)
+        return collection.save(current_id, self, version=version, refresh=refresh)

--- a/api/howler/services/case_service.py
+++ b/api/howler/services/case_service.py
@@ -19,6 +19,7 @@ from howler.common.exceptions import (
 from howler.common.loader import APP_NAME, datastore
 from howler.common.logging import get_logger
 from howler.config import CLASSIFICATION
+from howler.datastore.collection import CREATE_TOKEN
 from howler.datastore.exceptions import DataStoreException
 from howler.odm.models.case import Case, CaseItem, CaseItemTypes, CaseLog, CaseRule
 from howler.odm.models.ecs.related import Related
@@ -56,7 +57,7 @@ def create_case(
 
     case = Case(case_data)
     case.log = [CaseLog({"timestamp": "NOW", "explanation": "Case created", "user": user.uname if user else "system"})]
-    case.save(refresh="wait_for")
+    case.save(refresh="wait_for", version=CREATE_TOKEN)
     CREATED_CASES.inc()
 
     for item in items:
@@ -693,18 +694,18 @@ def remove_case_items(  # noqa: C901
 
     # Resolve backing objects for back-reference cleanup
     items_to_remove = [items_by_id[iid] for iid in ids_to_remove if iid in items_by_id]
-    backing_objs: list[Hit | Event] = []
+    backing_objs: list[tuple[Hit | Event, str]] = []
     for item in items_to_remove:
         if item.type in [CaseItemTypes.HIT, CaseItemTypes.EVENT]:
-            obj = ds[item.type].get(item.value)
+            obj, version = ds[item.type].get(item.value, as_obj=True, version=True)
             if obj:
-                backing_objs.append(obj)
+                backing_objs.append((obj, version))
 
     case.items = [item for item in case.items if item.id not in ids_to_remove]
 
-    for backing_obj in backing_objs:
+    for backing_obj, version in backing_objs:
         remove_backreference(backing_obj, case.case_id)
-        backing_obj.save()
+        backing_obj.save(version=version)
 
     recompute_case_metadata(case)
 
@@ -745,7 +746,7 @@ def append_hit(case: Case, item: CaseItem, refresh: Literal["true", "false", "wa
     """
     ds = datastore()
 
-    hit = ds.hit.get(item.value)
+    hit, version = ds.hit.get(item.value, as_obj=True, version=True)
     if hit is None:
         raise NotFoundException(f"Hit {item.value} not found, cannot be added to case")
 
@@ -754,7 +755,7 @@ def append_hit(case: Case, item: CaseItem, refresh: Literal["true", "false", "wa
     case.items.append(item)
 
     add_backreference(hit, case.case_id)
-    hit.save()
+    hit.save(version=version)
 
     recompute_case_metadata(case)
     if not case.save(refresh=refresh):  # pragma: no cover
@@ -783,7 +784,7 @@ def append_event(case: Case, item: CaseItem, refresh: Literal["true", "false", "
     """
     ds = datastore()
 
-    event = ds.event.get(key=item.value)
+    event, version = ds.event.get(key=item.value, as_obj=True, version=True)
 
     if event is None:
         raise NotFoundException(f"Event {item.value} not found, cannot be added to case")
@@ -793,7 +794,7 @@ def append_event(case: Case, item: CaseItem, refresh: Literal["true", "false", "
     case.items.append(item)
 
     add_backreference(event, case.case_id)
-    event.save()
+    event.save(version=version)
 
     recompute_case_metadata(case)
     if not case.save(refresh=refresh):  # pragma: no cover

--- a/api/howler/services/dossier_service.py
+++ b/api/howler/services/dossier_service.py
@@ -199,7 +199,7 @@ def update_dossier(  # noqa: C901
     storage = datastore()
 
     # Retrieve the existing dossier for access control checks
-    existing_dossier: Dossier = get_dossier(dossier_id, as_odm=True)
+    existing_dossier, server_version = get_dossier(dossier_id, as_odm=True, version=True)
 
     # Enforce access control for personal dossiers
     # Only the owner or admin users can modify personal dossiers
@@ -228,7 +228,7 @@ def update_dossier(  # noqa: C901
         # Merge the new data with existing dossier data
         new_data = Dossier(cast(dict, merge({}, existing_dossier.as_primitives(), dossier_data)))
 
-        storage.dossier.save(dossier_id, new_data, refresh=refresh)
+        storage.dossier.save(dossier_id, new_data, version=server_version, refresh=refresh)
 
         return new_data
     except SearchException:

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -152,7 +152,7 @@ suppress-none-returning = true
 [tool.poetry]
 package-mode = true
 name = "howler-api"
-version = "4.0.3"
+version = "4.0.4"
 description = "Howler - API server"
 authors = [
     "Canadian Centre for Cyber Security <howler@cyber.gc.ca>",

--- a/api/test/unit/endpoints/test_ingest_endpoint.py
+++ b/api/test/unit/endpoints/test_ingest_endpoint.py
@@ -618,7 +618,7 @@ class TestOverwrite:
 
         existing = {"howler": {"id": "hit-001", "analytic": "A"}, "event": {"kind": "alert"}}
         mock_ds.return_value.__getitem__.return_value.get.side_effect = [
-            existing,
+            (existing, "v1"),
             ({"howler": {"id": "hit-001", "analytic": "B"}, "event": {"kind": "alert"}}, "v2"),
         ]
         mock_ds.return_value.__getitem__.return_value.save.return_value = True
@@ -630,10 +630,20 @@ class TestOverwrite:
         ):
             from howler.api.v2.ingest import overwrite
 
-            result: Response = overwrite(index="hit", id="hit-001", server_version="v1", user=user)
+            result: Response = overwrite(index="hit", id="hit-001", user=user)
 
             assert result.status_code == 200
             assert result.headers.get("ETag") == "v2"
+            mock_ds.return_value.__getitem__.return_value.save.assert_called_once_with(
+                "hit-001",
+                {
+                    "howler.id": "hit-001",
+                    "howler.analytic": "B",
+                    "event.kind": "alert",
+                },
+                version="v1",
+                refresh=None,
+            )
 
     @patch("howler.api.v2.ingest.datastore")
     @patch("howler.security.auth_service")
@@ -660,7 +670,7 @@ class TestOverwrite:
         user = _build_user()
         _mock_auth(mock_auth_service, user)
 
-        mock_ds.return_value.__getitem__.return_value.get.return_value = None
+        mock_ds.return_value.__getitem__.return_value.get.return_value = (None, "create")
 
         with request_context.test_request_context(
             method="PATCH",
@@ -680,7 +690,7 @@ class TestOverwrite:
         user = _build_user()
         _mock_auth(mock_auth_service, user)
 
-        mock_ds.return_value.__getitem__.return_value.get.return_value = {"howler": {"id": "hit-001"}}
+        mock_ds.return_value.__getitem__.return_value.get.return_value = ({"howler": {"id": "hit-001"}}, "v1")
 
         with request_context.test_request_context(
             method="PATCH",

--- a/api/test/unit/odm/test_mixins.py
+++ b/api/test/unit/odm/test_mixins.py
@@ -164,15 +164,34 @@ class TestSaveMethod:
 
     @patch("howler.odm.mixins.datastore")
     def test_save_calls_collection_save_with_correct_id_and_instance(self, mock_datastore):
-        """save calls ds[index].save(id, self) with the correct arguments."""
+        """save delegates the ID, instance, and default refresh to ds[index].save."""
         mock_ds = MagicMock()
         mock_datastore.return_value = mock_ds
+        collection = mock_ds.__getitem__.return_value
 
         instance = _FakeModel(fake_id="my-id")
         instance.save()
 
         mock_ds.__getitem__.assert_called_once_with("_fakemodel")
-        mock_ds["_fakemodel"].save.assert_called_once_with("my-id", instance, refresh="wait_for")
+        collection.get_if_exists.assert_not_called()
+        collection.save.assert_called_once_with("my-id", instance, version=None, refresh="wait_for")
+
+    @patch("howler.odm.mixins.datastore")
+    def test_save_uses_the_supplied_version(self, mock_datastore):
+        mock_ds = MagicMock()
+        mock_datastore.return_value = mock_ds
+        instance = _FakeModel(fake_id="my-id")
+
+        instance.save(version="howler-case-000001---5---2")
+
+        collection = mock_ds.__getitem__.return_value
+        collection.get_if_exists.assert_not_called()
+        collection.save.assert_called_once_with(
+            "my-id",
+            instance,
+            version="howler-case-000001---5---2",
+            refresh="wait_for",
+        )
 
     @patch("howler.odm.mixins.datastore")
     def test_save_uses_lowercase_class_name_as_index(self, mock_datastore):
@@ -181,7 +200,7 @@ class TestSaveMethod:
         mock_datastore.return_value = mock_ds
 
         instance = _AnotherModel(another_id="another-id")
-        instance.save()
+        instance.save(version="v1")
 
         mock_ds.__getitem__.assert_called_once_with("_anothermodel")
 
@@ -193,7 +212,7 @@ class TestSaveMethod:
         mock_datastore.return_value = mock_ds
 
         instance = _FakeModel()
-        result = instance.save()
+        result = instance.save(version="v1")
 
         assert result is True
 
@@ -205,7 +224,7 @@ class TestSaveMethod:
         mock_datastore.return_value = mock_ds
 
         instance = _FakeModel()
-        result = instance.save()
+        result = instance.save(version="v1")
 
         assert result is False
 
@@ -216,7 +235,7 @@ class TestSaveMethod:
         mock_datastore.return_value = mock_ds
 
         instance = _FakeModel(fake_id="specific-id-123")
-        instance.save()
+        instance.save(version="v1")
 
         saved_id = mock_ds.__getitem__.return_value.save.call_args[0][0]
         assert saved_id == "specific-id-123"
@@ -228,7 +247,7 @@ class TestSaveMethod:
         mock_datastore.return_value = mock_ds
 
         instance = _DottedIDModel(fake_id="specific-id-456")
-        instance.save()
+        instance.save(version="v1")
 
         saved_id = mock_ds.__getitem__.return_value.save.call_args[0][0]
         assert saved_id == "specific-id-456"
@@ -240,7 +259,7 @@ class TestSaveMethod:
         mock_datastore.return_value = mock_ds
 
         instance = _FakeModel(fake_id="id-abc")
-        instance.save()
+        instance.save(version="v1")
 
         saved_obj = mock_ds.__getitem__.return_value.save.call_args[0][1]
         assert saved_obj is instance
@@ -251,7 +270,7 @@ class TestSaveMethod:
         mock_datastore.return_value = MagicMock()
 
         instance = _FakeModel()
-        instance.save()
-        instance.save()
+        instance.save(version="v1")
+        instance.save(version="v1")
 
         assert mock_datastore.call_count == 2

--- a/api/test/unit/services/test_case_service.py
+++ b/api/test/unit/services/test_case_service.py
@@ -137,6 +137,7 @@ class TestUpdateCase:
         """update_case raises InvalidDataException when an immutable field is supplied."""
         mock_ds = MagicMock()
         mock_ds_fn.return_value = mock_ds
+        mock_ds.case.get_if_exists.return_value = (None, "create")
         mock_ds.case.get.return_value = Case(
             {
                 "case_id": "case-001",
@@ -158,6 +159,7 @@ class TestUpdateCase:
         """update_case saves the updated case and returns it."""
         mock_ds = MagicMock()
         mock_ds_fn.return_value = mock_ds
+        mock_ds.case.get_if_exists.return_value = (None, "create")
         mock_ds.case.get.return_value = Case(
             {
                 "case_id": "case-001",
@@ -186,6 +188,7 @@ class TestUpdateCase:
         """update_case raises InvalidDataException when the immutable 'updated' field is supplied."""
         mock_ds = MagicMock()
         mock_ds_fn.return_value = mock_ds
+        mock_ds.case.get_if_exists.return_value = (None, "create")
         mock_ds.case.get.return_value = Case(
             {"case_id": "case-001", "title": "T", "summary": "S", "overview": "O", "escalation": "normal"}
         )
@@ -200,6 +203,7 @@ class TestUpdateCase:
         """update_case accepts 'items' as a compound field (not immutable) and does not raise."""
         mock_ds = MagicMock()
         mock_ds_fn.return_value = mock_ds
+        mock_ds.case.get_if_exists.return_value = (None, "create")
         mock_ds.case.get.return_value = Case(
             {"case_id": "case-001", "title": "T", "summary": "S", "overview": "O", "escalation": "normal"}
         )
@@ -642,7 +646,7 @@ class TestAppendHit:
 
         mock_hit = MagicMock()
         mock_hit.classification = CLASSIFICATION.UNRESTRICTED
-        mock_ds.hit.get.return_value = mock_hit
+        mock_ds.hit.get.return_value = (mock_hit, "howler-hit-000001---5---2")
 
         item = CaseItem({"type": "hit", "value": "hit-001"})
         case_service.append_hit(mock_case, item)
@@ -650,7 +654,7 @@ class TestAppendHit:
         assert len(mock_case.items) == 1
         mock_backref.assert_called_once_with(mock_hit, "case-001")
         mock_sync.assert_called_once_with(mock_case)
-        mock_hit.save.assert_called_once()
+        mock_hit.save.assert_called_once_with(version="howler-hit-000001---5---2")
 
     @patch("howler.services.case_service.recompute_case_metadata")
     @patch("howler.services.case_service.add_backreference")
@@ -667,7 +671,7 @@ class TestAppendHit:
 
         mock_hit = MagicMock()
         mock_hit.classification = CLASSIFICATION.UNRESTRICTED
-        mock_ds.hit.get.return_value = mock_hit
+        mock_ds.hit.get.return_value = (mock_hit, "howler-hit-000001---5---2")
 
         item = CaseItem({"type": "hit", "value": "hit-001", "name": "My Alert", "parent": None})
         case_service.append_hit(mock_case, item)
@@ -695,7 +699,7 @@ class TestAppendHit:
         mock_case = MagicMock()
         mock_case.items = []
         mock_ds.case.get.return_value = mock_case
-        mock_ds.hit.get.return_value = None
+        mock_ds.hit.get.return_value = (None, "create")
 
         item = CaseItem({"type": "hit", "value": "nonexistent-hit"})
         with pytest.raises(NotFoundException):
@@ -714,7 +718,8 @@ class TestAppendHit:
         mock_case = MagicMock()
         mock_case.items = [existing]
         mock_ds.case.get.return_value = mock_case
-        mock_ds.hit.get.return_value = MagicMock(classification=CLASSIFICATION.UNRESTRICTED)
+        mock_hit = MagicMock(classification=CLASSIFICATION.UNRESTRICTED)
+        mock_ds.hit.get.side_effect = [(mock_hit, "howler-hit-000001---5---2"), mock_hit, mock_hit]
 
         item = CaseItem({"type": "hit", "value": "hit-002", "name": "dup"})
         case_service.append_case_item("case-001", item=item)
@@ -764,7 +769,7 @@ class TestAppendEvent:
         mock_obs = MagicMock()
         mock_obs.classification = CLASSIFICATION.UNRESTRICTED
         mock_obs.howler.id = "obs-001"
-        mock_ds.event.get.return_value = mock_obs
+        mock_ds.event.get.return_value = (mock_obs, "howler-event-000001---5---2")
 
         item = CaseItem({"type": "event", "value": "obs-001"})
         case_service.append_event(mock_case, item)
@@ -773,7 +778,7 @@ class TestAppendEvent:
         assert len(mock_case.items) == 1
         mock_backref.assert_called_once_with(mock_obs, "case-001")
         mock_sync.assert_called_once_with(mock_case)
-        mock_obs.save.assert_called_once()
+        mock_obs.save.assert_called_once_with(version="howler-event-000001---5---2")
 
     @patch("howler.services.case_service.datastore")
     def test_append_event_missing_case_raises(self, mock_ds_fn):
@@ -795,7 +800,7 @@ class TestAppendEvent:
         mock_case = MagicMock()
         mock_case.items = []
         mock_ds.case.get.return_value = mock_case
-        mock_ds.event.get.return_value = None
+        mock_ds.event.get.return_value = (None, "create")
 
         item = CaseItem({"type": "event", "value": "nonexistent-obs"})
         with pytest.raises(NotFoundException):
@@ -811,7 +816,12 @@ class TestAppendEvent:
         mock_case = MagicMock()
         mock_case.items = [existing]
         mock_ds.case.get.return_value = mock_case
-        mock_ds.event.get.return_value = MagicMock(classification=CLASSIFICATION.UNRESTRICTED)
+        mock_event = MagicMock(classification=CLASSIFICATION.UNRESTRICTED)
+        mock_ds.event.get.return_value = (
+            mock_event,
+            "howler-event-000001---5---2",
+        )
+        mock_ds.event.get.side_effect = [(mock_event, "howler-event-000001---5---2"), mock_event, mock_event]
 
         item = CaseItem({"type": "event", "value": "obs-002", "name": "dup"})
         case_service.append_case_item("case-001", item=item)
@@ -1086,7 +1096,7 @@ class TestRemoveCaseItem:
 
         mock_hit = MagicMock()
         mock_hit.howler.related = ["case-001"]
-        mock_ds.hit.get.return_value = mock_hit
+        mock_ds.__getitem__.return_value.get.return_value = (mock_hit, "howler-hit-000001---5---2")
 
         case_service.remove_case_items("case-001", [hit_item.id])
 
@@ -1110,7 +1120,7 @@ class TestRemoveCaseItem:
 
         mock_obs = MagicMock()
         mock_obs.howler.related = ["case-001"]
-        mock_ds.event.get.return_value = mock_obs
+        mock_ds.__getitem__.return_value.get.return_value = (mock_obs, "howler-event-000001---5---2")
 
         case_service.remove_case_items("case-001", [obs_item.id])
 
@@ -1547,7 +1557,7 @@ class TestCaseEventEmission:
         mock_hit.howler.id = "hit-001"
 
         mock_ds.case.get.return_value = mock_case
-        mock_ds.hit.get.return_value = mock_hit
+        mock_ds.hit.get.return_value = (mock_hit, "howler-hit-000001---5---2")
         mock_ds.case.save.return_value = True
 
         item = CaseItem({"type": "hit", "value": "hit-001", "name": "test"})
@@ -2098,7 +2108,7 @@ class TestCaseItemClassificationPropagation:
 
         mock_hit = MagicMock()
         mock_hit.classification = "RESTRICTED"
-        mock_ds.hit.get.return_value = mock_hit
+        mock_ds.hit.get.return_value = (mock_hit, "howler-hit-000001---5---2")
 
         item = CaseItem({"type": "hit", "value": "hit-001", "name": "hit-001"})
         case_service.append_hit(mock_case, item)
@@ -2121,7 +2131,7 @@ class TestCaseItemClassificationPropagation:
 
         mock_hit = MagicMock()
         mock_hit.classification = "UNRESTRICTED"
-        mock_ds.hit.get.return_value = mock_hit
+        mock_ds.hit.get.return_value = (mock_hit, "howler-hit-000001---5---2")
 
         item = CaseItem({"type": "hit", "value": "hit-001", "name": "hit-001"})
         case_service.append_hit(mock_case, item)
@@ -2145,7 +2155,7 @@ class TestCaseItemClassificationPropagation:
         mock_event = MagicMock()
         mock_event.classification = "RESTRICTED"
         mock_event.howler.id = "event-001"
-        mock_ds.event.get.return_value = mock_event
+        mock_ds.event.get.return_value = (mock_event, "howler-event-000001---5---2")
 
         item = CaseItem({"type": "event", "value": "event-001", "name": "event-001"})
         case_service.append_event(mock_case, item)
@@ -2169,7 +2179,7 @@ class TestCaseItemClassificationPropagation:
         mock_event = MagicMock()
         mock_event.classification = "UNRESTRICTED"
         mock_event.howler.id = "event-001"
-        mock_ds.event.get.return_value = mock_event
+        mock_ds.event.get.return_value = (mock_event, "howler-event-000001---5---2")
 
         item = CaseItem({"type": "event", "value": "event-001", "name": "event-001"})
         case_service.append_event(mock_case, item)

--- a/api/test/unit/test_ilm_collection.py
+++ b/api/test/unit/test_ilm_collection.py
@@ -88,6 +88,99 @@ class TestExists:
         )
 
 
+class TestILMVersionedOperations:
+    """Tests for alias-safe ILM reads followed by optimistic-concurrency writes."""
+
+    def test_versioned_get_uses_search_and_returns_concrete_index(self, mock_datastore):
+        col = _make_collection(mock_datastore, ilm_config=ILMIndexConfig(warm="30d"))
+        concrete_index = f"{col.name}-000001"
+        mock_datastore.client.search.return_value = {
+            "hits": {
+                "hits": [
+                    {
+                        "_index": concrete_index,
+                        "_seq_no": 5,
+                        "_primary_term": 2,
+                        "_source": {"id": "document-id", "value": "original"},
+                    }
+                ]
+            }
+        }
+
+        data, version = col.get_if_exists("document-id", as_obj=False, version=True)
+
+        assert data == {"value": "original"}
+        assert version == f"{concrete_index}---5---2"
+        mock_datastore.client.get.assert_not_called()
+        mock_datastore.client.search.assert_called_once_with(
+            index=col.name,
+            query={"ids": {"values": ["document-id"]}},
+            size=1,
+            seq_no_primary_term=True,
+        )
+
+    def test_versioned_get_returns_create_token_for_missing_ilm_document(self, mock_datastore):
+        col = _make_collection(mock_datastore, ilm_config=ILMIndexConfig(warm="30d"))
+        mock_datastore.client.search.return_value = {"hits": {"hits": []}}
+
+        data, version = col.get_if_exists("missing-document", as_obj=False, version=True)
+
+        assert data is None
+        assert version == "create"
+
+    def test_versioned_writes_target_the_concrete_ilm_index(self, mock_datastore):
+        col = _make_collection(mock_datastore, ilm_config=ILMIndexConfig(warm="30d"))
+        concrete_index = f"{col.name}-000001"
+        version = f"{concrete_index}---5---2"
+        mock_datastore.client.update.return_value = {
+            "result": "updated",
+            "_index": concrete_index,
+            "_seq_no": 6,
+            "_primary_term": 2,
+        }
+
+        col.save("document-id", {"value": "updated"}, version=version)
+        updated, new_version = col.update("document-id", [(col.UPDATE_SET, "value", "updated")], version=version)
+
+        assert mock_datastore.client.index.call_args.kwargs["index"] == concrete_index
+        assert mock_datastore.client.update.call_args.kwargs["index"] == concrete_index
+        assert mock_datastore.client.index.call_args.kwargs["if_seq_no"] == "5"
+        assert mock_datastore.client.index.call_args.kwargs["if_primary_term"] == "2"
+        assert updated is True
+        assert new_version == f"{concrete_index}---6---2"
+
+    def test_unversioned_save_resolves_the_existing_ilm_document_version(self, mock_datastore):
+        col = _make_collection(mock_datastore, ilm_config=ILMIndexConfig(warm="30d"))
+        concrete_index = f"{col.name}-000001"
+        mock_datastore.client.search.return_value = {
+            "hits": {
+                "hits": [
+                    {
+                        "_index": concrete_index,
+                        "_seq_no": 5,
+                        "_primary_term": 2,
+                        "_source": {"id": "document-id", "value": "original"},
+                    }
+                ]
+            }
+        }
+
+        col.save("document-id", {"value": "updated"})
+
+        assert mock_datastore.client.index.call_args.kwargs["index"] == concrete_index
+        assert mock_datastore.client.index.call_args.kwargs["if_seq_no"] == "5"
+        assert mock_datastore.client.index.call_args.kwargs["if_primary_term"] == "2"
+
+    def test_unversioned_save_creates_a_missing_ilm_document(self, mock_datastore):
+        col = _make_collection(mock_datastore, ilm_config=ILMIndexConfig(warm="30d"))
+        mock_datastore.client.search.return_value = {"hits": {"hits": []}}
+
+        col.save("document-id", {"value": "new"})
+
+        assert mock_datastore.client.index.call_args.kwargs["index"] == col.name
+        assert mock_datastore.client.index.call_args.kwargs["op_type"] == "create"
+
+
 class TestCreateILMPolicy:
     """Tests for _create_ilm_policy."""
 

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -1,8 +1,11 @@
 # Howler Releases
 
-## Howler API `v4.0.3`
+## Howler API `v4.0.4`
 
 - **ILM Atomic Document Writes** _(bugfix)_: Versioned ILM document lookups now search all rollover indices and use the matched concrete index for optimistic-concurrency writes.
+
+## Howler API `v4.0.3`
+
 - **ILM Collection Existence Checks** _(bugfix)_: Document existence checks now use alias-safe searches for ILM collections and recover from multi-index alias errors on legacy checks.
 
 ## Howler API `v4.0.2`

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -2,6 +2,7 @@
 
 ## Howler API `v4.0.3`
 
+- **ILM Atomic Document Writes** _(bugfix)_: Versioned ILM document lookups now search all rollover indices and use the matched concrete index for optimistic-concurrency writes.
 - **ILM Collection Existence Checks** _(bugfix)_: Document existence checks now use alias-safe searches for ILM collections and recover from multi-index alias errors on legacy checks.
 
 ## Howler API `v4.0.2`


### PR DESCRIPTION
This PR fixes errors when `get(...)` or `get_if_exists(...)` is used to fetch a record in an ILM-enabled index. This also fixes potential duplication errors when updating/saving records in an older index.

---

This pull request introduces improved support for versioned (optimistic-concurrency) document operations throughout the Howler API and services. The changes ensure that updates, saves, and related operations correctly pass and handle version tokens, especially for indices managed by Index Lifecycle Management (ILM). This reduces the risk of conflicting writes and improves data integrity. The update also refines the API and service method signatures to consistently support versioning, and adapts tests to the new behavior.

**Core Datastore and Versioning Enhancements:**

* Refactored `collection.py` to generate and use version tokens that include the index name for ILM-managed indices, and to correctly extract and pass these tokens for all versioned operations (`get`, `save`, `update`). Added helper methods for handling version tokens and document-not-found errors. [[1]](diffhunk://#diff-1e4c8255a42b678b2962be8e4a244ce73da06e063ec1eb1249277a21972df5d4R1170-R1180) [[2]](diffhunk://#diff-1e4c8255a42b678b2962be8e4a244ce73da06e063ec1eb1249277a21972df5d4R1210-R1232) [[3]](diffhunk://#diff-1e4c8255a42b678b2962be8e4a244ce73da06e063ec1eb1249277a21972df5d4R1251-R1259) [[4]](diffhunk://#diff-1e4c8255a42b678b2962be8e4a244ce73da06e063ec1eb1249277a21972df5d4R1389-R1399) [[5]](diffhunk://#diff-1e4c8255a42b678b2962be8e4a244ce73da06e063ec1eb1249277a21972df5d4L1366-R1409) [[6]](diffhunk://#diff-1e4c8255a42b678b2962be8e4a244ce73da06e063ec1eb1249277a21972df5d4R1609-R1618) [[7]](diffhunk://#diff-1e4c8255a42b678b2962be8e4a244ce73da06e063ec1eb1249277a21972df5d4L1584-R1632)

* Updated the `save` and `update` methods in the ODM mixin to accept and pass version tokens, ensuring atomic updates and proper concurrency control. [[1]](diffhunk://#diff-6f2f3c1e0e8dad3ef282cca0c4e20f90ba4f90bf9ae236f858d7a16520229063L85-R89) [[2]](diffhunk://#diff-6f2f3c1e0e8dad3ef282cca0c4e20f90ba4f90bf9ae236f858d7a16520229063R103-R105)

**API Endpoint Updates:**

* Modified endpoints such as `update_action` and `overwrite` to retrieve and pass version tokens when updating or saving documents, ensuring optimistic concurrency is respected. [[1]](diffhunk://#diff-8a12d621087c010367d1ecc7df208f3e651d919cb0437033969020cc3fde5545L146-R146) [[2]](diffhunk://#diff-8a12d621087c010367d1ecc7df208f3e651d919cb0437033969020cc3fde5545L169-R169) [[3]](diffhunk://#diff-ce8ea93c4c19e2d4f637a74a0c1e3720840b82d13f1c5eeb66a30966c98b6f53L268-R268) [[4]](diffhunk://#diff-ce8ea93c4c19e2d4f637a74a0c1e3720840b82d13f1c5eeb66a30966c98b6f53L295-R295)

**Service Layer Improvements:**

* Updated service functions in `case_service.py` and `dossier_service.py` to retrieve version tokens when loading objects and to pass them when saving, including in batch operations and when managing backreferences for hits and events. Case creation now uses the `CREATE_TOKEN` for initial saves. [[1]](diffhunk://#diff-4f6ee8823fc3ed367f6afb7493f24bbf6154261797b5dba5bd612a2c5650a2d5L59-R60) [[2]](diffhunk://#diff-4f6ee8823fc3ed367f6afb7493f24bbf6154261797b5dba5bd612a2c5650a2d5L696-R708) [[3]](diffhunk://#diff-4f6ee8823fc3ed367f6afb7493f24bbf6154261797b5dba5bd612a2c5650a2d5L748-R749) [[4]](diffhunk://#diff-4f6ee8823fc3ed367f6afb7493f24bbf6154261797b5dba5bd612a2c5650a2d5L757-R758) [[5]](diffhunk://#diff-4f6ee8823fc3ed367f6afb7493f24bbf6154261797b5dba5bd612a2c5650a2d5L786-R787) [[6]](diffhunk://#diff-4f6ee8823fc3ed367f6afb7493f24bbf6154261797b5dba5bd612a2c5650a2d5L796-R797) [[7]](diffhunk://#diff-f63df571fe56055de25e17e039f5d863f53ccaf1c799c949d285f2132125eedeL202-R202) [[8]](diffhunk://#diff-f63df571fe56055de25e17e039f5d863f53ccaf1c799c949d285f2132125eedeL231-R231)

**Testing and Miscellaneous:**

* Updated unit tests to reflect the new versioned API, ensuring that version tokens are checked and passed as expected in test scenarios. [[1]](diffhunk://#diff-eb3e91f8bf0837907824cb112d2fc796a9d7e68db1b1014a9169a94fbbde3e89L621-R621) [[2]](diffhunk://#diff-eb3e91f8bf0837907824cb112d2fc796a9d7e68db1b1014a9169a94fbbde3e89L633-R646)
* Bumped the API version to `4.0.4`.

These changes collectively ensure robust, consistent, and safe handling of concurrent document updates across the Howler API and backend services.