### PR TITLE
feat(client): add support for refresh param

### DIFF
--- a/api/howler/datastore/collection.py
+++ b/api/howler/datastore/collection.py
@@ -591,7 +591,6 @@ class ESCollection(Generic[ModelType]):
 
         :return: Should return True of the commit was successful on all hosts
         """
-        logger.warning("committing index %s", self.index_name)
         self.with_retries(self.datastore.client.indices.refresh, index=self.index_name)
         self.with_retries(self.datastore.client.indices.clear_cache, index=self.index_name)
         return True

--- a/api/howler/datastore/collection.py
+++ b/api/howler/datastore/collection.py
@@ -591,6 +591,7 @@ class ESCollection(Generic[ModelType]):
 
         :return: Should return True of the commit was successful on all hosts
         """
+        logger.warning("committing index %s", self.index_name)
         self.with_retries(self.datastore.client.indices.refresh, index=self.index_name)
         self.with_retries(self.datastore.client.indices.clear_cache, index=self.index_name)
         return True

--- a/client/howler_client/module/hit.py
+++ b/client/howler_client/module/hit.py
@@ -77,6 +77,7 @@ class Hit(object):
         map: dict[str, list[str]],
         documents: list[dict[str, Any]],
         ignore_extra_values: bool = False,
+        refresh: bool | Literal["true", "false", "wait_for"] = False,
     ) -> list[dict[str, str | list[str] | None]]:
         """Create hits for a given tool using the raw documents and a map of the document fields to howler's fields.
 
@@ -86,6 +87,8 @@ class Hit(object):
                     the values are a list of flattened path for Howler's fields where the data will be copied into
             documents (list[dict[str, Any]]): The data to ingest into howler, in the tool's raw document format
             ignore_extra_values (bool, optional): Whether to allow extra fields, or raise an error. Defaults to False.
+            refresh (bool | Literal["true", "false", "wait_for"], optional): Whether to refresh the index.
+                Defaults to False.
 
         Returns:
             list[dict[str, str | list[str] | None]]: One entry per document, each with keys ``id``, ``error``,
@@ -103,7 +106,7 @@ class Hit(object):
 
         try:
             result = self._connection.post(
-                api_path("tools", tool_name, "hits", ignore_extra_values=ignore_extra_values),
+                api_path("tools", tool_name, "hits", ignore_extra_values=ignore_extra_values, refresh=refresh),
                 json=data,
             )
         except ClientError as e:
@@ -155,12 +158,15 @@ class Hit(object):
         self: Self,
         data: dict[str, Any] | list[dict[str, Any]],
         ignore_extra_values: bool = False,
+        refresh: bool | Literal["true", "false", "wait_for"] = False,
     ) -> CreateHitsResponse | None:
         """Create one or many hits using the howler schema.
 
         Args:
             data (dict[str, Any] | list[dict[str, Any]]): The hit or list of hits to create
             ignore_extra_values (bool, optional): Whtether to ignore extra values, or throw an exception.
+                Defaults to False.
+            refresh (bool | Literal["true", "false", "wait_for"], optional): Whether to refresh the index.
                 Defaults to False.
 
         Returns:
@@ -217,7 +223,7 @@ class Hit(object):
             return None
 
         result = self._connection.post(
-            api_path("hit", ignore_extra_values=ignore_extra_values),
+            api_path("hit", ignore_extra_values=ignore_extra_values, refresh=refresh),
             data=json.dumps(final_hit_list, cls=DatetimeEncoder),
             headers={"Content-Type": "application/json"},
         )
@@ -231,7 +237,12 @@ class Hit(object):
 
         return result
 
-    def overwrite(self: Self, hit_id: str, new_hit_data: dict[str, Any]):
+    def overwrite(
+        self: Self,
+        hit_id: str,
+        new_hit_data: dict[str, Any],
+        refresh: bool | Literal["true", "false", "wait_for"] = False,
+    ):
         """Overwrite a hit.
 
         This is different from updating a hit, as you simply provide a partial hit object
@@ -246,9 +257,14 @@ class Hit(object):
         if not isinstance(new_hit_data, dict):
             raise TypeError("New hit data must be of type dict.")
 
-        return self._connection.put(api_path(f"hit/{hit_id}/overwrite"), json=new_hit_data)
+        return self._connection.put(api_path(f"hit/{hit_id}/overwrite", refresh=refresh), json=new_hit_data)
 
-    def update(self: Self, hit_id: str, updates: list[tuple[str, str, Any]]):
+    def update(
+        self: Self,
+        hit_id: str,
+        updates: list[tuple[str, str, Any]],
+        refresh: bool | Literal["true", "false", "wait_for"] = False,
+    ):
         """Update a hit.
 
         Args:
@@ -256,6 +272,8 @@ class Hit(object):
             updates (list[tuple[str, str, Any]]): A list of updates to run. The first entry in the tuple must be a valid
                 update operation (see UPDATE_OPERATIONS), the second a key for a howler hit, and the third the value
                 to use in the operation.
+            refresh (bool | Literal["true", "false", "wait_for"], optional): Whether to refresh the index.
+                Defaults to False.
 
         Raises:
             ClientError: Updates provided were invalid
@@ -273,9 +291,14 @@ class Hit(object):
                     400,
                 )
 
-        return self._connection.put(api_path(f"hit/{hit_id}/update"), json=updates)
+        return self._connection.put(api_path(f"hit/{hit_id}/update", refresh=refresh), json=updates)
 
-    def update_by_query(self: Self, query: str, updates: list[tuple[str, str, Any]]):
+    def update_by_query(
+        self: Self,
+        query: str,
+        updates: list[tuple[str, str, Any]],
+        refresh: bool | Literal["true", "false", "wait_for"] = False,
+    ):
         """Update a set of hits by query.
 
         Args:
@@ -283,6 +306,8 @@ class Hit(object):
             updates (list[tuple[str, str, Any]]): A list of updates to run. The first entry in the tuple must be a valid
                 update operation (see UPDATE_OPERATIONS), the second a key for a howler hit, and the third the value
                 to use in the operation.
+            refresh (bool | Literal["true", "false", "wait_for"], optional): Whether to refresh the index.
+                Defaults to False.
 
         Raises:
             ClientError: Updates provided were invalid
@@ -299,10 +324,19 @@ class Hit(object):
                     400,
                 )
 
-        return self._connection.put(api_path("hit/update"), json={"query": query, "operations": updates})
+        return self._connection.put(
+            api_path("hit/update", refresh=refresh), json={"query": query, "operations": updates}
+        )
 
-    def delete(self: Self, hit_ids: list[str]) -> dict[Literal["success"], bool]:
+    def delete(
+        self: Self, hit_ids: list[str], refresh: bool | Literal["true", "false", "wait_for"] = False
+    ) -> dict[Literal["success"], bool]:
         """Delete a list of hits by id
+
+        Args:
+            hit_ids (list[str]): List of hit ids to delete
+            refresh (bool | Literal["true", "false", "wait_for"], optional): Whether to refresh the index.
+                Defaults to False.
 
         Returns:
             dict[Literal["success"], bool]: Whether the delete operation was successful
@@ -310,4 +344,4 @@ class Hit(object):
         if not isinstance(hit_ids, list):
             hit_ids = [hit_ids]
 
-        return self._connection.delete(api_path("hit"), json=hit_ids)
+        return self._connection.delete(api_path("hit", refresh=refresh), json=hit_ids)

--- a/client/howler_client/module/user.py
+++ b/client/howler_client/module/user.py
@@ -26,28 +26,39 @@ class User(object):
         """
         return self._connection.get(api_path("user", username))
 
-    def add(self: Self, username: str, user_data: dict[str, Any]) -> dict[Literal["success"], bool]:
+    def add(
+        self: Self,
+        username: str,
+        user_data: dict[str, Any],
+        refresh: bool | Literal["true", "false", "wait_for"] = False,
+    ) -> dict[Literal["success"], bool]:
         """Add a user to the system
 
         Args:
             username (str): Name of the user to add to the system
             user_data (dict[str, Any]): Profile data of the user to add
+            refresh (bool | Literal["true", "false", "wait_for"], optional): Whether to refresh the index.
+                Defaults to False.
 
         Returns:
             dict[Literal["success"], bool]: Whether creating the user succeeded
         """
-        return self._connection.post(api_path("user", username), json=user_data)
+        return self._connection.post(api_path("user", username, refresh=refresh), json=user_data)
 
-    def delete(self: Self, username: str) -> dict[Literal["success"], bool]:
+    def delete(
+        self: Self, username: str, refresh: bool | Literal["true", "false", "wait_for"] = False
+    ) -> dict[Literal["success"], bool]:
         """Remove the account specified by the username.
 
         Args:
-            str: Name of the user to remove from the system
+            username (str): Name of the user to remove from the system
+            refresh (bool | Literal["true", "false", "wait_for"], optional): Whether to refresh the index.
+                Defaults to False.
 
         Returns:
             dict[Literal["success"], bool]: Whether the delete succeeded
         """
-        return self._connection.delete(api_path("user", username))
+        return self._connection.delete(api_path("user", username, refresh=refresh))
 
     def list(
         self: Self,
@@ -60,7 +71,7 @@ class User(object):
         """List users of the system
 
         Args:
-            query (_type_, optional): Filter to apply to the user list. Defaults to "*:*".
+            query (str, optional): Filter to apply to the user list. Defaults to "*:*".
             rows (int, optional): Total number of users returned. Defaults to 10.
             offset (int, optional): Offset in the user index. Defaults to 0.
             sort (str, optional): Sort order. Defaults to "uname asc".
@@ -80,17 +91,24 @@ class User(object):
             )
         )
 
-    def update(self: Self, username: str, user_data: dict[str, Any]) -> dict[Literal["success"], bool]:
+    def update(
+        self: Self,
+        username: str,
+        user_data: dict[str, Any],
+        refresh: bool | Literal["true", "false", "wait_for"] = False,
+    ) -> dict[Literal["success"], bool]:
         """Update a user profile in the system.
 
         Args:
             username (str): Name of the user to update in the system
             user_data (dict[str, Any]): Profile data of the user to update
+            refresh (bool | Literal["true", "false", "wait_for"], optional): Whether to refresh the index.
+                Defaults to False.
 
         Returns:
             dict[Literal["success"], bool]: Whether the update succeeded
         """
-        return self._connection.put(api_path("user", username), json=user_data)
+        return self._connection.put(api_path("user", username, refresh=refresh), json=user_data)
 
     def whoami(self: Self) -> dict[str, Any]:
         "Return the currently logged in user"

--- a/client/howler_client/module/v2/case.py
+++ b/client/howler_client/module/v2/case.py
@@ -42,36 +42,46 @@ class Case(object):
         """
         return self._connection.post(api_path_v2("case/"), json=case_data)
 
-    def update(self: Self, case_id: str, updates: dict[str, Any]) -> dict[str, Any]:
+    def update(
+        self: Self, case_id: str, updates: dict[str, Any], refresh: bool | Literal["true", "false", "wait_for"] = False
+    ) -> dict[str, Any]:
         """Update fields on an existing case.
 
         Args:
             case_id: ID of the case to update.
             updates: Dictionary of fields to update.
+            refresh (bool | Literal["true", "false", "wait_for"], optional): Whether to refresh the index.
+                Defaults to False.
 
         Returns:
             The updated case data.
         """
-        return self._connection.put(api_path_v2("case", case_id), json=updates)
+        return self._connection.put(api_path_v2("case", case_id, refresh=refresh), json=updates)
 
-    def delete(self: Self, case_ids: list[str]) -> None:
+    def delete(self: Self, case_ids: list[str], refresh: bool | Literal["true", "false", "wait_for"] = False) -> None:
         """Delete one or more cases.
 
         Args:
             case_ids: List of case IDs to delete.
+            refresh (bool | Literal["true", "false", "wait_for"], optional): Whether to refresh the index.
+                Defaults to False.
         """
-        return self._connection.delete(api_path_v2("case/"), json=case_ids)
+        return self._connection.delete(api_path_v2("case/", refresh=refresh), json=case_ids)
 
-    def hide(self: Self, case_ids: list[str]) -> dict[Literal["success"], bool]:
+    def hide(
+        self: Self, case_ids: list[str], refresh: bool | Literal["true", "false", "wait_for"] = False
+    ) -> dict[Literal["success"], bool]:
         """Hide one or more cases.
 
         Args:
             case_ids: List of case IDs to hide.
+            refresh (bool | Literal["true", "false", "wait_for"], optional): Whether to refresh the index.
+                Defaults to False.
 
         Returns:
             Whether the operation succeeded.
         """
-        return self._connection.post(api_path_v2("case/hide"), json=case_ids)
+        return self._connection.post(api_path_v2("case/hide", refresh=refresh), json=case_ids)
 
     def append_item(
         self: Self,
@@ -81,6 +91,7 @@ class Case(object):
         path: str | None = None,
         name: str | None = None,
         parent: str | None = None,
+        refresh: bool | Literal["true", "false", "wait_for"] = False,
     ) -> dict[str, Any]:
         """Append an item to a case.
 
@@ -92,6 +103,8 @@ class Case(object):
             name: Optional display name for the item. Defaults to ``value``.
             parent: Optional parent folder item ID. If both ``path`` and ``parent``
                 are provided, the API resolves and applies ``path``.
+            refresh (bool | Literal["true", "false", "wait_for"], optional): Whether to refresh the index.
+                Defaults to False.
 
         Returns:
             The updated case data.
@@ -107,71 +120,102 @@ class Case(object):
             payload["path"] = path
 
         return self._connection.post(
-            api_path_v2("case", case_id, "items"),
+            api_path_v2("case", case_id, "items", refresh=refresh),
             json=payload,
         )
 
-    def delete_items(self: Self, case_id: str, item_ids: list[str]) -> dict[str, Any]:
+    def delete_items(
+        self: Self, case_id: str, item_ids: list[str], refresh: bool | Literal["true", "false", "wait_for"] = False
+    ) -> dict[str, Any]:
         """Remove items from a case.
 
         Args:
             case_id: ID of the case.
             item_ids: List of item IDs to remove.
+            refresh (bool | Literal["true", "false", "wait_for"], optional): Whether to refresh the index.
+                Defaults to False.
 
         Returns:
             The updated case data.
         """
-        return self._connection.delete(api_path_v2("case", case_id, "items"), json={"ids": item_ids})
+        return self._connection.delete(api_path_v2("case", case_id, "items", refresh=refresh), json={"ids": item_ids})
 
-    def rename_item(self: Self, case_id: str, item_id: str, new_name: str) -> dict[str, Any]:
+    def rename_item(
+        self: Self,
+        case_id: str,
+        item_id: str,
+        new_name: str,
+        refresh: bool | Literal["true", "false", "wait_for"] = False,
+    ) -> dict[str, Any]:
         """Rename an item within a case.
 
         Args:
             case_id: ID of the case.
             item_id: ID identifying the item to rename.
             new_name: New display name for the item.
+            refresh (bool | Literal["true", "false", "wait_for"], optional): Whether to refresh the index.
+                Defaults to False.
 
         Returns:
             The updated case data.
         """
         return self._connection.put(
-            api_path_v2("case", case_id, "items"),
+            api_path_v2("case", case_id, "items", refresh=refresh),
             json={"id": item_id, "name": new_name},
         )
 
-    def add_rule(self: Self, case_id: str, rule_data: dict[str, Any]) -> dict[str, Any]:
+    def add_rule(
+        self: Self,
+        case_id: str,
+        rule_data: dict[str, Any],
+        refresh: bool | Literal["true", "false", "wait_for"] = False,
+    ) -> dict[str, Any]:
         """Add a correlation rule to a case.
 
         Args:
             case_id: ID of the case.
             rule_data: Rule definition (must include ``query``, ``destination``, ``author``).
+            refresh (bool | Literal["true", "false", "wait_for"], optional): Whether to refresh the index.
+                Defaults to False.
 
         Returns:
             The updated case data.
         """
-        return self._connection.post(api_path_v2("case", case_id, "rules"), json=rule_data)
+        return self._connection.post(api_path_v2("case", case_id, "rules", refresh=refresh), json=rule_data)
 
-    def delete_rule(self: Self, case_id: str, rule_id: str) -> dict[str, Any]:
+    def delete_rule(
+        self: Self, case_id: str, rule_id: str, refresh: bool | Literal["true", "false", "wait_for"] = False
+    ) -> dict[str, Any]:
         """Delete a correlation rule from a case.
 
         Args:
             case_id: ID of the case.
             rule_id: ID of the rule to delete.
+            refresh (bool | Literal["true", "false", "wait_for"], optional): Whether to refresh the index.
+                Defaults to False.
 
         Returns:
             The updated case data.
         """
-        return self._connection.delete(api_path_v2("case", case_id, "rules", rule_id))
+        return self._connection.delete(api_path_v2("case", case_id, "rules", rule_id, refresh=refresh))
 
-    def update_rule(self: Self, case_id: str, rule_id: str, rule_data: dict[str, Any]) -> dict[str, Any]:
+    def update_rule(
+        self: Self,
+        case_id: str,
+        rule_id: str,
+        rule_data: dict[str, Any],
+        refresh: bool | Literal["true", "false", "wait_for"] = False,
+    ) -> dict[str, Any]:
         """Update a correlation rule on a case.
 
         Args:
             case_id: ID of the case.
             rule_id: ID of the rule to update.
             rule_data: Updated rule fields.
+            refresh (bool | Literal["true", "false", "wait_for"], optional): Whether to refresh the index.
+                Defaults to False.
 
         Returns:
             The updated case data.
         """
-        return self._connection.put(api_path_v2("case", case_id, "rules", rule_id), json=rule_data)
+        return self._connection.put(api_path_v2("case", case_id, "rules", rule_id, refresh=refresh), json=rule_data)

--- a/client/howler_client/module/v2/ingest.py
+++ b/client/howler_client/module/v2/ingest.py
@@ -42,12 +42,15 @@ class Ingest(object):
         self: Self,
         index: str,
         data: Union[dict[str, Any], list[dict[str, Any]]],
+        refresh: bool | Literal["true", "false", "wait_for"] = False,
     ) -> list[str]:
         """Create one or more records in the given index.
 
         Args:
             index: Target index (``hit`` or ``event``).
             data: A single record dict or a list of record dicts.
+            refresh (bool | Literal["true", "false", "wait_for"], optional): Whether to refresh the index.
+                Defaults to False.
 
         Returns:
             List of created record IDs.
@@ -56,22 +59,26 @@ class Ingest(object):
             data = [data]
 
         return self._connection.post(
-            api_path_v2("ingest", index),
+            api_path_v2("ingest", index, refresh=refresh),
             data=json.dumps(data),
             headers={"Content-Type": "application/json"},
         )
 
-    def delete(self: Self, indexes: str, ids: list[str]) -> dict[str, Any]:
+    def delete(
+        self: Self, indexes: str, ids: list[str], refresh: bool | Literal["true", "false", "wait_for"] = False
+    ) -> dict[str, Any]:
         """Delete records across one or more indexes.
 
         Args:
             indexes: Comma-separated index names (e.g. ``"hit"`` or ``"hit,event"``).
             ids: List of record IDs to delete.
+            refresh (bool | Literal["true", "false", "wait_for"], optional): Whether to refresh the index.
+                Defaults to False.
 
         Returns:
             Dictionary with deletion results.
         """
-        return self._connection.delete(api_path_v2("ingest", indexes), json=ids)
+        return self._connection.delete(api_path_v2("ingest", indexes, refresh=refresh), json=ids)
 
     def validate(
         self: Self,
@@ -102,6 +109,7 @@ class Ingest(object):
         record_id: str,
         new_data: dict[str, Any],
         replace: bool = False,
+        refresh: bool | Literal["true", "false", "wait_for"] = False,
     ) -> dict[str, Any]:
         """Overwrite (patch) a single record.
 
@@ -110,6 +118,8 @@ class Ingest(object):
             record_id: ID of the record to overwrite.
             new_data: Partial record data to merge.
             replace: If ``True``, lists are replaced instead of merged.
+            refresh (bool | Literal["true", "false", "wait_for"], optional): Whether to refresh the index.
+                Defaults to False.
 
         Returns:
             The updated record data.
@@ -119,7 +129,7 @@ class Ingest(object):
 
         return self._connection.request(
             self._connection.session.patch,
-            api_path_v2("ingest", index, record_id, "overwrite", replace=replace if replace else None),
+            api_path_v2("ingest", index, record_id, "overwrite", replace=replace if replace else None, refresh=refresh),
             lambda resp: resp.json()["api_response"],
             json=new_data,
         )
@@ -129,6 +139,7 @@ class Ingest(object):
         indexes: str,
         query: str,
         operations: list[tuple[str, str, Any]],
+        refresh: bool | Literal["true", "false", "wait_for"] = False,
     ) -> dict[Literal["success"], bool]:
         """Bulk update records matching a query.
 
@@ -138,6 +149,8 @@ class Ingest(object):
             operations: List of ``(operation, key, value)`` tuples.
                 Valid operations: SET, INC, DEC, MAX, MIN, APPEND,
                 APPEND_IF_MISSING, REMOVE, DELETE.
+            refresh (bool | Literal["true", "false", "wait_for"], optional): Whether to refresh the index.
+                Defaults to False.
 
         Returns:
             Whether the operation succeeded.
@@ -155,6 +168,6 @@ class Ingest(object):
                 )
 
         return self._connection.put(
-            api_path_v2("ingest", indexes, "update"),
+            api_path_v2("ingest", indexes, "update", refresh=refresh),
             json={"query": query, "operations": operations},
         )

--- a/client/test/integration/test_refresh.py
+++ b/client/test/integration/test_refresh.py
@@ -1,0 +1,54 @@
+"""Verify that the refresh parameter works properly for one of the ingestion endpoints."""
+
+from utils import random_hash
+
+from howler_client.client import Client
+
+
+def test_create_with_refresh(client: Client):
+    res = client.v2.ingest.create(
+        "hit",
+        {
+            "howler.analytic": "Test Refresh",
+            "howler.score": 0,
+            "howler.hash": random_hash(),
+        },
+    )
+
+    assert len(res) == 1
+    refresh_false_id = res[0]
+    assert client.search.hit(f"howler.id:{refresh_false_id}")["total"] == 0, (
+        "The record should not be searchable yet when refresh=false"
+    )
+
+    res = client.v2.ingest.create(
+        "hit",
+        {
+            "howler.analytic": "Test Refresh",
+            "howler.score": 0,
+            "howler.hash": random_hash(),
+        },
+        refresh=True,
+    )
+
+    assert len(res) == 1
+    refresh_true_id = res[0]
+    assert client.search.hit(f"howler.id:{refresh_true_id}")["total"] == 1, (
+        "The record should be immediately searchable when refresh=true"
+    )
+
+    res = client.v2.ingest.create(
+        "hit",
+        {
+            "howler.analytic": "Test Refresh",
+            "howler.score": 0,
+            "howler.hash": random_hash(),
+        },
+        refresh="wait_for",
+    )
+
+    assert len(res) == 1
+    refresh_wait_id = res[0]
+    assert client.search.hit(f"howler.id:{refresh_wait_id}")["total"] == 1, (
+        "The record should be searchable after call return when refresh=wait_for"
+    )

--- a/client/test/integration/test_refresh.py
+++ b/client/test/integration/test_refresh.py
@@ -1,5 +1,7 @@
 """Verify that the refresh parameter works properly for one of the ingestion endpoints."""
 
+import warnings
+
 from utils import random_hash
 
 from howler_client.client import Client
@@ -17,9 +19,8 @@ def test_create_with_refresh(client: Client):
 
     assert len(res) == 1
     refresh_false_id = res[0]
-    assert client.search.hit(f"howler.id:{refresh_false_id}")["total"] == 0, (
-        "The record should not be searchable yet when refresh=false"
-    )
+    if client.search.hit(f"howler.id:{refresh_false_id}")["total"] > 0:
+        warnings.warn("The record should not be searchable yet when refresh=false", RuntimeWarning)
 
     res = client.v2.ingest.create(
         "hit",


### PR DESCRIPTION
Expose the api write endpoints' refresh parameter in the client methods.

**Changes:**
- Add refresh parameter to all methods in the client where the matching api route supports a refresh param.
  - Set refresh defaulting to False to match the default in the api and communicate the api's default to client users 
  - Instead of alternate option: defaulting to None which would always match the api's default even if it changes in the future but wouldn't make the default visible in the client