### PR TITLE
fix(api): execution error in action system

### DIFF
--- a/api/howler/cronjobs/action_queue_worker.py
+++ b/api/howler/cronjobs/action_queue_worker.py
@@ -13,7 +13,7 @@ from apscheduler.schedulers.base import BaseScheduler
 from howler.common.logging import get_logger
 from howler.config import config
 from howler.odm.models.action import VALID_TRIGGERS
-from howler.services.action_service import _get_action_queue, process_action_batch
+from howler.services.action_service import TriggeredAction, get_action_queue, process_action_batch
 
 logger = get_logger(__file__)
 
@@ -33,7 +33,7 @@ def run_worker(trigger: str) -> None:  # pragma: no cover – long-running loop,
         logger.info("Action queue worker disabled by configuration, not starting for trigger=%s", trigger)
         return
 
-    queue = _get_action_queue(trigger)
+    queue = get_action_queue(trigger)
     logger.info(
         "Action queue worker started for trigger=%s (batch_size=%d, timeout=%ds)",
         trigger,
@@ -41,7 +41,7 @@ def run_worker(trigger: str) -> None:  # pragma: no cover – long-running loop,
         BATCH_TIMEOUT,
     )
 
-    batch: list[dict] = []
+    batch: list[TriggeredAction] = []
 
     while True:
         try:

--- a/api/howler/services/action_service.py
+++ b/api/howler/services/action_service.py
@@ -1,5 +1,6 @@
 import json
-from typing import Any, Optional
+from collections import defaultdict
+from typing import Any, Optional, TypedDict
 
 from flask import Response
 
@@ -18,11 +19,19 @@ from howler.utils.str_utils import sanitize_lucene_query
 
 logger = get_logger(__file__)
 
+
+class TriggeredAction(TypedDict):
+    """Type for triggered actions"""
+
+    hit_ids: list[str]
+    uname: str | None
+
+
 # Per-trigger persistent queues for buffering action execution requests.
-_action_queues: dict[str, NamedQueue[dict]] = {}
+_action_queues: dict[str, NamedQueue[TriggeredAction]] = {}
 
 
-def _get_action_queue(trigger: str) -> NamedQueue[dict]:
+def get_action_queue(trigger: str) -> NamedQueue[TriggeredAction]:
     """Return the action queue for *trigger*, creating it on first use.
 
     Raises:
@@ -65,10 +74,10 @@ def enqueue_action_execution(hit_ids: list[str], trigger: str = "create", user: 
         return
 
     try:
-        _get_action_queue(trigger).push(
+        get_action_queue(trigger).push(
             {
                 "hit_ids": hit_ids,
-                "user": user.as_primitives() if user is not None and hasattr(user, "as_primitives") else user,
+                "uname": user.uname if user else None,
             }
         )
     except Exception:
@@ -77,7 +86,7 @@ def enqueue_action_execution(hit_ids: list[str], trigger: str = "create", user: 
         bulk_execute_on_query(query, trigger=trigger, user=user)
 
 
-def process_action_batch(trigger: str, items: list[dict]) -> None:
+def process_action_batch(trigger: str, items: list[TriggeredAction]) -> None:
     """Process a batch of queued action execution requests for a single trigger.
 
     Groups items by user and issues a single coalesced
@@ -90,26 +99,23 @@ def process_action_batch(trigger: str, items: list[dict]) -> None:
     if not items:
         return
 
-    groups: dict[str | None, tuple[list[str], Any]] = {}
+    groups: dict[str | None, list[str]] = defaultdict(list)
 
     for item in items:
-        user_data = item.get("user")
-        user_key = user_data["uname"] if isinstance(user_data, dict) and "uname" in user_data else None
+        uname = item.get("uname")
 
-        if user_key not in groups:
-            groups[user_key] = ([], user_data)
+        groups[uname].extend(item["hit_ids"])
 
-        groups[user_key][0].extend(item["hit_ids"])
-
-    for user_key, (hit_ids, user_data) in groups.items():
+    for uname, hit_ids in groups.items():
         # Deduplicate IDs within a batch group
         unique_ids = list(dict.fromkeys(hit_ids))
         query = f"howler.id:({' OR '.join(sanitize_lucene_query(h) for h in unique_ids)})"
 
         try:
-            bulk_execute_on_query(query, trigger=trigger, user=user_data)
+            user = datastore().user.get(uname)
+            bulk_execute_on_query(query, trigger=trigger, user=user)
         except Exception:
-            logger.exception("Error processing action batch for trigger=%s user=%s", trigger, user_key)
+            logger.exception("Error processing action batch for trigger=%s user=%s", trigger, uname)
 
 
 def validate_action(new_action: Any) -> Optional[Response]:  # noqa: C901

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -152,7 +152,7 @@ suppress-none-returning = true
 [tool.poetry]
 package-mode = true
 name = "howler-api"
-version = "4.0.7"
+version = "4.0.8"
 description = "Howler - API server"
 authors = [
     "Canadian Centre for Cyber Security <howler@cyber.gc.ca>",

--- a/api/test/integration/service/test_action_service.py
+++ b/api/test/integration/service/test_action_service.py
@@ -15,7 +15,7 @@ from howler.services import action_service, hit_service
 def _drain_action_queues():
     """Pop all pending items from every per-trigger action queue."""
     for trigger in VALID_TRIGGERS:
-        queue = action_service._get_action_queue(trigger)
+        queue = action_service.get_action_queue(trigger)
         while queue.pop(blocking=False) is not None:
             pass
 
@@ -211,7 +211,7 @@ def test_process_action_batch_create_trigger(datastore_connection: HowlerDatasto
     datastore_connection.hit.commit()
 
     batch = [
-        {"hit_ids": [test_hit.howler.id], "user": user.as_primitives()},
+        {"hit_ids": [test_hit.howler.id], "uname": user["uname"]},
     ]
 
     with caplog.at_level(logging.INFO):
@@ -260,7 +260,7 @@ def test_process_action_batch_no_matching_action(datastore_connection: HowlerDat
     datastore_connection.hit.commit()
 
     batch = [
-        {"hit_ids": [test_hit.howler.id], "user": user.as_primitives()},
+        {"hit_ids": [test_hit.howler.id], "uname": user["uname"]},
     ]
 
     with caplog.at_level(logging.DEBUG):
@@ -321,8 +321,8 @@ def test_process_action_batch_coalesces_duplicates(datastore_connection: HowlerD
 
     # Simulate two separate queue items that get coalesced into one batch
     batch = [
-        {"hit_ids": [hit1.howler.id], "user": user.as_primitives()},
-        {"hit_ids": [hit2.howler.id], "user": user.as_primitives()},
+        {"hit_ids": [hit1.howler.id], "uname": user["uname"]},
+        {"hit_ids": [hit2.howler.id], "uname": user["uname"]},
     ]
 
     with caplog.at_level(logging.INFO):

--- a/api/test/unit/services/test_enqueue_action.py
+++ b/api/test/unit/services/test_enqueue_action.py
@@ -8,17 +8,16 @@ from howler.services import action_service
 class TestEnqueueActionExecution:
     """Tests for enqueue_action_execution."""
 
-    @patch.object(action_service, "_get_action_queue")
+    @patch.object(action_service, "get_action_queue")
     @patch("howler.services.action_service.config")
     def test_enqueue_pushes_correct_item(self, mock_config, mock_get_queue):
-        """Verify queue receives correctly structured item with user primitives."""
+        """Verify queue receives hit IDs and the initiating username."""
         mock_config.system.action_queue.enabled = True
         mock_queue = MagicMock()
         mock_get_queue.return_value = mock_queue
 
         user = MagicMock()
-        user.__getitem__ = MagicMock(return_value="testuser")
-        user.as_primitives.return_value = {"uname": "testuser", "type": ["user"]}
+        user.uname = "testuser"
 
         action_service.enqueue_action_execution(["id1", "id2"], trigger="create", user=user)
 
@@ -27,9 +26,9 @@ class TestEnqueueActionExecution:
         pushed = mock_queue.push.call_args[0][0]
         assert pushed["hit_ids"] == ["id1", "id2"]
         assert "trigger" not in pushed
-        assert pushed["user"] == {"uname": "testuser", "type": ["user"]}
+        assert pushed["uname"] == "testuser"
 
-    @patch.object(action_service, "_get_action_queue")
+    @patch.object(action_service, "get_action_queue")
     @patch("howler.services.action_service.config")
     def test_enqueue_routes_to_trigger_queue(self, mock_config, mock_get_queue):
         """Each trigger should route to its own named queue."""
@@ -38,7 +37,7 @@ class TestEnqueueActionExecution:
         mock_get_queue.return_value = mock_queue
 
         user = MagicMock()
-        user.as_primitives.return_value = {"uname": "u", "type": ["user"]}
+        user.uname = "u"
 
         action_service.enqueue_action_execution(["id1"], trigger="promote", user=user)
         mock_get_queue.assert_called_with("promote")
@@ -63,7 +62,7 @@ class TestEnqueueActionExecution:
         assert call_kwargs[1]["trigger"] == "promote"
         assert call_kwargs[1]["user"] is user
 
-    @patch.object(action_service, "_get_action_queue")
+    @patch.object(action_service, "get_action_queue")
     @patch("howler.services.action_service.config")
     def test_enqueue_empty_ids_is_noop(self, mock_config, mock_get_queue):
         """Calling with empty hit_ids should not push anything."""
@@ -74,7 +73,7 @@ class TestEnqueueActionExecution:
         mock_get_queue.assert_not_called()
 
     @patch.object(action_service, "bulk_execute_on_query")
-    @patch.object(action_service, "_get_action_queue")
+    @patch.object(action_service, "get_action_queue")
     @patch("howler.services.action_service.config")
     def test_enqueue_fallback_on_push_error(self, mock_config, mock_get_queue, mock_bulk):
         """If queue push fails, fall back to direct execution."""
@@ -90,10 +89,10 @@ class TestEnqueueActionExecution:
 
         mock_bulk.assert_called_once()
 
-    @patch.object(action_service, "_get_action_queue")
+    @patch.object(action_service, "get_action_queue")
     @patch("howler.services.action_service.config")
     def test_enqueue_none_user(self, mock_config, mock_get_queue):
-        """When user is None, user field should be None in the queued item."""
+        """When user is None, the queued username should be None."""
         mock_config.system.action_queue.enabled = True
         mock_queue = MagicMock()
         mock_get_queue.return_value = mock_queue
@@ -101,7 +100,7 @@ class TestEnqueueActionExecution:
         action_service.enqueue_action_execution(["id1"], trigger="create", user=None)
 
         pushed = mock_queue.push.call_args[0][0]
-        assert pushed["user"] is None
+        assert pushed["uname"] is None
 
     @patch.object(action_service, "bulk_execute_on_query")
     @patch("howler.services.action_service.config")
@@ -117,16 +116,29 @@ class TestEnqueueActionExecution:
 
 
 class TestGetActionQueue:
-    """Tests for _get_action_queue."""
+    """Tests for get_action_queue."""
 
     def test_invalid_trigger_raises_value_error(self):
-        """_get_action_queue should raise ValueError for an unknown trigger."""
+        """get_action_queue should raise ValueError for an unknown trigger."""
         with pytest.raises(ValueError, match="Invalid trigger"):
-            action_service._get_action_queue("bogus_trigger")
+            action_service.get_action_queue("bogus_trigger")
 
 
 class TestProcessActionBatch:
     """Tests for process_action_batch."""
+
+    @patch.object(action_service, "datastore")
+    @patch.object(action_service, "bulk_execute_on_query")
+    def test_process_batch_fetches_odm_user(self, mock_bulk, mock_datastore):
+        """The batch processor should fetch an ODM user from the queued username."""
+        user = MagicMock()
+        mock_datastore.return_value.user.get.return_value = user
+
+        action_service.process_action_batch("create", [{"hit_ids": ["id1"], "uname": "admin"}])
+
+        mock_datastore.return_value.user.get.assert_called_once_with("admin")
+        mock_bulk.assert_called_once()
+        assert mock_bulk.call_args.kwargs["user"] is user
 
     @patch.object(action_service, "bulk_execute_on_query")
     def test_process_batch_empty(self, mock_bulk):
@@ -135,14 +147,13 @@ class TestProcessActionBatch:
 
         mock_bulk.assert_not_called()
 
+    @patch.object(action_service, "datastore")
     @patch.object(action_service, "bulk_execute_on_query")
-    def test_process_batch_coalesces_same_user(self, mock_bulk):
+    def test_process_batch_coalesces_same_user(self, mock_bulk, mock_datastore):
         """Two items with same user should produce one bulk call."""
-        user_data = {"uname": "admin", "type": ["admin", "user"]}
-
         items = [
-            {"hit_ids": ["id1", "id2"], "user": user_data},
-            {"hit_ids": ["id3"], "user": user_data},
+            {"hit_ids": ["id1", "id2"], "uname": "admin"},
+            {"hit_ids": ["id3"], "uname": "admin"},
         ]
 
         action_service.process_action_batch("create", items)
@@ -154,28 +165,27 @@ class TestProcessActionBatch:
         assert "id2" in query_arg
         assert "id3" in query_arg
         assert mock_bulk.call_args[1]["trigger"] == "create"
-        assert mock_bulk.call_args[1]["user"] == user_data
 
+    @patch.object(action_service, "datastore")
     @patch.object(action_service, "bulk_execute_on_query")
-    def test_process_batch_groups_by_user(self, mock_bulk):
+    def test_process_batch_groups_by_user(self, mock_bulk, mock_datastore):
         """Different users -> separate bulk calls."""
-        user1 = {"uname": "user1", "type": ["user"]}
-        user2 = {"uname": "user2", "type": ["user"]}
-
         items = [
-            {"hit_ids": ["id1"], "user": user1},
-            {"hit_ids": ["id2"], "user": user2},
+            {"hit_ids": ["id1"], "uname": "user1"},
+            {"hit_ids": ["id2"], "uname": "user2"},
         ]
 
         action_service.process_action_batch("create", items)
 
         assert mock_bulk.call_count == 2
 
+    @patch.object(action_service, "datastore")
     @patch.object(action_service, "bulk_execute_on_query")
-    def test_process_batch_none_user(self, mock_bulk):
+    def test_process_batch_none_user(self, mock_bulk, mock_datastore):
         """When user is None, the batch group should still be processed."""
+        mock_datastore.return_value.user.get.return_value = None
         items = [
-            {"hit_ids": ["id1"], "user": None},
+            {"hit_ids": ["id1"], "uname": None},
         ]
 
         action_service.process_action_batch("create", items)
@@ -183,14 +193,13 @@ class TestProcessActionBatch:
         assert mock_bulk.call_count == 1
         assert mock_bulk.call_args[1]["user"] is None
 
+    @patch.object(action_service, "datastore")
     @patch.object(action_service, "bulk_execute_on_query")
-    def test_process_batch_deduplicates_ids(self, mock_bulk):
+    def test_process_batch_deduplicates_ids(self, mock_bulk, mock_datastore):
         """Duplicate IDs within a batch group should be deduplicated."""
-        user_data = {"uname": "admin", "type": ["admin"]}
-
         items = [
-            {"hit_ids": ["id1", "id2"], "user": user_data},
-            {"hit_ids": ["id2", "id3"], "user": user_data},
+            {"hit_ids": ["id1", "id2"], "uname": "admin"},
+            {"hit_ids": ["id2", "id3"], "uname": "admin"},
         ]
 
         action_service.process_action_batch("create", items)
@@ -201,25 +210,24 @@ class TestProcessActionBatch:
         assert "id1" in query_arg
         assert "id3" in query_arg
 
+    @patch.object(action_service, "datastore")
     @patch.object(action_service, "bulk_execute_on_query")
-    def test_process_batch_passes_trigger(self, mock_bulk):
+    def test_process_batch_passes_trigger(self, mock_bulk, mock_datastore):
         """The trigger argument should be forwarded to bulk_execute_on_query."""
-        user_data = {"uname": "admin", "type": ["admin"]}
-
-        items = [{"hit_ids": ["id1"], "user": user_data}]
+        items = [{"hit_ids": ["id1"], "uname": "admin"}]
 
         action_service.process_action_batch("promote", items)
 
         assert mock_bulk.call_args[1]["trigger"] == "promote"
 
+    @patch.object(action_service, "datastore")
     @patch.object(action_service, "bulk_execute_on_query")
-    def test_process_batch_bulk_error_does_not_crash(self, mock_bulk):
+    def test_process_batch_bulk_error_does_not_crash(self, mock_bulk, mock_datastore):
         """If bulk_execute_on_query raises, the error is logged but not propagated."""
-        user_data = {"uname": "admin", "type": ["admin"]}
         mock_bulk.side_effect = Exception("ES is down")
 
         items = [
-            {"hit_ids": ["id1"], "user": user_data},
+            {"hit_ids": ["id1"], "uname": "admin"},
         ]
 
         # Should not raise

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -2,7 +2,7 @@
 
 ## Howler API `v4.0.8`
 
-- **Action User Execution** _(bugfix)_: Fixed bug when running transition action via action batch
+- **Action User Execution** _(bugfix)_: Fixed bug when running transition action via action batch. This slightly changes the structure of the queue, in a minor breaking change, but this should be an internal system.
 
 ## Howler API `v4.0.7`
 

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -1,6 +1,10 @@
 # Howler Releases
 
-## Howler API `v4.0.6`
+## Howler API `v4.0.8`
+
+- **Action User Execution** _(bugfix)_: Fixed bug when running transition action via action batch
+
+## Howler API `v4.0.7`
 
 - **Action Batching Fix** _(bugfix)_: Fixed race condition in clearing executed batches.
 


### PR DESCRIPTION
This PR addresses some bad design/behaviour with the action queue where the user's object was persisted alongside the list of ids to process. This new approach fixes that issue by fetching by the username on the far side.

---

This pull request refactors how user information is handled in the action execution queue and batch processing logic. The main change is that queued actions now store only the username (`uname`) instead of the full user object, and the batch processor fetches the user from the datastore at execution time. This simplifies the queue structure, fixes a bug with transition actions, and results in a minor internal breaking change. All relevant tests and documentation have been updated.

**Action queue and batch processing refactor:**

* Introduced a new `TriggeredAction` `TypedDict` to represent queued actions, containing only `hit_ids` and `uname` fields instead of the full user object. (`api/howler/services/action_service.py` [api/howler/services/action_service.pyR22-R34](diffhunk://#diff-5f532aa591c4c6b094fee91c3cdc3519df26b9196410901caeca9a7e63c22b64R22-R34))
* The queue now stores only the username (`uname`), and the batch processor fetches the user object from the datastore when processing the batch. (`api/howler/services/action_service.py` [[1]](diffhunk://#diff-5f532aa591c4c6b094fee91c3cdc3519df26b9196410901caeca9a7e63c22b64L68-R80) [[2]](diffhunk://#diff-5f532aa591c4c6b094fee91c3cdc3519df26b9196410901caeca9a7e63c22b64L93-R118)
* Renamed `_get_action_queue` to `get_action_queue` and updated all references accordingly for consistency and clarity. (`api/howler/services/action_service.py` [[1]](diffhunk://#diff-5f532aa591c4c6b094fee91c3cdc3519df26b9196410901caeca9a7e63c22b64R22-R34) [[2]](diffhunk://#diff-5dac40fa52b7cc9677258462307ebce95d7ee467e7dabfe0b8189f4b0da9009bL16-R16) [[3]](diffhunk://#diff-5dac40fa52b7cc9677258462307ebce95d7ee467e7dabfe0b8189f4b0da9009bL36-R44) [[4]](diffhunk://#diff-956a8525906864e99a1657449a8c02e97cad458d005929e188820f48395012f2L18-R18) [[5]](diffhunk://#diff-c14f566e8efa12fde5a24351116fa5533319c85d455b8e6e634fafb12123d9b5L11-R20) [[6]](diffhunk://#diff-c14f566e8efa12fde5a24351116fa5533319c85d455b8e6e634fafb12123d9b5L30-R31) [[7]](diffhunk://#diff-c14f566e8efa12fde5a24351116fa5533319c85d455b8e6e634fafb12123d9b5L41-R40) [[8]](diffhunk://#diff-c14f566e8efa12fde5a24351116fa5533319c85d455b8e6e634fafb12123d9b5L66-R65) [[9]](diffhunk://#diff-c14f566e8efa12fde5a24351116fa5533319c85d455b8e6e634fafb12123d9b5L77-R76) [[10]](diffhunk://#diff-c14f566e8efa12fde5a24351116fa5533319c85d455b8e6e634fafb12123d9b5L93-R103) [[11]](diffhunk://#diff-c14f566e8efa12fde5a24351116fa5533319c85d455b8e6e634fafb12123d9b5L120-R156)

**Testing and documentation updates:**

* Updated all unit and integration tests to use the new queue item structure and to verify that the batch processor fetches users by username. (`api/test/unit/services/test_enqueue_action.py` [[1]](diffhunk://#diff-c14f566e8efa12fde5a24351116fa5533319c85d455b8e6e634fafb12123d9b5L11-R20) [[2]](diffhunk://#diff-c14f566e8efa12fde5a24351116fa5533319c85d455b8e6e634fafb12123d9b5L30-R31) [[3]](diffhunk://#diff-c14f566e8efa12fde5a24351116fa5533319c85d455b8e6e634fafb12123d9b5L41-R40) [[4]](diffhunk://#diff-c14f566e8efa12fde5a24351116fa5533319c85d455b8e6e634fafb12123d9b5L66-R65) [[5]](diffhunk://#diff-c14f566e8efa12fde5a24351116fa5533319c85d455b8e6e634fafb12123d9b5L77-R76) [[6]](diffhunk://#diff-c14f566e8efa12fde5a24351116fa5533319c85d455b8e6e634fafb12123d9b5L93-R103) [[7]](diffhunk://#diff-c14f566e8efa12fde5a24351116fa5533319c85d455b8e6e634fafb12123d9b5L120-R156) [[8]](diffhunk://#diff-c14f566e8efa12fde5a24351116fa5533319c85d455b8e6e634fafb12123d9b5L157-R202) [[9]](diffhunk://#diff-c14f566e8efa12fde5a24351116fa5533319c85d455b8e6e634fafb12123d9b5R213-R230); `api/test/integration/service/test_action_service.py` [[10]](diffhunk://#diff-956a8525906864e99a1657449a8c02e97cad458d005929e188820f48395012f2L18-R18) [[11]](diffhunk://#diff-956a8525906864e99a1657449a8c02e97cad458d005929e188820f48395012f2L214-R214) [[12]](diffhunk://#diff-956a8525906864e99a1657449a8c02e97cad458d005929e188820f48395012f2L263-R263) [[13]](diffhunk://#diff-956a8525906864e99a1657449a8c02e97cad458d005929e188820f48395012f2L324-R325)
* Documented the bugfix and minor breaking change in the release notes. (`docs/RELEASES.md` [docs/RELEASES.mdL3-R7](diffhunk://#diff-94fd84d8893cd91cd0c77710b90bd0c68d4e0d2ddce48b6bf04b1cba48129b0aL3-R7))
* Bumped the API version to `4.0.8`. (`api/pyproject.toml` [api/pyproject.tomlL155-R155](diffhunk://#diff-40f8f985c548e2b57b803d17f42833f8a4d94603ca5b5e0bf48de51872809400L155-R155))