### PR TITLE
fix(ui): bugfixes in the UI

### DIFF
--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -1,5 +1,9 @@
 # Howler Releases
 
+## Howler UI `v3.0.5`
+
+- **Hit Viewing Notifications** _(bugfix)_: Hit viewers and search information panes now emit viewing notifications and invoke plugin viewing hooks without repeating them during rerenders ([#572](https://github.com/CybercentreCanada/howler/pull/572)).
+
 ## Howler UI `v3.0.4`
 
 - **Dashboard View Card Settings** _(bugfix)_: Dashboard view cards now apply the view's configured sort and time span when fetching records.

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -3,6 +3,7 @@
 ## Howler UI `v3.0.5`
 
 - **Hit Viewing Notifications** _(bugfix)_: Hit viewers and search information panes now emit viewing notifications and invoke plugin viewing hooks without repeating them during rerenders ([#572](https://github.com/CybercentreCanada/howler/pull/572)).
+- **Search Pagination Count** _(bugfix)_: Search result pagination now uses the configured page count instead of the response row count, keeping page offsets and displayed pages consistent.
 
 ## Howler UI `v3.0.4`
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -136,5 +136,5 @@
     "test-ui": "vitest --ui --coverage"
   },
   "type": "module",
-  "version": "3.0.4"
+  "version": "3.0.5"
 }

--- a/ui/src/components/routes/hits/search/InformationPane.tsx
+++ b/ui/src/components/routes/hits/search/InformationPane.tsx
@@ -50,7 +50,7 @@ const InformationPane: FC<{ selected?: string; onClose?: () => void }> = ({ onCl
   const { emit, open } = useContext(SocketContext);
   const { getMatchingOverview, getMatchingDossiers, getMatchingAnalytic } = useMatchers();
   const selected = useContextSelector(ParameterContext, ctx => ctx?.selected) ?? _selected;
-  const pluginStore = usePluginStore();
+  const { executeFunction } = usePluginStore();
 
   const getRecord = useContextSelector(RecordContext, ctx => ctx.getRecord);
 
@@ -69,9 +69,15 @@ const InformationPane: FC<{ selected?: string; onClose?: () => void }> = ({ onCl
 
   const record = useContextSelector(RecordContext, ctx => ctx.records[selected]);
 
-  howlerPluginStore.plugins.forEach(plugin => {
-    pluginStore.executeFunction(`${plugin}.on`, 'viewing');
-  });
+  useEffect(() => {
+    if (!selected) {
+      return;
+    }
+
+    howlerPluginStore.plugins.forEach(plugin => {
+      executeFunction(`${plugin}.on`, 'viewing');
+    });
+  }, [executeFunction, selected]);
 
   useEffect(() => {
     if (!selected) {

--- a/ui/src/components/routes/hits/search/SearchPane.tsx
+++ b/ui/src/components/routes/hits/search/SearchPane.tsx
@@ -130,6 +130,7 @@ const SearchPane: FC = () => {
   const { onClick } = useRecordSelection();
 
   const searchPaneWidth = useMyLocalStorageItem(StorageKey.SEARCH_PANE_WIDTH, null)[0];
+  const pageCount = useMyLocalStorageItem(StorageKey.PAGE_COUNT, 25)[0];
 
   const verticalSorters = useMediaQuery('(max-width: 1919px)') || (searchPaneWidth ?? Number.MAX_SAFE_INTEGER) < 900;
 
@@ -198,7 +199,7 @@ const SearchPane: FC = () => {
                 <Box flex={1} />
                 <SearchPagination
                   total={response.total}
-                  limit={response.rows}
+                  limit={pageCount}
                   offset={response.offset}
                   onChange={nextOffset => setOffset(nextOffset)}
                 />

--- a/ui/src/components/routes/hits/view/HitViewer.test.tsx
+++ b/ui/src/components/routes/hits/view/HitViewer.test.tsx
@@ -1,0 +1,221 @@
+import { render, waitFor } from '@testing-library/react';
+import { RecordContext } from 'components/app/providers/RecordProvider';
+import { SocketContext } from 'components/app/providers/SocketProvider';
+import type { FC, PropsWithChildren } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockEmit = vi.hoisted(() => vi.fn());
+const mockExecutePlugin = vi.hoisted(() => vi.fn());
+const mockOpen = vi.hoisted(() => ({ current: true }));
+const mockParams = vi.hoisted(() => ({ id: 'hit-1' }));
+const mockGetHit = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const mockGetMatchingAnalytic = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const mockGetMatchingDossiers = vi.hoisted(() => vi.fn().mockResolvedValue([]));
+const mockGetMatchingOverview = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const mockNavigate = vi.hoisted(() => vi.fn());
+
+vi.mock('plugins/store', () => ({
+  default: {
+    plugins: ['test-plugin']
+  }
+}));
+
+vi.mock('react-pluggable', () => ({
+  usePluginStore: () => ({ executeFunction: mockExecutePlugin })
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: 'en' }
+  })
+}));
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+    useParams: () => mockParams
+  };
+});
+
+vi.mock('components/app/hooks/useMatchers', () => ({
+  default: () => ({
+    getMatchingAnalytic: mockGetMatchingAnalytic,
+    getMatchingDossiers: mockGetMatchingDossiers,
+    getMatchingOverview: mockGetMatchingOverview
+  })
+}));
+
+vi.mock('components/hooks/useMyLocalStorage', () => ({
+  useMyLocalStorageItem: () => ['vertical', vi.fn()]
+}));
+
+vi.mock('components/hooks/useMyUserList', () => ({
+  default: () => []
+}));
+
+vi.mock('utils/recordFunctions', () => ({
+  getUserList: () => new Set()
+}));
+
+vi.mock('utils/utils', () => ({
+  tryParse: (value: unknown) => value
+}));
+
+vi.mock('commons/components/pages/PageCenter', () => ({
+  default: ({ children }: PropsWithChildren) => <>{children}</>
+}));
+
+vi.mock('components/elements/display/HowlerCard', () => ({
+  default: ({ children }: PropsWithChildren) => <>{children}</>
+}));
+
+vi.mock('components/elements/display/icons/SocketBadge', () => ({
+  default: () => null
+}));
+
+vi.mock('components/elements/display/json/JSONViewer', () => ({
+  default: () => null
+}));
+
+vi.mock('components/elements/hit/HitActions', () => ({
+  default: () => null
+}));
+
+vi.mock('components/elements/hit/HitBanner', () => ({
+  default: () => null
+}));
+
+vi.mock('components/elements/hit/HitLabels', () => ({
+  default: () => null
+}));
+
+vi.mock('components/elements/hit/HitLinks', () => ({
+  default: () => null
+}));
+
+vi.mock('components/elements/hit/HitOutline', () => ({
+  default: () => null
+}));
+
+vi.mock('components/elements/hit/HitOverview', () => ({
+  default: () => null
+}));
+
+vi.mock('components/elements/ObjectDetails', () => ({
+  default: () => null
+}));
+
+vi.mock('components/elements/record/RecordComments', () => ({
+  default: () => null
+}));
+
+vi.mock('components/elements/record/RecordRelated', () => ({
+  default: () => null
+}));
+
+vi.mock('components/elements/record/RecordWorklog', () => ({
+  default: () => null
+}));
+
+vi.mock('./LeadRenderer', () => ({
+  default: () => null
+}));
+
+import HitViewer from './HitViewer';
+
+const recordContextValue = {
+  records: {
+    'hit-1': {
+      howler: {
+        data: [],
+        dossier: [],
+        comment: []
+      }
+    }
+  },
+  getRecord: mockGetHit
+};
+
+const createWrapper = (): FC<PropsWithChildren> => {
+  const Wrapper: FC<PropsWithChildren> = ({ children }) => (
+    <SocketContext.Provider
+      value={
+        {
+          emit: mockEmit,
+          open: mockOpen.current,
+          addListener: vi.fn(),
+          removeListener: vi.fn(),
+          status: 1,
+          reconnect: vi.fn(),
+          viewers: {},
+          fetchViewers: vi.fn()
+        } as any
+      }
+    >
+      <RecordContext.Provider value={recordContextValue as any}>{children}</RecordContext.Provider>
+    </SocketContext.Provider>
+  );
+
+  return Wrapper;
+};
+
+beforeEach(() => {
+  mockEmit.mockReset();
+  mockExecutePlugin.mockReset();
+  mockOpen.current = true;
+  mockParams.id = 'hit-1';
+  mockGetHit.mockClear().mockResolvedValue(undefined);
+  mockGetMatchingAnalytic.mockClear().mockResolvedValue(undefined);
+  mockGetMatchingDossiers.mockClear().mockResolvedValue([]);
+  mockGetMatchingOverview.mockClear().mockResolvedValue(undefined);
+  mockNavigate.mockReset();
+});
+
+describe('HitViewer', () => {
+  it('emits the plugin viewing event', async () => {
+    render(<HitViewer />, { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(mockGetMatchingOverview).toHaveBeenCalled();
+    });
+
+    expect(mockExecutePlugin).toHaveBeenCalledWith('test-plugin.on', 'viewing');
+  });
+
+  it('emits viewing and stop_viewing socket events', async () => {
+    const { unmount } = render(<HitViewer />, { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(mockEmit).toHaveBeenCalledWith({
+        broadcast: false,
+        action: 'viewing',
+        id: 'hit-1'
+      });
+    });
+
+    mockEmit.mockClear();
+    unmount();
+
+    expect(mockEmit).toHaveBeenCalledWith({
+      broadcast: false,
+      action: 'stop_viewing',
+      id: 'hit-1'
+    });
+  });
+
+  it('does not emit socket events when the socket is closed', async () => {
+    mockOpen.current = false;
+
+    render(<HitViewer />, { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(mockGetMatchingOverview).toHaveBeenCalled();
+    });
+
+    expect(mockEmit).not.toHaveBeenCalled();
+  });
+});

--- a/ui/src/components/routes/hits/view/HitViewer.test.tsx
+++ b/ui/src/components/routes/hits/view/HitViewer.test.tsx
@@ -237,6 +237,7 @@ describe('HitViewer', () => {
       expect(screen.getByText('links:analytic-1:1')).toBeInTheDocument();
     });
     expect(screen.getByText('details-content')).toBeInTheDocument();
+    expect(mockExecutePlugin).toHaveBeenCalledTimes(1);
     expect(mockExecutePlugin).toHaveBeenCalledWith('test-plugin.on', 'viewing');
   });
 

--- a/ui/src/components/routes/hits/view/HitViewer.test.tsx
+++ b/ui/src/components/routes/hits/view/HitViewer.test.tsx
@@ -1,18 +1,34 @@
-import { render, waitFor } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { RecordContext } from 'components/app/providers/RecordProvider';
 import { SocketContext } from 'components/app/providers/SocketProvider';
+import type { Analytic } from 'models/entities/generated/Analytic';
+import type { Dossier } from 'models/entities/generated/Dossier';
+import type { Hit } from 'models/entities/generated/Hit';
 import type { FC, PropsWithChildren } from 'react';
+import type * as MuiMaterial from '@mui/material';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockEmit = vi.hoisted(() => vi.fn());
 const mockExecutePlugin = vi.hoisted(() => vi.fn());
 const mockOpen = vi.hoisted(() => ({ current: true }));
-const mockParams = vi.hoisted(() => ({ id: 'hit-1' }));
+const mockParams = vi.hoisted(() => ({ id: 'hit-1' as string | undefined }));
 const mockGetHit = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
 const mockGetMatchingAnalytic = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
 const mockGetMatchingDossiers = vi.hoisted(() => vi.fn().mockResolvedValue([]));
 const mockGetMatchingOverview = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
 const mockNavigate = vi.hoisted(() => vi.fn());
+const mockUseMediaQuery = vi.hoisted(() => vi.fn(() => false));
+const mockSetOrientation = vi.hoisted(() => vi.fn());
+
+vi.mock('@mui/material', async () => {
+  const actual = await vi.importActual<typeof MuiMaterial>('@mui/material');
+
+  return {
+    ...actual,
+    useMediaQuery: mockUseMediaQuery
+  };
+});
 
 vi.mock('plugins/store', () => ({
   default: {
@@ -50,7 +66,7 @@ vi.mock('components/app/hooks/useMatchers', () => ({
 }));
 
 vi.mock('components/hooks/useMyLocalStorage', () => ({
-  useMyLocalStorageItem: () => ['vertical', vi.fn()]
+  useMyLocalStorageItem: () => [Orientation.VERTICAL, mockSetOrientation]
 }));
 
 vi.mock('components/hooks/useMyUserList', () => ({
@@ -58,85 +74,93 @@ vi.mock('components/hooks/useMyUserList', () => ({
 }));
 
 vi.mock('utils/recordFunctions', () => ({
-  getUserList: () => new Set()
+  getUserList: () => new Set(['analyst'])
 }));
 
 vi.mock('utils/utils', () => ({
-  tryParse: (value: unknown) => value
+  tryParse: (value: string) => `parsed:${value}`
 }));
 
-vi.mock('commons/components/pages/PageCenter', () => ({
-  default: ({ children }: PropsWithChildren) => <>{children}</>
-}));
-
-vi.mock('components/elements/display/HowlerCard', () => ({
-  default: ({ children }: PropsWithChildren) => <>{children}</>
+vi.mock('components/elements/hit/HitActions', () => ({
+  default: ({ orientation }: { orientation: string }) => <div>actions:{orientation}</div>
 }));
 
 vi.mock('components/elements/display/icons/SocketBadge', () => ({
   default: () => null
 }));
 
-vi.mock('components/elements/display/json/JSONViewer', () => ({
-  default: () => null
-}));
-
-vi.mock('components/elements/hit/HitActions', () => ({
-  default: () => null
-}));
-
 vi.mock('components/elements/hit/HitBanner', () => ({
-  default: () => null
-}));
-
-vi.mock('components/elements/hit/HitLabels', () => ({
-  default: () => null
-}));
-
-vi.mock('components/elements/hit/HitLinks', () => ({
-  default: () => null
+  default: () => <div>banner</div>
 }));
 
 vi.mock('components/elements/hit/HitOutline', () => ({
-  default: () => null
+  default: () => <div>outline</div>
+}));
+
+vi.mock('components/elements/hit/HitLabels', () => ({
+  default: () => <div>labels</div>
+}));
+
+vi.mock('components/elements/hit/HitLinks', () => ({
+  default: ({ analytic, dossiers }: { analytic?: Analytic; dossiers: Dossier[] }) => (
+    <div>
+      links:{analytic?.analytic_id}:{dossiers.length}
+    </div>
+  )
 }));
 
 vi.mock('components/elements/hit/HitOverview', () => ({
-  default: () => null
+  default: () => <div>overview-content</div>
 }));
 
 vi.mock('components/elements/ObjectDetails', () => ({
-  default: () => null
+  default: () => <div>details-content</div>
+}));
+
+vi.mock('components/elements/display/json/JSONViewer', () => ({
+  default: ({ data }: { data: unknown }) => <div id="json-content">{JSON.stringify(data)}</div>
 }));
 
 vi.mock('components/elements/record/RecordComments', () => ({
-  default: () => null
-}));
-
-vi.mock('components/elements/record/RecordRelated', () => ({
-  default: () => null
+  default: () => <div>comments-content</div>
 }));
 
 vi.mock('components/elements/record/RecordWorklog', () => ({
-  default: () => null
+  default: () => <div>worklog-content</div>
+}));
+
+vi.mock('components/elements/record/RecordRelated', () => ({
+  default: () => <div>related-content</div>
 }));
 
 vi.mock('./LeadRenderer', () => ({
-  default: () => null
+  default: ({ lead }: { lead: { label: { en: string } } }) => <div>lead-content:{lead.label.en}</div>
 }));
 
-import HitViewer from './HitViewer';
+import HitViewer, { Orientation } from './HitViewer';
 
-const recordContextValue = {
-  records: {
-    'hit-1': {
-      howler: {
-        data: [],
-        dossier: [],
-        comment: []
+const hit: Hit = {
+  __index: 'hit',
+  timestamp: '2026-01-01T00:00:00Z',
+  howler: {
+    id: 'hit-1',
+    analytic: 'analytic-1',
+    assignment: 'analyst',
+    hash: 'hash-1',
+    data: ['{"source":"data"}'],
+    dossier: [
+      {
+        label: { en: 'Local lead', fr: 'Piste locale' },
+        format: 'markdown',
+        content: 'local'
       }
-    }
-  },
+    ],
+    comment: [{}]
+  }
+};
+
+const recordContextValue: { records: Record<string, Hit>; getRecord: typeof mockGetHit } = {
+  records: { 'hit-1': hit },
   getRecord: mockGetHit
 };
 
@@ -163,31 +187,61 @@ const createWrapper = (): FC<PropsWithChildren> => {
   return Wrapper;
 };
 
+const renderViewer = () => render(<HitViewer />, { wrapper: createWrapper() });
+
 beforeEach(() => {
   mockEmit.mockReset();
   mockExecutePlugin.mockReset();
   mockOpen.current = true;
   mockParams.id = 'hit-1';
-  mockGetHit.mockClear().mockResolvedValue(undefined);
-  mockGetMatchingAnalytic.mockClear().mockResolvedValue(undefined);
-  mockGetMatchingDossiers.mockClear().mockResolvedValue([]);
-  mockGetMatchingOverview.mockClear().mockResolvedValue(undefined);
+  mockUseMediaQuery.mockReset().mockReturnValue(false);
+  mockSetOrientation.mockReset();
+  mockGetHit.mockReset().mockResolvedValue(undefined);
+  mockGetMatchingAnalytic.mockReset().mockResolvedValue(undefined);
+  mockGetMatchingDossiers.mockReset().mockResolvedValue([]);
+  mockGetMatchingOverview.mockReset().mockResolvedValue(undefined);
   mockNavigate.mockReset();
+  recordContextValue.records = { 'hit-1': hit };
 });
 
 describe('HitViewer', () => {
-  it('emits the plugin viewing event', async () => {
-    render(<HitViewer />, { wrapper: createWrapper() });
+  it('loads a missing hit and shows the loading state', async () => {
+    recordContextValue.records = {};
+
+    renderViewer();
+
+    expect(screen.queryByText('details-content')).not.toBeInTheDocument();
+    await waitFor(() => expect(mockGetHit).toHaveBeenCalledWith('hit-1', true));
+  });
+
+  it('navigates to the not-found page when loading fails with a 404', async () => {
+    recordContextValue.records = {};
+    mockGetHit.mockRejectedValue({ cause: { api_status_code: 404 } });
+
+    renderViewer();
+
+    await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith('/404'));
+  });
+
+  it('fetches matching data, notifies plugins, and renders the details view', async () => {
+    const analytic = { analytic_id: 'analytic-1' };
+    const dossiers = [{ leads: [] }];
+    mockGetMatchingAnalytic.mockResolvedValue(analytic);
+    mockGetMatchingDossiers.mockResolvedValue(dossiers);
+
+    renderViewer();
 
     await waitFor(() => {
-      expect(mockGetMatchingOverview).toHaveBeenCalled();
+      expect(mockGetMatchingAnalytic).toHaveBeenCalledWith(hit);
+      expect(mockGetMatchingDossiers).toHaveBeenCalledWith(hit);
+      expect(screen.getByText('links:analytic-1:1')).toBeInTheDocument();
     });
-
+    expect(screen.getByText('details-content')).toBeInTheDocument();
     expect(mockExecutePlugin).toHaveBeenCalledWith('test-plugin.on', 'viewing');
   });
 
   it('emits viewing and stop_viewing socket events', async () => {
-    const { unmount } = render(<HitViewer />, { wrapper: createWrapper() });
+    const { unmount } = renderViewer();
 
     await waitFor(() => {
       expect(mockEmit).toHaveBeenCalledWith({
@@ -207,15 +261,79 @@ describe('HitViewer', () => {
     });
   });
 
-  it('does not emit socket events when the socket is closed', async () => {
+  it('does not emit socket events when the socket is closed or no hit id is present', async () => {
     mockOpen.current = false;
+    renderViewer();
 
-    render(<HitViewer />, { wrapper: createWrapper() });
+    await waitFor(() => expect(mockGetMatchingOverview).toHaveBeenCalledWith(hit));
+    expect(mockEmit).not.toHaveBeenCalled();
 
-    await waitFor(() => {
-      expect(mockGetMatchingOverview).toHaveBeenCalled();
-    });
+    mockParams.id = undefined;
+    renderViewer();
 
     expect(mockEmit).not.toHaveBeenCalled();
+  });
+
+  it('opens an overview by default and lets the analyst select all content tabs', async () => {
+    const user = userEvent.setup();
+    mockGetMatchingOverview.mockResolvedValue({ content: 'overview' });
+    mockGetMatchingDossiers.mockResolvedValue([
+      {
+        leads: [
+          {
+            label: { en: 'External lead', fr: 'Piste externe' },
+            format: 'markdown',
+            content: 'external'
+          }
+        ]
+      }
+    ]);
+
+    renderViewer();
+
+    await screen.findByText('overview-content');
+    await user.click(screen.getByRole('tab', { name: 'hit.viewer.details' }));
+    expect(screen.getByText('details-content')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('tab', { name: 'Local lead' }));
+    expect(screen.getByText('lead-content:Local lead')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('tab', { name: 'External lead' }));
+    expect(screen.getByText('lead-content:External lead')).toBeInTheDocument();
+
+    const tabs = screen.getAllByRole('tab');
+    await user.click(tabs.at(-5)!);
+    expect(screen.getByTestId('json-content')).toHaveTextContent(JSON.stringify(['parsed:{"source":"data"}']));
+    await user.click(tabs.at(-4)!);
+    expect(screen.getByTestId('json-content')).toHaveTextContent(JSON.stringify(hit));
+    await user.click(tabs.at(-3)!);
+    expect(screen.getByText('comments-content')).toBeInTheDocument();
+    await user.click(tabs.at(-2)!);
+    expect(screen.getByText('worklog-content')).toBeInTheDocument();
+    await user.click(tabs.at(-1)!);
+    expect(screen.getByText('related-content')).toBeInTheDocument();
+  });
+
+  it('toggles the desktop layout and navigates to its matching analytic', async () => {
+    const user = userEvent.setup();
+    mockGetMatchingAnalytic.mockResolvedValue({ analytic_id: 'analytic-1' });
+
+    renderViewer();
+
+    await screen.findByText('links:analytic-1:0');
+    const buttons = screen.getAllByRole('button');
+    await user.click(buttons[0]);
+    expect(mockSetOrientation).toHaveBeenCalledWith(Orientation.HORIZONTAL);
+
+    await user.click(buttons[1]);
+    expect(mockNavigate).toHaveBeenCalledWith('/analytics/analytic-1');
+  });
+
+  it('forces a horizontal layout below the large breakpoint', async () => {
+    mockUseMediaQuery.mockReturnValue(true);
+
+    renderViewer();
+
+    await waitFor(() => expect(mockSetOrientation).toHaveBeenCalledWith(Orientation.HORIZONTAL));
   });
 });

--- a/ui/src/components/routes/hits/view/HitViewer.tsx
+++ b/ui/src/components/routes/hits/view/HitViewer.tsx
@@ -64,7 +64,7 @@ const HitViewer: FC = () => {
   const [orientation, setOrientation] = useMyLocalStorageItem(StorageKey.VIEWER_ORIENTATION, Orientation.VERTICAL);
   const { getMatchingOverview, getMatchingDossiers, getMatchingAnalytic } = useMatchers();
   const { emit, open } = useContext(SocketContext);
-  const pluginStore = usePluginStore();
+  const { executeFunction } = usePluginStore();
 
   const getHit = useContextSelector(RecordContext, ctx => ctx.getRecord);
   const hit = useContextSelector(RecordContext, ctx => ctx.records[params.id] as Hit);
@@ -75,10 +75,6 @@ const HitViewer: FC = () => {
   const [analytic, setAnalytic] = useState<Analytic>();
   const [dossiers, setDossiers] = useState<Dossier[]>([]);
   const [hasOverview, setHasOverview] = useState(false);
-
-  howlerPluginStore.plugins.forEach(plugin => {
-    pluginStore.executeFunction(`${plugin}.on`, 'viewing');
-  });
 
   const fetchData = useCallback(async () => {
     try {
@@ -102,6 +98,16 @@ const HitViewer: FC = () => {
       setOrientation(Orientation.HORIZONTAL);
     }
   }, [isUnderLg, setOrientation]);
+
+  useEffect(() => {
+    if (!hit) {
+      return;
+    }
+
+    howlerPluginStore.plugins.forEach(plugin => {
+      executeFunction(`${plugin}.on`, 'viewing');
+    });
+  }, [executeFunction, hit]);
 
   useEffect(() => {
     void fetchData();

--- a/ui/src/components/routes/hits/view/HitViewer.tsx
+++ b/ui/src/components/routes/hits/view/HitViewer.tsx
@@ -17,6 +17,7 @@ import {
 import PageCenter from 'commons/components/pages/PageCenter';
 import useMatchers from 'components/app/hooks/useMatchers';
 import { RecordContext } from 'components/app/providers/RecordProvider';
+import { SocketContext } from 'components/app/providers/SocketProvider';
 import FlexOne from 'components/elements/addons/layout/FlexOne';
 import HowlerCard from 'components/elements/display/HowlerCard';
 import SocketBadge from 'components/elements/display/icons/SocketBadge';
@@ -37,9 +38,11 @@ import useMyUserList from 'components/hooks/useMyUserList';
 import type { Analytic } from 'models/entities/generated/Analytic';
 import type { Dossier } from 'models/entities/generated/Dossier';
 import type { Hit } from 'models/entities/generated/Hit';
+import howlerPluginStore from 'plugins/store';
 import type { FC } from 'react';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { usePluginStore } from 'react-pluggable';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useContextSelector } from 'use-context-selector';
 import { StorageKey } from 'utils/constants';
@@ -60,6 +63,8 @@ const HitViewer: FC = () => {
   const isUnderLg = useMediaQuery(theme.breakpoints.down('lg'));
   const [orientation, setOrientation] = useMyLocalStorageItem(StorageKey.VIEWER_ORIENTATION, Orientation.VERTICAL);
   const { getMatchingOverview, getMatchingDossiers, getMatchingAnalytic } = useMatchers();
+  const { emit, open } = useContext(SocketContext);
+  const pluginStore = usePluginStore();
 
   const getHit = useContextSelector(RecordContext, ctx => ctx.getRecord);
   const hit = useContextSelector(RecordContext, ctx => ctx.records[params.id] as Hit);
@@ -70,6 +75,10 @@ const HitViewer: FC = () => {
   const [analytic, setAnalytic] = useState<Analytic>();
   const [dossiers, setDossiers] = useState<Dossier[]>([]);
   const [hasOverview, setHasOverview] = useState(false);
+
+  howlerPluginStore.plugins.forEach(plugin => {
+    pluginStore.executeFunction(`${plugin}.on`, 'viewing');
+  });
 
   const fetchData = useCallback(async () => {
     try {
@@ -83,7 +92,7 @@ const HitViewer: FC = () => {
       setAnalytic(await getMatchingAnalytic(hit));
     } catch (err) {
       if (err.cause?.api_status_code === 404) {
-        navigate('/404');
+        void navigate('/404');
       }
     }
   }, [hit, getMatchingAnalytic, getHit, params.id, navigate]);
@@ -97,6 +106,26 @@ const HitViewer: FC = () => {
   useEffect(() => {
     void fetchData();
   }, [params.id, fetchData, hit]);
+
+  useEffect(() => {
+    if (!params.id || !open) {
+      return;
+    }
+
+    emit({
+      broadcast: false,
+      action: 'viewing',
+      id: params.id
+    });
+
+    return () => {
+      emit({
+        broadcast: false,
+        action: 'stop_viewing',
+        id: params.id
+      });
+    };
+  }, [emit, params.id, open]);
 
   const onOrientationChange = useCallback(
     () => setOrientation(orientation === Orientation.VERTICAL ? Orientation.HORIZONTAL : Orientation.VERTICAL),


### PR DESCRIPTION
This PR addresses two bugs:

1. The search pane not showing the correct pagination on the final page
2. Ensuring viewer hooks are enabled for the HitViewer page

---

This pull request introduces improvements to the `HitViewer` component and its surrounding infrastructure, focusing on plugin integration, socket event handling, and test coverage. The most important changes are grouped below:

**Plugin and Socket Integration:**

* The `HitViewer` component now emits plugin "viewing" events for all plugins in `howlerPluginStore.plugins` by calling each plugin's `.on` function via the plugin store when the component renders.
* The component uses the `SocketContext` to emit "viewing" and "stop_viewing" socket events when a hit is viewed and when the viewer unmounts, respectively, but only if the socket is open. [[1]](diffhunk://#diff-2f8ebdca5ec7fe2b5451a636af3d72e8889d2605016506a25f2a804f795e6bc8R66-R67) [[2]](diffhunk://#diff-2f8ebdca5ec7fe2b5451a636af3d72e8889d2605016506a25f2a804f795e6bc8R110-R129)

**Testing Enhancements:**

* Added a comprehensive test suite for `HitViewer` in `HitViewer.test.tsx` to verify plugin event emission, socket event emission, and correct behavior when the socket is closed.

**Pagination and Local Storage:**

* The search pane now uses a `pageCount` value from local storage to control pagination, instead of relying on the response's row count. [[1]](diffhunk://#diff-c6cebea64cebeb8b105616e63c2d458f30e002392f78ce3130239d6cc62ef4f3R133) [[2]](diffhunk://#diff-c6cebea64cebeb8b105616e63c2d458f30e002392f78ce3130239d6cc62ef4f3L201-R202)

**Code Quality and Best Practices:**

* Minor improvements such as using `void` for navigation side effects and improved imports for clarity and maintainability. [[1]](diffhunk://#diff-2f8ebdca5ec7fe2b5451a636af3d72e8889d2605016506a25f2a804f795e6bc8R41-R45) [[2]](diffhunk://#diff-2f8ebdca5ec7fe2b5451a636af3d72e8889d2605016506a25f2a804f795e6bc8L86-R95)